### PR TITLE
Type hinting improved

### DIFF
--- a/pyrigi/data_type.py
+++ b/pyrigi/data_type.py
@@ -5,7 +5,7 @@ Module for defining data type used for type hinting.
 """
 
 from sympy import Matrix, SympifyError, MatrixBase
-from typing import TypeVar, Tuple, Hashable
+from typing import Tuple, Hashable
 from collections.abc import Sequence
 
 
@@ -28,10 +28,6 @@ Point = Sequence[Coordinate]
 """
 A Point is a Sequence of Coordinates whose length is the dimension of its affine space.
 """
-
-GraphType = TypeVar("Graph")
-FrameworkType = TypeVar("Framework")
-MatroidType = TypeVar("Matroid")
 
 
 def point_to_vector(point: Point) -> Matrix:

--- a/pyrigi/exception.py
+++ b/pyrigi/exception.py
@@ -1,3 +1,3 @@
 class LoopError(ValueError):
-    def __init__(self, msg="The graph needs to be loop-free.", *args, **kwargs):
+    def __init__(self, msg: str ="The graph needs to be loop-free.", *args, **kwargs):
         super().__init__(msg, *args, **kwargs)

--- a/pyrigi/exception.py
+++ b/pyrigi/exception.py
@@ -1,3 +1,3 @@
 class LoopError(ValueError):
-    def __init__(self, msg: str ="The graph needs to be loop-free.", *args, **kwargs):
+    def __init__(self, msg: str = "The graph needs to be loop-free.", *args, **kwargs):
         super().__init__(msg, *args, **kwargs)

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import List, Any, Dict, Union
 
 from copy import deepcopy
+from itertools import combinations
 from random import randrange
 
 import networkx as nx
@@ -1107,24 +1108,21 @@ class Framework(object):
                 "Not all vertices have a realization in the given dictionary."
             )
 
-        vertices = self._graph.nodes
-        vertices = list(vertices)
-        for i, u in enumerate(vertices):
-            for j, v in enumerate(vertices[i + 1 :]):
-                edge_vec = (self._realization[u]) - self._realization[v]
-                dist_squared = (edge_vec.T * edge_vec)[0, 0]
+        for u, v in combinations(self._graph.nodes, 2):
+            edge_vec = (self._realization[u]) - self._realization[v]
+            dist_squared = (edge_vec.T * edge_vec)[0, 0]
 
-                other_edge_vec = point_to_vector(
-                    other_realization[u]
-                ) - point_to_vector(other_realization[v])
-                otherdist_squared = (other_edge_vec.T * other_edge_vec)[0, 0]
+            other_edge_vec = point_to_vector(other_realization[u]) - point_to_vector(
+                other_realization[v]
+            )
+            otherdist_squared = (other_edge_vec.T * other_edge_vec)[0, 0]
 
-                difference = sp.simplify(dist_squared - otherdist_squared)
-                if not difference.is_zero:
-                    if not numerical:
-                        return False
-                    elif numerical and sp.Abs(difference) > tolerance:
-                        return False
+            difference = sp.simplify(dist_squared - otherdist_squared)
+            if not difference.is_zero:
+                if not numerical:
+                    return False
+                elif numerical and sp.Abs(difference) > tolerance:
+                    return False
         return True
 
     @doc_category("Framework properties")

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -23,7 +23,7 @@ import sympy as sp
 from sympy import Matrix, flatten, binomial
 
 
-from pyrigi.data_type import Vertex, Edge, Point, FrameworkType, point_to_vector
+from pyrigi.data_type import Vertex, Edge, Point, point_to_vector
 from pyrigi.graph import Graph
 from pyrigi.exception import LoopError
 from pyrigi.graphDB import Complete as CompleteGraph
@@ -319,7 +319,7 @@ class Framework(object):
     @doc_category("Class methods")
     def Random(
         cls, graph: Graph, dim: int = 2, rand_range: Union(int, List[int]) = None
-    ) -> FrameworkType:
+    ) -> Framework:
         """
         Return a framework with random realization.
 
