### PR TITLE
Feature vertex edge lists

### DIFF
--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -78,7 +78,7 @@ class Framework(object):
         else:
             dimension = len(list(realization.values())[0])
 
-        for v in graph.vertices():
+        for v in graph.nodes:
             if v not in realization:
                 raise KeyError(
                     f"Vertex {v} is not contained in the realization")
@@ -87,7 +87,7 @@ class Framework(object):
                     f"The point {realization[v]} in the realization that vertex {v} corresponds to does not have the right dimension")
 
         self._realization = {v: Matrix(realization[v])
-                             for v in graph.vertices()}
+                             for v in graph.nodes}
         self._graph = deepcopy(graph)
         self._dim = dimension
 
@@ -105,7 +105,7 @@ class Framework(object):
                 key] for key in sorted(self.get_realization_list())})
         except BaseException:
             realization_str = str({key: self.get_realization_list()[
-                key] for key in self._graph.vertices()})
+                key] for key in self._graph.nodes})
         return 'Graph:\t\t' + str(self._graph) + '\n' + 'Realization:\t' + \
             realization_str + '\n' + 'dim:\t\t' + str(self.dim())
 
@@ -145,7 +145,7 @@ class Framework(object):
                 candidate += 1
             vertex = candidate
 
-        if vertex in self._graph.vertices():
+        if vertex in self._graph.nodes:
             raise KeyError(f"Vertex {vertex} is already a vertex of the graph!")
 
         self._realization[vertex] = Matrix(point)
@@ -285,7 +285,7 @@ class Framework(object):
         N = 10 * graph.order()**2 * dim
         realization = {
             vertex: [randrange(1, N) for _ in range(dim)]
-            for vertex in graph.vertices()}
+            for vertex in graph.nodes}
 
         return Framework(graph=graph, realization=realization)
 
@@ -335,7 +335,7 @@ class Framework(object):
             raise ValueError("The realization cannot be empty.")
 
         Kn = Graph.complete_graph(len(points))
