### PR TITLE
Feature constructors

### DIFF
--- a/doc/development/cheatsheet.md
+++ b/doc/development/cheatsheet.md
@@ -137,3 +137,5 @@ The following `latex` macros can be used
 :::
 
 New `latex` commands can be created by modifying both `latex_elements` and `mathjax3_config` in `doc/conf.py`.
+
+Docstrings that use `latex` must be raw strings, namely `r""" ... """`.

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -304,7 +304,7 @@ class Framework(object):
         return F
 
     @classmethod
-    def Complete(cls, points: List[Point] = []) -> None:
+    def Complete(cls, points: List[Point]) -> None:
         """
         Generate a framework on the complete graph from a given list of points.
 
@@ -327,7 +327,7 @@ class Framework(object):
         dim:            1
         """
         if not points:
-            raise ValueError("The realization cannot be empty.")
+            raise ValueError("The list of points cannot be empty.")
 
         Kn = Graph.Complete(len(points))
         realization = {(Kn.vertices())[i]: Matrix(

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -334,7 +334,7 @@ class Framework(object):
         if not points:
             raise ValueError("The realization cannot be empty.")
 
-        Kn = Graph.complete_graph(len(points))
+        Kn = Graph.Complete(len(points))
         realization = {(Kn.vertices())[i]: Matrix(
             points[i]) for i in range(len(points))}
         return Framework(graph=Kn, realization=realization, dim=dim)
@@ -644,7 +644,7 @@ class Framework(object):
         ]
         """
         vertices = self._graph.vertices()
-        Kn = Graph.complete_graph_on_vertices(vertices)
+        Kn = Graph.Complete_on_vertices(vertices)
         F_Kn = Framework(
             graph=Kn,
             realization=self.realization(),

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -154,7 +154,7 @@ class Framework(object):
     def add_vertices(self,
                      points: List[Point],
                      vertices: List[Vertex] = []) -> None:
-        """
+        r"""
         Add a list of vertices to the framework.
 
         Parameters
@@ -393,7 +393,7 @@ class Framework(object):
         return self.get_realization()
 
     def set_realization(self, realization: Dict[Vertex, Point]) -> None:
-        """
+        r"""
         Change the realization of the framework.
 
         Parameters

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -639,7 +639,7 @@ class Framework(object):
         ]
         """
         vertices = self._graph.vertices()
-        Kn = Graph.Complete_on_vertices(vertices)
+        Kn = Graph.CompleteOnVertices(vertices)
         F_Kn = Framework(
             graph=Kn,
             realization=self.realization())

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -40,9 +40,10 @@ class Framework(object):
     graph
     realization:
         A dictionary mapping the vertices of the graph to points in $\RR^d$.
-    dim:
-        The dimension is usually initialized by the realization. If
-        the realization is empty, the dimension is 0 by default.
+        The dimension `d` is retrieved from the points in realization.
+        If `graph` is empty, and hence also the `realization`,
+        the dimension is set to 0 (:meth:`Framework.Empty` 
+        can be used to construct an empty framework with different dimension).
 
     Notes
     -----
@@ -61,35 +62,30 @@ class Framework(object):
     """
 
     def __init__(self,
-                 graph: Graph = Graph(),
-                 realization: Dict[Vertex, Point] = {},
-                 dim: int = 2) -> None:
+                 graph: Graph,
+                 realization: Dict[Vertex, Point]) -> None:
         if not isinstance(graph, Graph):
             raise TypeError("The graph has to be an instance of class Graph")
         if not len(realization.keys()) == len(graph.vertices()):
             raise KeyError(
                 "The length of realization has to be equal to the number of vertices of graph")
-        if not isinstance(dim, int) or dim < 1:
-            raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!")
 
-        if len(realization.values()) == 0:
-            dimension = dim
+        if realization:
+            self._dim = len(list(realization.values())[0])
         else:
-            dimension = len(list(realization.values())[0])
+            self._dim = 0
 
         for v in graph.vertices():
             if v not in realization:
                 raise KeyError(
                     f"Vertex {v} is not contained in the realization")
-            if not len(realization[v]) == dimension:
+            if not len(realization[v]) == self._dim:
                 raise ValueError(
                     f"The point {realization[v]} in the realization that vertex {v} corresponds to does not have the right dimension")
 
         self._realization = {v: Matrix(realization[v])
                              for v in graph.vertices()}
         self._graph = deepcopy(graph)
-        self._dim = dimension
 
     def __str__(self) -> str:
         """
@@ -272,7 +268,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.from_graph(Graph([(0,1), (1,2), (0,2)]), dim=2)
+        >>> F = Framework.from_graph(Graph([(0,1), (1,2), (0,2)]))
         >>> print(F)
         Graph:          Vertices: [0, 1, 2],    Edges: [(0, 1), (0, 2), (1, 2)]
         Realization:    {0: (65.0, 13.0), 1: (110.0, 64.0), 2: (54.0, 80.0)}
@@ -290,7 +286,7 @@ class Framework(object):
         return Framework(graph=graph, realization=realization)
 
     @classmethod
-    def Empty(cls, dim: int) -> None:
+    def Empty(cls, dim: int = 2) -> None:
         """
         Generate an empty framework.
 
@@ -303,10 +299,12 @@ class Framework(object):
         if not isinstance(dim, int) or dim < 1:
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
-        return Framework(graph=Graph(), realization={}, dim=dim)
+        F = Framework(graph=Graph(), realization={})
+        F._dim = dim
+        return F
 
     @classmethod
-    def Complete(cls, points: List[Point] = [], dim: int = 2) -> None:
+    def Complete(cls, points: List[Point] = []) -> None:
         """
         Generate a framework on the complete graph from a given list of points.
 
@@ -322,22 +320,19 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Complete([(1,),(2,),(3,),(4,)], dim=1)
+        >>> F = Framework.Complete([(1,),(2,),(3,),(4,)])
         >>> print(F)
         Graph:          Vertices: [0, 1, 2, 3], Edges: [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
         Realization:    {0: (1.0,), 1: (2.0,), 2: (3.0,), 3: (4.0,)}
         dim:            1
         """
-        if not isinstance(dim, int) or dim < 1:
-            raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!")
         if not points:
             raise ValueError("The realization cannot be empty.")
 
         Kn = Graph.Complete(len(points))
         realization = {(Kn.vertices())[i]: Matrix(
             points[i]) for i in range(len(points))}
-        return Framework(graph=Kn, realization=realization, dim=dim)
+        return Framework(graph=Kn, realization=realization)
 
     def delete_vertex(self, vertex: Vertex) -> None:
         """
@@ -647,8 +642,7 @@ class Framework(object):
         Kn = Graph.Complete_on_vertices(vertices)
         F_Kn = Framework(
             graph=Kn,
-            realization=self.realization(),
-            dim=self.dim())
+            realization=self.realization())
         return F_Kn.infinitesimal_flexes(
             pinned_vertices=pinned_vertices,
             include_trivial=True)

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -129,8 +129,12 @@ class Graph(nx.Graph):
         return Graph.from_vertices_and_edges(vertices, [])
 
     @classmethod
-    def complete_graph(cls, n: int) -> GraphType:
-        """Generate a complete graph on $n$ vertices. The vertices are labeled via the list $0,...,n-1$."""
+    def Complete(cls, n: int) -> GraphType:
+        """
+        Generate a complete graph on $n$ vertices. 
+        
+        The vertices are labeled by numbers from 0 to n-1.
+        """
         if not isinstance(n, int) or n < 1:
             raise TypeError("n needs to be a positive integer")
         vertices = range(n)
@@ -138,7 +142,7 @@ class Graph(nx.Graph):
         return Graph.from_vertices_and_edges(vertices, edges)
 
     @classmethod
-    def complete_graph_on_vertices(cls, vertices: List[Vertex]) -> GraphType:
+    def Complete_on_vertices(cls, vertices: List[Vertex]) -> GraphType:
         """
         Generate a complete graph on `vertices`.
         """

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -16,16 +16,11 @@ from pyrigi.data_type import Vertex, Edge, GraphType, List, Any
 class Graph(nx.Graph):
     '''
     Class representing a graph.
-
-    Parameters
-    ----------
-    vertices:
-        The graph's vertices can be labelled by any `Hashable`.
-    edges:
-        Edges are tuples of vertices. They can either be a tuple `(i,j)` or
-        a list `[i,j]` with two entries.
-
-
+        
+    One option for *incoming_graph_data* is a list of edges.
+    See :class:`networkx.Graph` for the other input formats
+    or use class methods :meth:`~Graph.from_vertices_and_edges`
+    or :meth:`~Graph.from_vertices` when specifying the vertex set is needed.
 
     Examples
     --------
@@ -107,7 +102,16 @@ class Graph(nx.Graph):
             cls,
             vertices: List[Vertex],
             edges: List[Edge]) -> GraphType:
-        """This method creates a graph from a list of vertices and edges."""
+        """
+        Create a graph from a list of vertices and edges.
+        
+        Parameters
+        ----------
+        vertices
+        edges:
+            Edges are tuples of vertices. They can either be a tuple `(i,j)` or
+            a list `[i,j]` with two entries.
+        """
         G = Graph()
         G.add_nodes_from(vertices)
         for edge in edges:
@@ -696,7 +700,7 @@ class Graph(nx.Graph):
         for i, j in zip(range(shape(M)[0]), range(shape(M)[1])):
             if not (M[i, j] == 0 or M[i, j] == 1):
                 raise TypeError(
-                    "The provided adjancency matrix contains entries other than 0 and 1")
+                    "The provided adjacency matrix contains entries other than 0 and 1")
         vertices = range(shape(M)[0])
         edges = []
         for vertex, vertex_ in zip(range(len(vertices)), range(len(vertices))):

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -142,7 +142,7 @@ class Graph(nx.Graph):
         return Graph.from_vertices_and_edges(vertices, edges)
 
     @classmethod
-    def Complete_on_vertices(cls, vertices: List[Vertex]) -> GraphType:
+    def CompleteOnVertices(cls, vertices: List[Vertex]) -> GraphType:
         """
         Generate a complete graph on `vertices`.
         """

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -5,13 +5,13 @@ def test_dimension():
     F = Framework(Graph([[0,1]]), {0:[1,2], 1:[0,5]})
     assert F.dim() == F.dimension()
     assert F.dim() == 2
-    F_ = Framework(dim=3)
+    F_ = Framework.Empty(dim=3)
     assert F_.dim() == 3
 
 def test_vertex_addition():
-    F = Framework()
+    F = Framework.Empty()
     F.add_vertices([[1., 2.0], [1.0, 1.0], [0.0, 0.0]])
-    F_ = Framework()
+    F_ = Framework.Empty()
     F_.add_vertices([[1., 2.0], [1.0, 1.0], [0.0, 0.0]])
     F_.set_realization(F.get_realization())
     assert (


### PR DESCRIPTION
 - `complete_graph` and `complete_graph_on_vertices` renamed using CamelCase since they serve as class constructors.
 - `dim` parameter removed from `Framework.__init__` since the dimension is anyway retrieved from the points of realization. The only case when this is not possible is when the empty graph is passed, then the dimension is set to 0. To get empty framework with different dimension, Framework.Empty(dim) can be used.