@@ -428,7 +428,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Empty(cls, dim: int = 2) -> FrameworkType:
+    def Empty(cls, dim: int = 2) -> Framework:
         """
         Generate an empty framework.
 
@@ -452,7 +452,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Complete(cls, points: List[Point]) -> FrameworkType:
+    def Complete(cls, points: List[Point]) -> Framework:
         """
         Generate a framework on the complete graph from a given list of points.
 

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -128,7 +128,7 @@ class Framework(object):
         """Return the representation"""
         return self.__str__()
 
-    def __getitem__(self, vertex) -> Point:
+    def __getitem__(self, vertex: Vertex) -> Matrix:
         """
         Return the coordinates corresponding to the image
         of a given vertex under the realization map.
@@ -295,7 +295,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def from_points(cls, points: List[Point]) -> None:
+    def from_points(cls, points: List[Point]) -> Framework:
         """
         Generate a framework from a list of points.
 
@@ -360,7 +360,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Circular(cls, graph: Graph):
+    def Circular(cls, graph: Graph) -> Framework:
         """
         Return the framework with a regular unit circle realization in the plane.
 
@@ -379,7 +379,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Collinear(cls, graph: Graph, d: int = 1):
+    def Collinear(cls, graph: Graph, d: int = 1) -> Framework:
         """
         Return the framework with a realization on the x-axis in the d-dimensional space.
 
@@ -398,7 +398,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Simplicial(cls, graph: Graph, d: int = None):
+    def Simplicial(cls, graph: Graph, d: int = None) -> Framework:
         """
         Return the framework with a realization on the d-simplex.
 
@@ -1084,7 +1084,10 @@ class Framework(object):
 
     @doc_category("Framework properties")
     def is_congruent_realization(
-        self, other_realization: dict, numerical: bool = False, tolerance: float = 10e-9
+        self,
+        other_realization: Dict[Vertex, Point],
+        numerical: bool = False,
+        tolerance: float = 10e-9,
     ) -> bool:
         """
         Return whether the given realization is congruent to self.
@@ -1153,7 +1156,10 @@ class Framework(object):
 
     @doc_category("Framework properties")
     def is_equivalent_realization(
-        self, other_realization: dict, numerical: bool = False, tolerance: float = 10e-9
+        self,
+        other_realization: Dict[Vertex, Point],
+        numerical: bool = False,
+        tolerance: float = 10e-9,
     ) -> bool:
         """
         Return whether the given realization is equivalent to self.
@@ -1218,7 +1224,7 @@ class Framework(object):
         )
 
     @doc_category("Framework manipulation")
-    def translate(self, vector: Point, inplace: bool = True) -> None:
+    def translate(self, vector: Point, inplace: bool = True) -> Union[None, Framework]:
         """
         Translate the framework.
 
@@ -1248,7 +1254,7 @@ class Framework(object):
         return new_framework
 
     @doc_category("Framework manipulation")
-    def rotate2D(self, angle: float, inplace: bool = True):
+    def rotate2D(self, angle: float, inplace: bool = True) -> Union[None, Framework]:
         """
         Rotate the planar framework counter clockwise.
 

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -9,7 +9,7 @@ import pyrigi.misc as misc
 import sympy as sp
 
 
-def Cycle(n: int, d: int = 2):
+def Cycle(n: int, d: int = 2) -> Framework:
     """Return d-dimensional framework of the n-cycle."""
     misc.check_integrality_and_range(n, "number of vertices n", 3)
     misc.check_integrality_and_range(d, "dimension d", 1)
@@ -25,17 +25,17 @@ def Cycle(n: int, d: int = 2):
     )
 
 
-def Square():
+def Square() -> Framework:
     """Framework of the 4-cycle with square realization in the plane"""
     return Framework(graphs.Cycle(4), {0: [0, 0], 1: [1, 0], 2: [1, 1], 3: [0, 1]})
 
 
-def Diamond():
+def Diamond() -> Framework:
     """Framework of the diamond with square realization in the plane"""
     return Framework(graphs.Diamond(), {0: [0, 0], 1: [1, 0], 2: [1, 1], 3: [0, 1]})
 
 
-def Complete(n: int, d: int = 2):
+def Complete(n: int, d: int = 2) -> Framework:
     """Return d-dimensional framework of the complete graph on n vertices."""
     misc.check_integrality_and_range(n, "number of vertices n", 1)
     misc.check_integrality_and_range(d, "dimension d", 1)
@@ -51,7 +51,7 @@ def Complete(n: int, d: int = 2):
     )
 
 
-def Path(n: int, d: int = 2):
+def Path(n: int, d: int = 2) -> Framework:
     """Return d-dimensional framework of the path graph on n vertices."""
     misc.check_integrality_and_range(n, "number of vertices n", 2)
     misc.check_integrality_and_range(d, "dimension d", 1)
@@ -67,7 +67,7 @@ def Path(n: int, d: int = 2):
     )
 
 
-def ThreePrism(realization: str = None):
+def ThreePrism(realization: str = None) -> Framework:
     """
     Return 3-prism framework.
 
