### PR TITLE
Doc jupyterlab/jupytext

### DIFF
--- a/doc/development/howto.md
+++ b/doc/development/howto.md
@@ -202,3 +202,12 @@ is achieved using [Jupytext](https://jupytext.readthedocs.io/en/latest/index.htm
 Please, **do not** commit the `.ipynb` to the repository.
 You can contact a maintainer if you have a `.ipynb` tutorial
 you want to contribute but struggle to get its `.md` version.
+
+
+In case `poetry shell` is used as described above, Jupyterlab and Jupytext
+can be install using
+```
+pip install jupyterlab jupytext
+```
+After setting the virtual enviroment in Jupyterlab to the one created
+by `poetry shell`, `.md` notebooks can be opened directly.

--- a/doc/userguide/tutorial.md
+++ b/doc/userguide/tutorial.md
@@ -1,6 +1,10 @@
 (tutorials)=
 # Tutorials
 
+:::{todo}
+Generate (when the documentation uploaded to the web) `.ipynb` notebooks from `.md` files that could be downloaded from here.
+:::
+
 :::{toctree}
 :maxdepth: 2
 tutorials/graph_basics


### PR DESCRIPTION
When using poetry, one has to install jupyterlab manually to be able to use it in the environment created by poetry. Shall we add jupyterlab as a dev dependency, or keep it only mentioned in the documentation as in the commit?

Similarly with Jupytext that is necessary for opening `.md` tutorials as notebooks.