### PR TITLE
Alternative pinned vertices

### DIFF
--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -641,7 +641,6 @@ class Framework(object):
     def stress_matrix(
         self,
         data: Any,
-        pinned_vertices: Dict[Vertex, List[int]] = {},
         edge_order: List[Edge] = None,
     ) -> Matrix:
         r"""

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -684,7 +684,6 @@ class Framework(object):
     @doc_category("Infinitesimal rigidity")
     def inf_flexes(
         self,
-        pinned_vertices: Dict[Vertex, List[int]] = {},
         include_trivial: bool = False,
     ) -> List[Matrix]:
         r"""
@@ -703,8 +702,6 @@ class Framework(object):
 
         Parameters
         ----------
-        pinned_vertices:
-            see :meth:`~Framework.rigidity_matrix`
         include_trivial:
             Boolean that decides, whether the trivial motions should
             be included (`True`) or not (`False`)
@@ -724,14 +721,14 @@ class Framework(object):
         [-1/4],
         [ 1/4]])]
         """
+        kernel = self.rigidity_matrix().nullspace()
         if include_trivial:
-            return self.rigidity_matrix(pinned_vertices=pinned_vertices).nullspace()
-        trivial_flexes = self.trivial_inf_flexes(pinned_vertices=pinned_vertices)
-        all_flexes = self.rigidity_matrix(pinned_vertices=pinned_vertices).nullspace()
+            return kernel
+        trivial_flexes = self.trivial_inf_flexes()
         basis_flexspace = Matrix.orthogonalize(
-            *(trivial_flexes + all_flexes), rankcheck=False
+            *(trivial_flexes + kernel), rankcheck=False
         )
-        return basis_flexspace[len(trivial_flexes) : len(all_flexes) + 1]
+        return basis_flexspace[len(trivial_flexes) : len(kernel) + 1]
 
     @doc_category("Waiting for implementation")
     def stresses(self) -> Any:

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -730,7 +730,10 @@ class Framework(object):
         return matrix_inf_flexes.transpose().echelon_form().transpose().columnspace()
 
     @doc_category("Infinitesimal rigidity")
-    def nontrivial_inf_flexes(self) -> List[Matrix]:
+    def nontrivial_inf_flexes(
+        self,
+        pinned_vertices: Dict[Vertex, List[int]] = None,
+    ) -> List[Matrix]:
         """
         Return non-trivial infinitesimal flexes.
 
@@ -743,12 +746,13 @@ class Framework(object):
         -----
         See :meth:`~Framework.trivial_inf_flexes`.
         """
-        return self.inf_flexes(include_trivial=False)
+        return self.inf_flexes(include_trivial=False, pinned_vertices=pinned_vertices)
 
     @doc_category("Infinitesimal rigidity")
     def inf_flexes(
         self,
         include_trivial: bool = False,
+        pinned_vertices: Dict[Vertex, List[int]] = None,
     ) -> List[Matrix]:
         r"""
         Return a basis of the space of infinitesimal flexes.
@@ -785,7 +789,11 @@ class Framework(object):
         [-1/4],
         [ 1/4]])]
         """
-        kernel = self.rigidity_matrix().nullspace()
+        if pinned_vertices is None:
+            rigidity_matrix = self.rigidity_matrix()
+        else:
+            rigidity_matrix = self.pinned_rigidity_matrix(pinned_vertices)
+        kernel = rigidity_matrix.nullspace()
         if include_trivial:
             return kernel
         trivial_flexes = self.trivial_inf_flexes()

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -734,9 +734,7 @@ class Framework(object):
         raise NotImplementedError()
 
     @doc_category("Infinitesimal rigidity")
-    def rigidity_matrix_rank(
-        self, pinned_vertices: Dict[Vertex, List[int]] = {}
-    ) -> int:
+    def rigidity_matrix_rank(self) -> int:
         """
         Compute the rank of the rigidity matrix.
 