@@ -95,14 +95,14 @@ def ThreePrism(realization: str = None):
     )
 
 
-def ThreePrismPlusEdge():
+def ThreePrismPlusEdge() -> Framework:
     """Return a framework of the 3-prism graph with one extra edge."""
     G = ThreePrism()
     G.add_edge([0, 5])
     return G
 
 
-def CompleteBipartite(m: int, n: int, realization: str = None):
+def CompleteBipartite(m: int, n: int, realization: str = None) -> Framework:
     """
     Return a complete bipartite framework on m+n vertices in the plane.
 
@@ -144,7 +144,7 @@ def CompleteBipartite(m: int, n: int, realization: str = None):
     )
 
 
-def K33plusEdge():
+def K33plusEdge() -> Framework:
     """Return a framework of the complete bipartite graph on 3+3 vertices plus an edge."""
     G = CompleteBipartite(3, 3, "dixonI")
     G.add_edge([0, 1])

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -974,6 +974,7 @@ class Graph(nx.Graph):
 
     @doc_category("Other")
     def random_framework(self, dim: int = 2, rand_range: Union(int, List[int]) = None):
+        # the return type is intentionally omitted to avoid circular import
         """
         Return framework with random realization.
 

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -12,7 +12,7 @@ import networkx as nx
 from sympy import Matrix
 import math
 
-from pyrigi.data_type import Vertex, Edge, GraphType, FrameworkType
+from pyrigi.data_type import Vertex, Edge
 from pyrigi.misc import doc_category, generate_category_tables
 from pyrigi.exception import LoopError
 
@@ -101,7 +101,7 @@ class Graph(nx.Graph):
     @doc_category("Class methods")
     def from_vertices_and_edges(
         cls, vertices: List[Vertex], edges: List[Edge]
-    ) -> GraphType:
+    ) -> Graph:
         """
         Create a graph from a list of vertices and edges.
 
@@ -129,7 +129,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def from_vertices(cls, vertices: List[Vertex]) -> GraphType:
+    def from_vertices(cls, vertices: List[Vertex]) -> Graph:
         """
         Create a graph with no edges from a list of vertices.
 
@@ -144,7 +144,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def CompleteOnVertices(cls, vertices: List[Vertex]) -> GraphType:
+    def CompleteOnVertices(cls, vertices: List[Vertex]) -> Graph:
         """
         Generate a complete graph on ``vertices``.
 
@@ -675,7 +675,7 @@ class Graph(nx.Graph):
         raise NotImplementedError()
 
     @doc_category("Generic rigidity")
-    def max_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
+    def max_rigid_subgraphs(self, dim: int = 2) -> List[Graph]:
         """
         List vertex-maximal rigid subgraphs of the graph.
 
@@ -738,7 +738,7 @@ class Graph(nx.Graph):
         return clean_list
 
     @doc_category("Generic rigidity")
-    def min_rigid_subgraphs(self, dim: int = 2) -> List[GraphType]:
+    def min_rigid_subgraphs(self, dim: int = 2) -> List[Graph]:
         """
         List vertex-minimal non-trivial rigid subgraphs of the graph.
 
@@ -805,7 +805,7 @@ class Graph(nx.Graph):
         return clean_list
 
     @doc_category("General graph theoretical properties")
-    def is_isomorphic(self, graph: GraphType) -> bool:
+    def is_isomorphic(self, graph: Graph) -> bool:
         """
         Check whether two graphs are isomorphic.
 