-        realization = {(Kn.vertices())[i]: Matrix(
+        realization = {(Kn.vertex_list())[i]: Matrix(
             points[i]) for i in range(len(points))}
         return Framework(graph=Kn, realization=realization, dim=dim)
 
@@ -380,7 +380,7 @@ class Framework(object):
         {0: (0.0, 0.0), 1: (1.0, 0.0), 2: (1.0, 1.0)}
         """
         return {vertex: tuple([float(point) for point in self._realization[vertex]])
-                for vertex in self._graph.vertices()}
+                for vertex in self._graph.nodes}
 
     def get_realization(self) -> Dict[Vertex, Point]:
         """
@@ -410,7 +410,7 @@ class Framework(object):
         Examples
         --------
         >>> F = Framework.Complete([(0,0), (1,0), (1,1)])
-        >>> F.set_realization({vertex:(vertex,vertex+1) for vertex in F.graph().vertices()})
+        >>> F.set_realization({vertex:(vertex,vertex+1) for vertex in F.graph().vertex_list()})
         >>> print(F)
         Graph:          Vertices: [0, 1, 2],    Edges: [(0, 1), (0, 2), (1, 2)]
         Realization:    {0: (0.0, 1.0), 1: (1.0, 2.0), 2: (2.0, 3.0)}
@@ -419,7 +419,7 @@ class Framework(object):
         if not len(realization) == self._graph.order():
             raise IndexError(
                 "The realization does not contain the correct amount of vertices!")
-        for v in self._graph.vertices():
+        for v in self._graph.nodes:
             if v not in realization:
                 raise KeyError(
                     "Vertex {vertex} is not a key of the given realization!")
@@ -531,23 +531,23 @@ class Framework(object):
         """
         try:
             if vertex_order is None:
-                vertex_order = sorted(self._graph.vertices())
+                vertex_order = sorted(self._graph.nodes)
             else:
                 if not set(
-                        self._graph.vertices()) == set(vertex_order) or not len(
-                        self._graph.vertices()) == len(vertex_order):
+                        self._graph.nodes) == set(vertex_order) or not len(
+                        self._graph.nodes) == len(vertex_order):
                     raise KeyError(
                         "The vertex_order needs to contain exactly the same vertices as the graph!")
         except TypeError as error:
-            vertex_order = self._graph.vertices()
+            vertex_order = self._graph.vertex_list()
 
         for v in vertex_order:
             if v not in pinned_vertices:
                 pinned_vertices[v] = []
         pinned_vertices = {v: pinned_vertices[v] for v in pinned_vertices.keys(
-        ) if v in self._graph.vertices()}
+        ) if v in self._graph.nodes}
         for v in pinned_vertices:
-            if v not in self._graph.vertices():
+            if v not in self._graph.nodes:
                 raise KeyError(
                     f"Vertex {v} in pinned_vertices is not a vertex of the graph!")
             if not len(pinned_vertices[v]) <= self.dim():
@@ -643,7 +643,7 @@ class Framework(object):
             [ 1]])
         ]
         """
-        vertices = self._graph.vertices()
+        vertices = self._graph.vertex_list()
         Kn = Graph.complete_graph_on_vertices(vertices)
         F_Kn = Framework(
             graph=Kn,

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -66,7 +66,7 @@ class Framework(object):
                  dim: int = 2) -> None:
         if not isinstance(graph, Graph):
             raise TypeError("The graph has to be an instance of class Graph")
-        if not len(realization.keys()) == graph.order():
+        if not len(realization.keys()) == graph.number_of_nodes():
             raise KeyError(
                 "The length of realization has to be equal to the number of vertices of graph")
         if not isinstance(dim, int) or dim < 1:
@@ -140,7 +140,7 @@ class Framework(object):
         dim:            2
         """
         if vertex is None:
-            candidate = self._graph.order()
+            candidate = self._graph.number_of_nodes()
             while candidate in self._graph.nodes:
                 candidate += 1
             vertex = candidate
@@ -282,7 +282,7 @@ class Framework(object):
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
-        N = 10 * graph.order()**2 * dim
+        N = 10 * graph.number_of_nodes()**2 * dim
         realization = {
             vertex: [randrange(1, N) for _ in range(dim)]
             for vertex in graph.nodes}
@@ -416,7 +416,7 @@ class Framework(object):
         Realization:    {0: (0.0, 1.0), 1: (1.0, 2.0), 2: (2.0, 3.0)}
         dim:            2
         """
-        if not len(realization) == self._graph.order():
+        if not len(realization) == self._graph.number_of_nodes():
             raise IndexError(
                 "The realization does not contain the correct amount of vertices!")
         for v in self._graph.nodes:
@@ -739,8 +739,8 @@ class Framework(object):
         -----
         * :prf:ref:`Infinitesimal Rigidity <def-infinitesimal-rigidity>`
         """
-        return self.graph().order() <= 1 or \
-            self.rigidity_matrix_rank() == self.dim() * self.graph().order() \
+        return self.graph().number_of_nodes() <= 1 or \
+            self.rigidity_matrix_rank() == self.dim() * self.graph().number_of_nodes() \
             - (self.dim()) * (self.dim() + 1) // 2
 
     def is_infinitesimally_flexible(self) -> bool:

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -66,7 +66,7 @@ class Framework(object):
                  dim: int = 2) -> None:
         if not isinstance(graph, Graph):
             raise TypeError("The graph has to be an instance of class Graph")
-        if not len(realization.keys()) == len(graph.vertices()):
+        if not len(realization.keys()) == graph.order():
             raise KeyError(
                 "The length of realization has to be equal to the number of vertices of graph")
         if not isinstance(dim, int) or dim < 1:
@@ -140,8 +140,8 @@ class Framework(object):
         dim:            2
         """
         if vertex is None:
-            candidate = len(self._graph.vertices())
-            while candidate in self._graph.vertices():
+            candidate = self._graph.order()
+            while candidate in self._graph.nodes:
                 candidate += 1
             vertex = candidate
 
@@ -282,7 +282,7 @@ class Framework(object):
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
-        N = 10 * len(graph.vertices())**2 * dim
+        N = 10 * graph.order()**2 * dim
         realization = {
             vertex: [randrange(1, N) for _ in range(dim)]
             for vertex in graph.vertices()}
@@ -416,7 +416,7 @@ class Framework(object):
         Realization:    {0: (0.0, 1.0), 1: (1.0, 2.0), 2: (2.0, 3.0)}
         dim:            2
         """
-        if not len(realization) == len(self._graph.vertices()):
+        if not len(realization) == self._graph.order():
             raise IndexError(
                 "The realization does not contain the correct amount of vertices!")
         for v in self._graph.vertices():
@@ -739,8 +739,8 @@ class Framework(object):
         -----
         * :prf:ref:`Infinitesimal Rigidity <def-infinitesimal-rigidity>`
         """
-        return len(self.graph().vertices()) <= 1 or \
-            self.rigidity_matrix_rank() == self.dim() * len(self.graph().vertices()) \
+        return self.graph().order() <= 1 or \
+            self.rigidity_matrix_rank() == self.dim() * self.graph().order() \
             - (self.dim()) * (self.dim() + 1) // 2
 
     def is_infinitesimally_flexible(self) -> bool:

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -141,9 +141,13 @@ class Graph(nx.Graph):
         edges = combinations(vertices, 2)
         return Graph.from_vertices_and_edges(vertices, edges)
 
-    def vertices(self) -> List[Vertex]:
-        """Alias for the `nodes` attribute."""
+    def vertex_list(self) -> List[Vertex]:
+        """Return the list of vertices."""
         return list(self.nodes)
+    
+    def edge_list(self) -> List[Edge]:
+        """Return the list of edges"""
+        return list(self.edges)
 
     def delete_vertex(self, vertex: Vertex) -> None:
         """Alias for :meth:`networkx.Graph.remove_node`."""

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -184,7 +184,7 @@ class Graph(nx.Graph):
         if not (isinstance(K, int) and isinstance(L, int)):
             raise TypeError("K and L need to be integers!")
 
-        for j in range(K, len(self.vertices()) + 1):
+        for j in range(K, self.order() + 1):
             for vertex_set in combinations(self.vertices(), j):
                 G = self.subgraph(vertex_set)
                 if len(G.edges) > K * len(G.nodes) - L:
@@ -326,7 +326,7 @@ class Graph(nx.Graph):
         elif dim == 1:
             return self.is_connected()
         elif dim == 2 and combinatorial:
-            deficiency = -(2 * len(self.vertices()) - 3) + len(self.edges)
+            deficiency = -(2 * self.order() - 3) + len(self.edges)
             if deficiency < 0:
                 return False
             else:
@@ -338,7 +338,7 @@ class Graph(nx.Graph):
                 return False
         elif not combinatorial:
             from pyrigi.framework import Framework
-            N = 10 * len(self.vertices())**2 * dim
+            N = 10 * self.order()**2 * dim
             realization = {
                 vertex: [
                     randrange(
@@ -388,7 +388,7 @@ class Graph(nx.Graph):
             return self.is_tight(2, 3)
         elif not combinatorial:
             from pyrigi.framework import Framework
-            N = 10 * len(self.vertices())**2 * dim
+            N = 10 * self.order()**2 * dim
             realization = {
                 vertex: [
                     randrange(
@@ -520,14 +520,13 @@ class Graph(nx.Graph):
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
-        if len(self.vertices()) <= dim:
+        if self.order() <= dim:
             return []
         if self.is_rigid():
             return [self]
         maximal_subgraphs = []
         for vertex_subset in combinations(
-            self.vertices(), len(
-                self.vertices()) - 1):
+            self.vertices(), self.order() - 1):
             G = self.subgraph(vertex_subset)
             maximal_subgraphs = [
                 j for i in [
@@ -575,15 +574,14 @@ class Graph(nx.Graph):
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
         minimal_subgraphs = []
-        if len(self.vertices()) <= 2:
+        if self.order() <= 2:
             return []
-        elif len(self.vertices()) == dim + 1 and self.is_rigid():
+        elif self.order() == dim + 1 and self.is_rigid():
             return [self]
-        elif len(self.vertices()) == dim + 1:
+        elif self.order() == dim + 1:
             return []
         for vertex_subset in combinations(
-            self.vertices(), len(
-                self.vertices()) - 1):
+            self.vertices(), self.order() - 1):
             G = self.subgraph(vertex_subset)
             subgraphs = G.minimal_rigid_subgraphs(dim)
             if len(subgraphs) == 0 and G.is_rigid():

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -84,7 +84,7 @@ class Graph(nx.Graph):
         the internal order is used instead.
         """
         try:
-            vertices_str = str(sorted(self.vertices()))
+            vertices_str = str(sorted(self.nodes))
             edges_str = "["
             for edge in self.edges:
                 if edge[0] < edge[1]:
@@ -96,7 +96,7 @@ class Graph(nx.Graph):
                     edges_str += ", "
             edges_str += "]"
         except BaseException:
-            vertices_str = str(self.vertices())
+            vertices_str = str(self.vertex_list())
             edges_str = str(self.edges)
 
         return 'Vertices: ' + vertices_str + ',\t'\
@@ -189,7 +189,7 @@ class Graph(nx.Graph):
             raise TypeError("K and L need to be integers!")
 
         for j in range(K, self.order() + 1):
-            for vertex_set in combinations(self.vertices(), j):
+            for vertex_set in combinations(self.nodes, j):
                 G = self.subgraph(vertex_set)
                 if len(G.edges) > K * len(G.nodes) - L:
                     return False
@@ -271,7 +271,7 @@ class Graph(nx.Graph):
                 f"The dimension needs to be a positive integer, but is {dim}!")
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
-        for vertex_set in combinations(self.vertices(), k):
+        for vertex_set in combinations(self.nodes, k):
             G = deepcopy(self)
             G.delete_vertices(vertex_set)
             if not G.is_rigid(dim):
@@ -349,7 +349,7 @@ class Graph(nx.Graph):
                         1,
                         N) for _ in range(
                         0,
-                        dim)] for vertex in self.vertices()}
+                        dim)] for vertex in self.nodes}
             F = Framework(self, realization, dim)
             return F.is_infinitesimally_rigid()
         else:
@@ -399,7 +399,7 @@ class Graph(nx.Graph):
                         1,
                         N) for _ in range(
                         0,
-                        dim)] for vertex in self.vertices()}
+                        dim)] for vertex in self.nodes}
             F = Framework(self, realization, dim)
             return F.is_minimally_infinitesimally_rigid()
         else:
@@ -530,7 +530,7 @@ class Graph(nx.Graph):
             return [self]
         maximal_subgraphs = []
         for vertex_subset in combinations(
-            self.vertices(), self.order() - 1):
+            self.nodes, self.order() - 1):
             G = self.subgraph(vertex_subset)
             maximal_subgraphs = [
                 j for i in [
@@ -585,7 +585,7 @@ class Graph(nx.Graph):
         elif self.order() == dim + 1:
             return []
         for vertex_subset in combinations(
-            self.vertices(), self.order() - 1):
+            self.nodes, self.order() - 1):
             G = self.subgraph(vertex_subset)
             subgraphs = G.minimal_rigid_subgraphs(dim)
             if len(subgraphs) == 0 and G.is_rigid():
@@ -736,15 +736,14 @@ class Graph(nx.Graph):
         """
         try:
             if vertex_order is None:
-                vertex_order = sorted(self.vertices())
+                vertex_order = sorted(self.nodes)
             else:
-                if not set(
-                        self.vertices()) == set(vertex_order) or not len(
-                        self.vertices()) == len(vertex_order):
+                if (not set(self.nodes) == set(vertex_order)
+                    or not self.order() == len(vertex_order)):
                     raise IndexError(
                         "The vertex_order needs to contain the same vertices as the graph!")
         except TypeError as error:
-            vertex_order = self.vertices()
+            vertex_order = self.vertex_list()
 
         row_list = []
         for vertex in vertex_order:

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -188,7 +188,7 @@ class Graph(nx.Graph):
         if not (isinstance(K, int) and isinstance(L, int)):
             raise TypeError("K and L need to be integers!")
 
-        for j in range(K, self.order() + 1):
+        for j in range(K, self.number_of_nodes() + 1):
             for vertex_set in combinations(self.nodes, j):
                 G = self.subgraph(vertex_set)
                 if len(G.edges) > K * len(G.nodes) - L:
@@ -330,7 +330,7 @@ class Graph(nx.Graph):
         elif dim == 1:
             return self.is_connected()
         elif dim == 2 and combinatorial:
-            deficiency = -(2 * self.order() - 3) + len(self.edges)
+            deficiency = -(2 * self.number_of_nodes() - 3) + len(self.edges)
             if deficiency < 0:
                 return False
             else:
@@ -342,7 +342,7 @@ class Graph(nx.Graph):
                 return False
         elif not combinatorial:
             from pyrigi.framework import Framework
-            N = 10 * self.order()**2 * dim
+            N = 10 * self.number_of_nodes()**2 * dim
             realization = {
                 vertex: [
                     randrange(
@@ -392,7 +392,7 @@ class Graph(nx.Graph):
             return self.is_tight(2, 3)
         elif not combinatorial:
             from pyrigi.framework import Framework
-            N = 10 * self.order()**2 * dim
+            N = 10 * self.number_of_nodes()**2 * dim
             realization = {
                 vertex: [
                     randrange(
@@ -524,13 +524,13 @@ class Graph(nx.Graph):
             raise TypeError(
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
-        if self.order() <= dim:
+        if self.number_of_nodes() <= dim:
             return []
         if self.is_rigid():
             return [self]
         maximal_subgraphs = []
         for vertex_subset in combinations(
-            self.nodes, self.order() - 1):
+            self.nodes, self.number_of_nodes() - 1):
             G = self.subgraph(vertex_subset)
             maximal_subgraphs = [
                 j for i in [
@@ -578,14 +578,14 @@ class Graph(nx.Graph):
                 f"The dimension needs to be a positive integer, but is {dim}!")
 
         minimal_subgraphs = []
-        if self.order() <= 2:
+        if self.number_of_nodes() <= 2:
             return []
-        elif self.order() == dim + 1 and self.is_rigid():
+        elif self.number_of_nodes() == dim + 1 and self.is_rigid():
             return [self]
-        elif self.order() == dim + 1:
+        elif self.number_of_nodes() == dim + 1:
             return []
         for vertex_subset in combinations(
-            self.nodes, self.order() - 1):
+            self.nodes, self.number_of_nodes() - 1):
             G = self.subgraph(vertex_subset)
             subgraphs = G.minimal_rigid_subgraphs(dim)
             if len(subgraphs) == 0 and G.is_rigid():
@@ -739,7 +739,7 @@ class Graph(nx.Graph):
                 vertex_order = sorted(self.nodes)
             else:
                 if (not set(self.nodes) == set(vertex_order)
-                    or not self.order() == len(vertex_order)):
+                    or not self.number_of_nodes() == len(vertex_order)):
                     raise IndexError(
                         "The vertex_order needs to contain the same vertices as the graph!")
         except TypeError as error:

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -16,11 +16,11 @@ def test_vertex_addition():
     F_.set_realization(F.get_realization())
     assert (
         F.get_realization_list() == F_.get_realization_list()
-        and F.graph().vertices() == F_.graph().vertices()
+        and F.graph().vertex_list() == F_.graph().vertex_list()
         and F.dim() == F_.dim()
     )
     assert (
-        list(F.graph().vertices()) == [0, 1, 2]
+        F.graph().vertex_list() == [0, 1, 2]
         and len(F.graph().edges()) == 0
     )
     F.change_vertex_coordinates_list([0, 2], [[3.,0.], [0.,3.]])

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -11,8 +11,8 @@ def test_minimal_maximal_rigid_subgraphs():
     max_subgraphs = G.maximal_rigid_subgraphs()
     assert(
         len(max_subgraphs) == 2
-        and len(max_subgraphs[0].vertices()) in [3,6] 
-        and len(max_subgraphs[1].vertices()) in [3,6]
+        and len(max_subgraphs[0].vertex_list()) in [3,6] 
+        and len(max_subgraphs[1].vertex_list()) in [3,6]
         and len(max_subgraphs[0].edges) in [3,9]
         and len(max_subgraphs[1].edges) in [3,9]
     ) 
@@ -21,8 +21,8 @@ def test_minimal_maximal_rigid_subgraphs():
     print(min_subgraphs[1])
     assert(
         len(min_subgraphs) == 2
-        and len(min_subgraphs[0].vertices()) in [3,6] 
-        and len(min_subgraphs[1].vertices()) in [3,6]
+        and len(min_subgraphs[0].vertex_list()) in [3,6] 
+        and len(min_subgraphs[1].vertex_list()) in [3,6]
         and len(min_subgraphs[0].edges) in [3,9]
         and len(min_subgraphs[1].edges) in [3,9]
     ) 


### PR DESCRIPTION
Since NetworkX gives outputs in its own format, users can use `vertex_list` and `edge_list` to really get lists of objects. Internally, using `Graph.nodes` is better since it avoids creating lists.

`Graph.number_of_nodes()` is definitely better than `len(Graph.vertex_list())`.