### PR TITLE
documentation of the types

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,6 +83,7 @@ napoleon_custom_sections = ['Definitions']
 autodoc_type_aliases = {
     "Vertex": "Vertex",
     "Edge": "Edge",
+    "Point": "Point", 
     }
 napoleon_attr_annotations = True
 

--- a/doc/userguide/api.md
+++ b/doc/userguide/api.md
@@ -5,4 +5,5 @@
 api/graph
 api/framework
 api/motion
+api/datatype
 :::

--- a/doc/userguide/api/datatype.md
+++ b/doc/userguide/api/datatype.md
@@ -1,0 +1,14 @@
+# Data types
+
+The following datatypes are used for type hinting.
+
+```{eval-rst}
+.. autodata:: pyrigi.data_type.Vertex
+   
+.. autodata:: pyrigi.data_type.Edge
+
+.. autodata:: pyrigi.data_type.Point
+
+
+
+```

--- a/pyrigi/data_type.py
+++ b/pyrigi/data_type.py
@@ -7,10 +7,19 @@ from typing import TypeVar, List, Tuple, Hashable, Any, Dict
 
 
 Vertex = Hashable
+"""
+Any hashable type can be used for a Vertex.
+"""
+
 Edge = Tuple[Vertex, Vertex]
+"""
+An Edge is a pair of :obj:`Vertices <pyrigi.data_type.Vertex>`.
+"""
+
 Point = List[float]
+"""
+A Point is a list of coordinates whose length is the dimension of its affine space.
+"""
 
 GraphType = TypeVar("Graph")
 MatroidType = TypeVar("Matroid")
-Vertex = Hashable
-Edge = Tuple[Vertex, Vertex]


### PR DESCRIPTION
Documentation of Vertex, Edge and Point added.
They can be linked using `` :obj:`pyrigi.data_type.Vertex` `` in general, but setting 
```python
autodoc_type_aliases = {
    "Vertex": ":obj:`pyrigi.data_type.Vertex`",
    "Edge": "Edge",
    "Point": "Point", 
    }
```
in `conf.py` does not create the link correctly. So I propose we just keep it without linking.