@@ -876,7 +876,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def from_int(cls, N: int) -> GraphType:
+    def from_int(cls, N: int) -> Graph:
         """
         Return a graph given its integer representation.
 
@@ -902,7 +902,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def from_adjacency_matrix(cls, M: Matrix) -> GraphType:
+    def from_adjacency_matrix(cls, M: Matrix) -> Graph:
         """
         Create a graph from a given adjacency matrix.
 
@@ -973,9 +973,7 @@ class Graph(nx.Graph):
         return Matrix(row_list)
 
     @doc_category("Other")
-    def random_framework(
-        self, dim: int = 2, rand_range: Union(int, List[int]) = None
-    ) -> FrameworkType:
+    def random_framework(self, dim: int = 2, rand_range: Union(int, List[int]) = None):
         """
         Return framework with random realization.
 

--- a/pyrigi/graphDB.py
+++ b/pyrigi/graphDB.py
@@ -6,46 +6,46 @@ import networkx as nx
 from pyrigi.graph import Graph
 
 
-def Cycle(n: int):
+def Cycle(n: int) -> Graph:
     """Return the cycle graph on n vertices."""
     return Graph(nx.cycle_graph(n))
 
 
-def Complete(n: int):
+def Complete(n: int) -> Graph:
     """Return the complete graph on n vertices."""
     return Graph(nx.complete_graph(n))
 
 
-def Path(n: int):
+def Path(n: int) -> Graph:
     """Return the path graph with n vertices."""
     return Graph(nx.path_graph(n))
 
 
-def CompleteBipartite(m: int, n: int):
+def CompleteBipartite(m: int, n: int) -> Graph:
     """Return the complete bipartite graph on m+n vertices."""
     return Graph(nx.complete_multipartite_graph(m, n))
 
 
-def K33plusEdge():
+def K33plusEdge() -> Graph:
     """Return the complete bipartite graph on 3+3 vertices with an extra edge."""
     G = CompleteBipartite(3, 3)
     G.add_edge(0, 1)
     return G
 
 
-def Diamond():
+def Diamond() -> Graph:
     """Return the complete graph on 4 vertices minus an edge."""
     return Graph([(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
 
 
-def ThreePrism():
+def ThreePrism() -> Graph:
     """Return the 3-prism graph."""
     return Graph(
         [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5), (0, 3), (1, 4), (2, 5)]
     )
 
 
-def ThreePrismPlusEdge():
+def ThreePrismPlusEdge() -> Graph:
     """Return the 3-prism graph with one extra edge."""
     return Graph(
         [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5), (0, 3), (1, 4), (2, 5), (0, 5)]

--- a/pyrigi/matroid.py
+++ b/pyrigi/matroid.py
@@ -2,17 +2,17 @@
 This is the module for matroid functionality.
 """
 
+from __future__ import annotations
 from copy import deepcopy
 
 from networkx import minimum_spanning_tree
 
 from pyrigi.graph import Graph
-from pyrigi.data_type import MatroidType
 
 
 class Matroid(object):
 
-    def __init__(self, _ground_set) -> MatroidType:
+    def __init__(self, _ground_set) -> Matroid:
         """Initialize the matroid object."""
         raise NotImplementedError()
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -13,7 +13,7 @@ def doc_category(category):
     return decorator_doc_category
 
 
-def generate_category_tables(cls, tabs, cat_order=[], include_all=False):
+def generate_category_tables(cls, tabs, cat_order=[], include_all=False) -> str:
     categories = {}
     for func in dir(cls):
         if callable(getattr(cls, func)) and func[:2] != "__":
@@ -48,7 +48,7 @@ def generate_category_tables(cls, tabs, cat_order=[], include_all=False):
 
 def check_integrality_and_range(
     n: int, name: str = "number n", min_n: int = 0, max_n: int = math.inf
-):
+) -> None:
     if not isinstance(n, int):
         raise TypeError("The " + name + f" has to be an integer, not {type(n)}.")
     if n < min_n or n > max_n:


### PR DESCRIPTION
Since we already use 
```python
from __future__ import annotations
```
to postpone the evaluation of datatypes for generating the documentation, I have also used the fact that it allows to use class names directly for type hinting, namely Graph/Framework instead of GraphType/FrameworkType.

I have also added/fixed some missing type hinting.
(and squeezed here a small refactoring of is_congruent_realization proposed by @MatteoGallet ).