### PR TITLE
method names shortened

### DIFF
--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -596,7 +596,7 @@ class Framework(object):
         """
         raise NotImplementedError()
 
-    def trivial_infinitesimal_flexes(self,
+    def trivial_inf_flexes(self,
                                      pinned_vertices: Dict[Vertex,
                                                            List[int]] = {}) -> List[Matrix]:
         r"""
@@ -619,7 +619,7 @@ class Framework(object):
         Examples
         --------
         >>> F = Framework.Complete([(0,0),(2,0),(1,3)])
-        >>> F.trivial_infinitesimal_flexes()
+        >>> F.trivial_inf_flexes()
         [Matrix([
             [ 3],
             [-1],
@@ -649,21 +649,21 @@ class Framework(object):
             graph=Kn,
             realization=self.realization(),
             dim=self.dim())
-        return F_Kn.infinitesimal_flexes(
+        return F_Kn.inf_flexes(
             pinned_vertices=pinned_vertices,
             include_trivial=True)
 
-    def nontrivial_infinitesimal_flexes(
+    def nontrivial_inf_flexes(
             self, pinned_vertices: Dict[Vertex, List[int]] = {}) -> List[Matrix]:
         """
         Return the entries of the rigidity matrix' kernel that are not trivial infinitesimal flexes.
-        See :meth:`~Framework.trivial_infinitesimal_flexes`
+        See :meth:`~Framework.trivial_inf_flexes`
         """
-        return self.infinitesimal_flexes(
+        return self.inf_flexes(
             pinned_vertices=pinned_vertices,
             include_trivial=False)
 
-    def infinitesimal_flexes(
+    def inf_flexes(
             self,
             pinned_vertices: Dict[Vertex, List[int]] = {},
             include_trivial: bool = False) -> List[Matrix]:
@@ -691,7 +691,7 @@ class Framework(object):
         --------
         >>> F = Framework.Complete([[0,0], [1,0], [1,1], [0,1]])
         >>> F.delete_edges([(0,2), (1,3)])
-        >>> F.infinitesimal_flexes(include_trivial=False)
+        >>> F.inf_flexes(include_trivial=False)
         [Matrix([
         [ 1/4],
         [ 1/4],
@@ -705,7 +705,7 @@ class Framework(object):
         if include_trivial:
             return self.rigidity_matrix(
                 pinned_vertices=pinned_vertices).nullspace()
-        trivial_flexes = self.trivial_infinitesimal_flexes(
+        trivial_flexes = self.trivial_inf_flexes(
             pinned_vertices=pinned_vertices)
         all_flexes = self.rigidity_matrix(
             pinned_vertices=pinned_vertices).nullspace()
@@ -729,7 +729,7 @@ class Framework(object):
         """
         return self.rigidity_matrix(pinned_vertices=pinned_vertices).rank()
 
-    def is_infinitesimally_rigid(self) -> bool:
+    def is_inf_rigid(self) -> bool:
         """
         Check whether the given framework is infinitesimally rigid 
         
@@ -743,17 +743,17 @@ class Framework(object):
             self.rigidity_matrix_rank() == self.dim() * len(self.graph().vertices()) \
             - (self.dim()) * (self.dim() + 1) // 2
 
-    def is_infinitesimally_flexible(self) -> bool:
+    def is_inf_flexible(self) -> bool:
         """
         Check whether the given framework is infinitesimally flexible.
-        See :meth:`~Framework.is_infinitesimally_rigid`
+        See :meth:`~Framework.is_inf_rigid`
         """
-        return not self.is_infinitesimally_rigid()
+        return not self.is_inf_rigid()
 
-    def is_infinitesimally_spanning(self) -> bool:
+    def is_inf_spanning(self) -> bool:
         raise NotImplementedError()
 
-    def is_minimally_infinitesimally_rigid(self) -> bool:
+    def is_min_inf_rigid(self) -> bool:
         """
         Check whether a framework is minimally infinitesimally rigid.
 
@@ -764,19 +764,19 @@ class Framework(object):
         Examples
         --------
         >>> F = Framework.Complete([[0,0], [1,0], [1,1], [0,1]])
-        >>> F.is_minimally_infinitesimally_rigid()
+        >>> F.is_min_inf_rigid()
         False
         >>> F.delete_edge((0,2))
-        >>> F.is_minimally_infinitesimally_rigid()
+        >>> F.is_min_inf_rigid()
         True
         """
-        if not self.is_infinitesimally_rigid():
+        if not self.is_inf_rigid():
             return False
         for edge in self.graph().edges:
             F = deepcopy(self)
             F.delete_edge(edge)
             print(F)
-            if F.is_infinitesimally_rigid():
+            if F.is_inf_rigid():
                 return False
         return True
 
@@ -806,7 +806,7 @@ class Framework(object):
         for edge in self._graph.edges:
             F = deepcopy(self)
             F.delete_edge(edge)
-            if not F.is_infinitesimally_rigid():
+            if not F.is_inf_rigid():
                 return False
         return True
 

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -347,12 +347,12 @@ class Graph(nx.Graph):
                         0,
                         dim)] for vertex in self.vertices()}
             F = Framework(self, realization, dim)
-            return F.is_infinitesimally_rigid()
+            return F.is_inf_rigid()
         else:
             raise ValueError(
                 f"The Dimension for combinatorial computation must be either 1 or 2, but is {dim}")
 
-    def is_minimally_rigid(
+    def is_min_rigid(
             self,
             dim: int = 2,
             combinatorial: bool = True) -> bool:
@@ -369,10 +369,10 @@ class Graph(nx.Graph):
         Examples
         --------
         >>> G = Graph([(0,1), (1,2), (2,3), (3,0), (1,3)])
-        >>> G.is_minimally_rigid()
+        >>> G.is_min_rigid()
         True
         >>> G.add_edge(0,2)
-        >>> G.is_minimally_rigid()
+        >>> G.is_min_rigid()
         False
         """
         if not isinstance(dim, int) or dim < 1:
@@ -397,7 +397,7 @@ class Graph(nx.Graph):
                         0,
                         dim)] for vertex in self.vertices()}
             F = Framework(self, realization, dim)
-            return F.is_minimally_infinitesimally_rigid()
+            return F.is_min_inf_rigid()
         else:
             raise ValueError(
                 f"The dimension for combinatorial computation must be either 1 or 2, but is {dim}")
@@ -490,7 +490,7 @@ class Graph(nx.Graph):
                 f"The dimension needs to be a positive integer, but is {dim}!")
         raise NotImplementedError()
 
-    def maximal_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
+    def max_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
         """
         List vertex-maximal rigid subgraphs of the graph.
 
@@ -507,12 +507,12 @@ class Graph(nx.Graph):
         Examples
         --------
         >>> G = Graph([(0,1), (1,2), (2,3), (3,0)])
-        >>> G.maximal_rigid_subgraphs()
+        >>> G.max_rigid_subgraphs()
         []
         >>> G_ = Graph([(0,1), (1,2), (2,3), (3,4), (4,5), (5,0), (0,2), (5,3)])
         >>> G_.is_rigid()
         False
-        >>> [print(entry) for entry in G.maximal_rigid_subgraphs()]
+        >>> [print(entry) for entry in G.max_rigid_subgraphs()]
         Vertices: [0, 1, 2],    Edges: [(0, 1), (0, 2), (1, 2)]
         Vertices: [3, 4, 5],    Edges: [(3, 4), (3, 5), (4, 5)]
         """
@@ -524,32 +524,32 @@ class Graph(nx.Graph):
             return []
         if self.is_rigid():
             return [self]
-        maximal_subgraphs = []
+        max_subgraphs = []
         for vertex_subset in combinations(
             self.vertices(), len(
                 self.vertices()) - 1):
             G = self.subgraph(vertex_subset)
-            maximal_subgraphs = [
+            max_subgraphs = [
                 j for i in [
-                    maximal_subgraphs,
-                    G.maximal_rigid_subgraphs(dim)] for j in i]
+                    max_subgraphs,
+                    G.max_rigid_subgraphs(dim)] for j in i]
 
         # We now remove the graphs that were found at least twice.
         clean_list = []
-        for i in range(0, len(maximal_subgraphs)):
+        for i in range(0, len(max_subgraphs)):
             iso_bool = False
-            for j in range(i + 1, len(maximal_subgraphs)):
+            for j in range(i + 1, len(max_subgraphs)):
                 if set(
-                        maximal_subgraphs[i].nodes) == set(
-                        maximal_subgraphs[j].nodes) and maximal_subgraphs[i].is_isomorphic(
-                        maximal_subgraphs[j]):
+                        max_subgraphs[i].nodes) == set(
+                        max_subgraphs[j].nodes) and max_subgraphs[i].is_isomorphic(
+                        max_subgraphs[j]):
                     iso_bool = True
                     break
             if not iso_bool:
-                clean_list.append(maximal_subgraphs[i])
+                clean_list.append(max_subgraphs[i])
         return clean_list
 
-    def minimal_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
+    def min_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
         """
         List vertex-minimal non-trivial rigid subgraphs of the graph.
 
@@ -567,14 +567,14 @@ class Graph(nx.Graph):
         >>> G = Graph([(0,1), (1,2), (2,3), (3,4), (4,5), (5,0), (0,3), (4,1), (5,2)])
         >>> G.is_rigid()
         True
-        >>> [print(entry) for entry in G.minimal_rigid_subgraphs()]
+        >>> [print(entry) for entry in G.min_rigid_subgraphs()]
         Vertices: [0, 1, 2, 3, 4, 5],   Edges: [(0, 1), (0, 5), (0, 3), (1, 2), (1, 4), (2, 3), (2, 5), (3, 4), (4, 5)]
         """
         if not isinstance(dim, int) or dim < 1:
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
-        minimal_subgraphs = []
+        min_subgraphs = []
         if len(self.vertices()) <= 2:
             return []
         elif len(self.vertices()) == dim + 1 and self.is_rigid():
@@ -585,28 +585,28 @@ class Graph(nx.Graph):
             self.vertices(), len(
                 self.vertices()) - 1):
             G = self.subgraph(vertex_subset)
-            subgraphs = G.minimal_rigid_subgraphs(dim)
+            subgraphs = G.min_rigid_subgraphs(dim)
             if len(subgraphs) == 0 and G.is_rigid():
-                minimal_subgraphs.append(G)
+                min_subgraphs.append(G)
             else:
-                minimal_subgraphs = [
+                min_subgraphs = [
                     j for i in [
-                        minimal_subgraphs,
-                        G.minimal_rigid_subgraphs(dim)] for j in i]
+                        min_subgraphs,
+                        G.min_rigid_subgraphs(dim)] for j in i]
 
         # We now remove the graphs that were found at least twice.
         clean_list = []
-        for i in range(0, len(minimal_subgraphs)):
+        for i in range(0, len(min_subgraphs)):
             iso_bool = False
-            for j in range(i + 1, len(minimal_subgraphs)):
+            for j in range(i + 1, len(min_subgraphs)):
                 if set(
-                        minimal_subgraphs[i].nodes) == set(
-                        minimal_subgraphs[j].nodes) and minimal_subgraphs[i].is_isomorphic(
-                        minimal_subgraphs[j]):
+                        min_subgraphs[i].nodes) == set(
+                        min_subgraphs[j].nodes) and min_subgraphs[i].is_isomorphic(
+                        min_subgraphs[j]):
                     iso_bool = True
                     break
             if not iso_bool:
-                clean_list.append(minimal_subgraphs[i])
+                clean_list.append(min_subgraphs[i])
         # If no smaller graph is found and the graph is rigid, it is returned.
         if not clean_list and self.is_rigid():
             clean_list = [self]

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -37,25 +37,25 @@ def test_vertex_addition():
 
 def test_inf_rigidity():
     F = Framework(Graph([[0,1], [1,2], [0,2]]), {0:[1,2], 1:[0,5], 2:[3,3]})
-    assert (F.is_infinitesimally_rigid() and F.is_minimally_infinitesimally_rigid())
+    assert (F.is_inf_rigid() and F.is_min_inf_rigid())
     F_ = Framework(Graph([[0,1], [1,2], [2,3], [3,0], [0,2], [1,3]]), {0:[0,0], 1:[2,0], 2:[2,2], 3:[-1,1]})
-    assert (F_.is_infinitesimally_rigid() and not F_.is_minimally_infinitesimally_rigid())
+    assert (F_.is_inf_rigid() and not F_.is_min_inf_rigid())
     F_.delete_edge([0,2])
-    assert (F_.is_infinitesimally_rigid() and F_.is_minimally_infinitesimally_rigid())
+    assert (F_.is_inf_rigid() and F_.is_min_inf_rigid())
 
 def test_inf_motions():
     F = Framework(Graph([[0,1]]), {0:[0,0], 1:[1,0]})
-    assert F.infinitesimal_flexes(include_trivial=True) == F.trivial_infinitesimal_flexes()
+    assert F.inf_flexes(include_trivial=True) == F.trivial_inf_flexes()
     F_ = Framework(Graph([[0,1], [1,2], [2,3], [0,3]]), {0:[0,0], 1:[1,0], 2:[1,1], 3:[0,1]})
-    assert (len(F_.infinitesimal_flexes(include_trivial=False))==1 and F_.infinitesimal_flexes(include_trivial=False)[0].rank()==1)
+    assert (len(F_.inf_flexes(include_trivial=False))==1 and F_.inf_flexes(include_trivial=False)[0].rank()==1)
 
 def test_pinning():
     F = Framework(Graph([[0,1], [0,2]]), {0:[0,0], 1:[1,0], 2:[1,1]})
-    assert(len(F.infinitesimal_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=False))==1 and
-            len(F.infinitesimal_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True))==1 and
-            F.infinitesimal_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True)[0][0:4]==[0 for _ in range(4)])
+    assert(len(F.inf_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=False))==1 and
+            len(F.inf_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True))==1 and
+            F.inf_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True)[0][0:4]==[0 for _ in range(4)])
     F.add_edge([1,2])
-    assert(len(F.infinitesimal_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=False))==0 and
-           len(F.infinitesimal_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True))==0)
-    assert(len(F.infinitesimal_flexes(pinned_vertices={0:[0],2:[0]}, include_trivial=False))==0 and
-           len(F.infinitesimal_flexes(pinned_vertices={0:[0],2:[0]}, include_trivial=True))==1)
+    assert(len(F.inf_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=False))==0 and
+           len(F.inf_flexes(pinned_vertices={0:[0,1],1:[1]}, include_trivial=True))==0)
+    assert(len(F.inf_flexes(pinned_vertices={0:[0],2:[0]}, include_trivial=False))==0 and
+           len(F.inf_flexes(pinned_vertices={0:[0],2:[0]}, include_trivial=True))==1)

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -2,13 +2,13 @@ from pyrigi.graph import Graph
 import pytest
 
 @pytest.mark.slow
-def test_minimal_maximal_rigid_subgraphs():
+def test_min_max_rigid_subgraphs():
     G = Graph()
     G.add_nodes_from([0,1,2,3,4,5,'a','b'])
     G.add_edges_from([(0,1), (1,2), (2,3), (3,4), (4,5), (5,0),
                       (0,3), (1,4), (2,5),
                       (0,'a'), (0,'b'), ('a','b')])
-    max_subgraphs = G.maximal_rigid_subgraphs()
+    max_subgraphs = G.max_rigid_subgraphs()
     assert(
         len(max_subgraphs) == 2
         and len(max_subgraphs[0].vertices()) in [3,6] 
@@ -16,7 +16,7 @@ def test_minimal_maximal_rigid_subgraphs():
         and len(max_subgraphs[0].edges) in [3,9]
         and len(max_subgraphs[1].edges) in [3,9]
     ) 
-    min_subgraphs = G.minimal_rigid_subgraphs()
+    min_subgraphs = G.min_rigid_subgraphs()
     print(min_subgraphs[0])
     print(min_subgraphs[1])
     assert(
@@ -39,7 +39,7 @@ def test_graph_rigidity_and_sparsity():
     assert(
         G.is_tight(2,3)
         and G.is_rigid(dim=2, combinatorial=True)
-        and G.is_minimally_rigid(dim=2, combinatorial=True)
+        and G.is_min_rigid(dim=2, combinatorial=True)
         and not G.is_globally_rigid(dim=2)
     ) 
     G.add_edge(1,3)


### PR DESCRIPTION
Since some method names can get lengthy (minimally k-vertex redundantly globally rigid), we could use `inf`, `min`, `max` instead of `infinitesimally`, `minimally`,`maximally` respectively.