### PR TITLE
Missing misc.md file added

### DIFF
--- a/doc/userguide/api/misc.md
+++ b/doc/userguide/api/misc.md
@@ -1,0 +1,8 @@
+# Miscellaneous
+
+The following functions are used in the code.
+
+```{eval-rst}
+.. autofunction:: pyrigi.misc.is_zero_vector
+
+```


### PR DESCRIPTION
The link to `misc.is_zero_vector` should work now as there is a page generated from `misc.md`.