@@ -745,7 +743,7 @@ class Framework(object):
         pinned_vertices:
             see :meth:`~Framework.rigidity_matrix`
         """
-        return self.rigidity_matrix(pinned_vertices=pinned_vertices).rank()
+        return self.rigidity_matrix().rank()
 
     @doc_category("Infinitesimal rigidity")
     def is_inf_rigid(self) -> bool:

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -655,54 +655,56 @@ class Framework(object):
         raise NotImplementedError()
 
     @doc_category("Infinitesimal rigidity")
-    def trivial_inf_flexes(
-        self, pinned_vertices: Dict[Vertex, List[int]] = {}
-    ) -> List[Matrix]:
+    def trivial_inf_flexes(self) -> List[Matrix]:
         r"""
         Return the trivial infinitesimal flexes of the framework.
 
         Definitions
         -----------
-        * :prf:ref:`Trivial flexes <def-trivial-flexes>`
-
-        Parameters
-        ----------
-        pinned_vertices:
-            see :meth:`~Framework.rigidity_matrix`
-
-        Notes
-        -----
-        Trival infinitesimal flexes are computed by calculating all
-        infinitesimal flexes of the complete graph.
+        * :prf:ref:`Trivial infinitesimal flexes <def-trivial-inf-flexes>`
 
         Examples
         --------
-        >>> F = Framework.Complete([(0,0),(2,0),(1,3)])
+        >>> F = Framework.Complete([(0,0), (2,0), (0,2)])
         >>> F.trivial_inf_flexes()
         [Matrix([
-        [ 3],
-        [-1],
-        [ 3],
-        [ 1],
-        [ 0],
-        [ 0]]), Matrix([
         [1],
         [0],
         [1],
         [0],
         [1],
         [0]]), Matrix([
-        [-3],
+        [0],
+        [1],
+        [0],
+        [1],
+        [0],
+        [1]]), Matrix([
+        [ 0],
+        [ 0],
+        [ 0],
         [ 2],
-        [-3],
-        [ 0],
-        [ 0],
-        [ 1]])]
+        [-2],
+        [ 0]])]
         """
-        vertices = self._graph.vertex_list()
-        Kn = Graph.CompleteOnVertices(vertices)
-        F_Kn = Framework(graph=Kn, realization=self.realization())
-        return F_Kn.inf_flexes(pinned_vertices=pinned_vertices, include_trivial=True)
+        dim = self._dim
+        translations = [
+            Matrix.vstack(*[A for _ in self._graph.nodes])
+            for A in Matrix.eye(dim).columnspace()
+        ]
+        basis_skew_symmetric = []
+        for i in range(1, dim):
+            for j in range(i):
+                A = Matrix.zeros(dim)
+                A[i, j] = 1
+                A[j, i] = -1
+                basis_skew_symmetric += [A]
+        inf_rot = [
+            Matrix.vstack(*[A * self._realization[v] for v in self._graph.nodes])
+            for A in basis_skew_symmetric
+        ]
+        matrix_inf_flexes = Matrix.hstack(*(translations + inf_rot))
+        return matrix_inf_flexes.transpose().echelon_form().transpose().columnspace()
 
     @doc_category("Infinitesimal rigidity")
     def nontrivial_inf_flexes(

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -664,9 +664,7 @@ class Framework(object):
         return matrix_inf_flexes.transpose().echelon_form().transpose().columnspace()
 
     @doc_category("Infinitesimal rigidity")
-    def nontrivial_inf_flexes(
-        self, pinned_vertices: Dict[Vertex, List[int]] = {}
-    ) -> List[Matrix]:
+    def nontrivial_inf_flexes(self) -> List[Matrix]:
         """
         Return non-trivial infinitesimal flexes.
 
