### PR TITLE
Poetry migration

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,8 +14,18 @@ jobs:
       pages: write
       id-token: write
     steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry config virtualenvs.create false 
+        poetry install --without dev
     - id: deployment
       uses: sphinx-notes/pages@v3
       with:
         documentation_path: ./doc
-        requirements_path: ./doc/requirements.txt

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -19,19 +19,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install poetry
+        poetry install --without doc
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --show-source --statistics
+        poetry run flake8 . --count --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest --doctest-modules
+        poetry run pytest --doctest-modules

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .vscode/settings.json
 *.ipynb
 /.pytest_cache/
+poetry.lock

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.pyc
 .vscode/settings.json
 *.ipynb
+/.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In the future, we will enable installation via `pip`.
 
 The documentation of the `main` branch is available [online](https://pyrigi.github.io/PyRigi/).
 For compiling it locally,
-see the [development guide](https://pyrigi.github.io/PyRigi/development/).
+see the [development guide](https://pyrigi.github.io/PyRigi/development/howto).
 
 An important part of the documentation is the mathematical background.
 We specify the outputs of the methods in the package

--- a/doc/development/howto.md
+++ b/doc/development/howto.md
@@ -37,36 +37,50 @@ Once in a while, the maintainers merge the branch `dev` into `main` and create a
 
 ## Code
 
+### Dependencies
+
+We maintain the dependencies of the package using [Poetry](https://python-poetry.org/).
+See the [installation instructions](https://python-poetry.org/docs/#installation).
+
+To install the package dependencies including those needed for the development, run
+```
+poetry install --no-root
+```
+in the root folder of PyRigi.
+Omitting `--no-root` installs also PyRigi itself, so it can be used system-wide.
+Poetry installs the dependencies and the package to a virtual environment.
+To activate this environment, run `poetry shell`.
+You can exit it with `exit` or `Ctrl+D`.
+
+If you want to install dependencies necessary only for the package itself, not for the development, run
+```
+poetry install --only main
+```
+
+
+
 ### PEP8
 
 We follow [PEP8](https://peps.python.org/pep-0008/) indications regarding Python code format.
 
 To check whether the code is PEP8-compliant, we strongly suggest to use
 [flake8](https://flake8.pycqa.org).
-To install it, run
-```
-pip install flake8
-```
 To check your code, simply run
 ```
-flake8 .
+flake8
 ```
-in PyRigi's home folder.
+in PyRigi's home folder (with poetry shell activated).
 The `.flake8` file in PyRigi's home folder, which specifies `flake8` configuration,
 is the same that is used in the automatic tests once a pull request is filed in GitHub.
 Therefore, please check your code with `flake8` before performing a pull request.
 
 There are tools that format code according to PEP8 indications.
 We **strongly** suggest to use [`black`](https://black.readthedocs.io).
-To install it, run
-```
-pip install black
-```
 To format your code, run
 ```
 black .
 ```
-in the root folder to modify the files in place.
+in the root folder (with poetry shell activated) to modify the files in place.
 We suggest to integrate the use of `black` at every commit
 as explained at [this page](https://black.readthedocs.io/en/stable/integrations/source_version_control.html) of `black`'s guide.
 
@@ -94,7 +108,7 @@ Therefore, before opening a pull request we **strongly advise** to run
 ```
 pytest --doctest-modules
 ```
-in the root folder of PyRigi.
+in the root folder of PyRigi (with poetry shell activated).
 The reason why the examples in the docstrings are tested is to make sure their outputs are valid,
 they do **not** replace the tests in the `test` folder.
 
@@ -121,12 +135,9 @@ The following extensions are used:
  - [`sphinx-design`](https://sphinx-design.readthedocs.io) - fancy features like tabs;
  - [`sphinx-tippy`](https://sphinx-tippy.readthedocs.io/en/latest/) - previews of definitions and methods.
 
-These can be installed by running the following command in the folder `doc`:
-```
-pip install --upgrade -r requirements.txt
-```
+These are already installed if you used `poetry install`.
 
-To compile, run Sphinx in the folder `doc` by:
+To compile, run Sphinx in the folder `doc` (with poetry shell activated) by:
 ```
 make html
 ```
@@ -138,11 +149,8 @@ make latexpdf
 
 ### Auto-build
 
-If you want that the documentation folder is kept watched and documentation is automatically rebuilt once a change is detected (works only for `.md` files, not docstrings), you can use the Sphinx extension [`sphinx-autobuild`](https://github.com/sphinx-doc/sphinx-autobuild), which can be installed via
-```
-pip install sphinx-autobuild
-```
-At this point, run in the `doc` folder:
+If you want that the documentation folder is kept watched and documentation is automatically rebuilt once a change is detected (works only for `.md` files, not docstrings), you can use the Sphinx extension [`sphinx-autobuild`](https://github.com/sphinx-doc/sphinx-autobuild).
+Run in the `doc` folder (with poetry shell activated):
 ```
 sphinx-autobuild . _build/html --open-browser
 ```

--- a/doc/development/howto.md
+++ b/doc/development/howto.md
@@ -37,6 +37,7 @@ Once in a while, the maintainers merge the branch `dev` into `main` and create a
 
 ## Code
 
+(dev-dependencies)=
 ### Dependencies
 
 We maintain the dependencies of the package using [Poetry](https://python-poetry.org/).

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,0 @@
-furo
-myst-nb
-sphinx-copybutton
-sphinx-design
-sphinx-math-dollar
-sphinx-proof
-sphinx-tippy
-sphinxcontrib-bibtex
-sphinxcontrib-napoleon

--- a/doc/userguide/getting_started.md
+++ b/doc/userguide/getting_started.md
@@ -1,12 +1,14 @@
 # Getting started
 
-SOME BASIC INFORMATION
-
 
 ## Installation and usage
 
 We have not reached a stable version yet.
-Hence, the current usage is to clone/download the package
+Hence, the current usage is to install the dependencies
+```
+pip install sympy networkx
+```
+and clone/download the package
 from [this GitHub repository](https://github.com/pyRigi/PyRigi).
 In the root folder of the package, it can be used by
 ```python
@@ -22,3 +24,5 @@ from pyrigi import Graph, Framework
 where `<path_to_pyrigi>` is replaced by the path to the root folder of the package.
 
 In the future, we will enable installation via `pip`.
+
+An alternative way of installation is the one used for the [development via Poetry](#dev-dependencies).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ Issues = "https://github.com/PyRigi/PyRigi/issues"
 python = "^3.10"		#networkx requires >= 3.10
 networkx = "^3.3"
 sympy = "^1.12"
+matplotlib = "^3.9.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,49 @@
-[project]
-name = "PyRigi"
+[tool.poetry]
+name = "pyrigi"
 version = "0.0.1"
-authors = [
-  { name="The PyRigi Developers" },
-]
 description = "Python package concerning the rigidity and flexibility of bar-and-joint frameworks."
+authors = ["The PyRigi Developers"]
+license = "MIT"
 readme = "README.md"
-requires-python = ">=3.9"
+homepage = "https://pyrigi.github.io/PyRigi/"
+repository = "https://github.com/PyRigi/PyRigi/"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = [
-  "networkx",
-  "sympy",
-]
 
-[project.urls]
-Homepage = "https://github.com/PyRigi/"
+[tool.poetry.urls]
 Issues = "https://github.com/PyRigi/PyRigi/issues"
+
+[tool.poetry.dependencies]
+python = "^3.10"		#networkx requires >= 3.10
+networkx = "^3.3"
+sympy = "^1.12"
+
+[tool.poetry.group.dev.dependencies]
+black = "^24.4.2"
+flake8 = "^7.0.0"
+pre-commit = "^3.7.1"
+pytest = "^8.2.1"
+
+[tool.poetry.group.doc.dependencies]
+furo = "^2024.5.6"
+myst-nb = "^1.1.0"
+sphinx-copybutton = "^0.5.2"
+sphinx-design = "^0.5.0"
+sphinx-math-dollar = "^1.2.1"
+sphinx-proof = "^0.1.3"
+sphinx-tippy = "^0.4.3"
+sphinxcontrib-bibtex = "^2.6.2"
+sphinxcontrib-napoleon = "^0.7"
+sphinx-autobuild = "^2024.4.16"
+setuptools = "^69.5.1"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 
 [tool.pytest.ini_options]
 pythonpath = [
@@ -29,6 +53,3 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "serial",
 ]
-
-[tool.setuptools]
-packages = ["pyrigi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ black = "^24.4.2"
 flake8 = "^7.0.0"
 pre-commit = "^3.7.1"
 pytest = "^8.2.1"
+sphinx = "^7.3.7"
 
 [tool.poetry.group.doc.dependencies]
 furo = "^2024.5.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-networkx
-sympy
-matplotlib
-sphinx


### PR DESCRIPTION
Migrating to poetry simplifies keeping track of dependencies (runtime, dev, doc).
Poetry also makes easier to work with a virtual python environment dedicated to PyRigi.
Moreover, it should allow easy publication to PyPi.