@@ -679,7 +677,7 @@ class Framework(object):
         -----
         See :meth:`~Framework.trivial_inf_flexes`.
         """
-        return self.inf_flexes(pinned_vertices=pinned_vertices, include_trivial=False)
+        return self.inf_flexes(include_trivial=False)
 
     @doc_category("Infinitesimal rigidity")
     def inf_flexes(

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -581,8 +581,6 @@ class Framework(object):
                 return -1
             return 0
 
-        # Return the rigidity matrix with standard unit basis vectors added for
-        # each pinned coordinate.
         return Matrix(
             [
                 flatten(
@@ -737,11 +735,6 @@ class Framework(object):
     def rigidity_matrix_rank(self) -> int:
         """
         Compute the rank of the rigidity matrix.
-
-        Parameters
-        ----------
-        pinned_vertices:
-            see :meth:`~Framework.rigidity_matrix`
         """
         return self.rigidity_matrix().rank()
 

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -56,29 +56,3 @@ def test_inf_motions():
         len(F_.inf_flexes(include_trivial=False)) == 1
         and F_.inf_flexes(include_trivial=False)[0].rank() == 1
     )
-
-
-def test_pinning():
-    F = Framework(Graph([[0, 1], [0, 2]]), {0: [0, 0], 1: [1, 0], 2: [1, 1]})
-    assert (
-        len(F.inf_flexes(pinned_vertices={0: [0, 1], 1: [1]}, include_trivial=False))
-        == 1
-        and len(F.inf_flexes(pinned_vertices={0: [0, 1], 1: [1]}, include_trivial=True))
-        == 1
-        and F.inf_flexes(pinned_vertices={0: [0, 1], 1: [1]}, include_trivial=True)[0][
-            0:4
-        ]
-        == [0 for _ in range(4)]
-    )
-    F.add_edge([1, 2])
-    assert (
-        len(F.inf_flexes(pinned_vertices={0: [0, 1], 1: [1]}, include_trivial=False))
-        == 0
-        and len(F.inf_flexes(pinned_vertices={0: [0, 1], 1: [1]}, include_trivial=True))
-        == 0
-    )
-    assert (
-        len(F.inf_flexes(pinned_vertices={0: [0], 2: [0]}, include_trivial=False)) == 0
-        and len(F.inf_flexes(pinned_vertices={0: [0], 2: [0]}, include_trivial=True))
-        == 1
-    )

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -1,6 +1,8 @@
 from pyrigi.graph import Graph
 from pyrigi.framework import Framework
 
+from sympy import Matrix
+
 
 def test_dimension():
     F = Framework(Graph([[0, 1]]), {0: [1, 2], 1: [0, 5]})
@@ -45,14 +47,13 @@ def test_inf_rigidity():
     assert F_.is_inf_rigid() and F_.is_min_inf_rigid()
 
 
-def test_inf_motions():
+def test_inf_flexes():
     F = Framework(Graph([[0, 1]]), {0: [0, 0], 1: [1, 0]})
-    assert F.inf_flexes(include_trivial=True) == F.trivial_inf_flexes()
-    F_ = Framework(
+    Q1 = Matrix.hstack(*(F.inf_flexes(include_trivial=True)))
+    Q2 = Matrix.hstack(*(F.trivial_inf_flexes()))
+    assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
+    F = Framework(
         Graph([[0, 1], [1, 2], [2, 3], [0, 3]]),
         {0: [0, 0], 1: [1, 0], 2: [1, 1], 3: [0, 1]},
     )
-    assert (
-        len(F_.inf_flexes(include_trivial=False)) == 1
-        and F_.inf_flexes(include_trivial=False)[0].rank() == 1
-    )
+    assert len(F.inf_flexes(include_trivial=False)) == 1


### PR DESCRIPTION
* Removed pinned vertices from Framework.rigidity_matrix().
* Created Framework.pinned_rigidity_matrix() where pinned_vertices can be given as an optional parameter (if not given, a "standard" pinning is chosen).
* Framework.inf_flexes() and Framework.nontrivial_inf_flexes() have pinned_vertices as optional parameter (if not given, no pinning is done).
