### PR TITLE
Equality of graphs

### DIFF
--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -104,7 +104,7 @@ class Graph(nx.Graph):
         Note
         ----
         :func:`~networkx.utils.misc.graphs_equal(self, other)`
-        behaves strange, hence it is not used.
+        behaves strangely, hence it is not used.
         """
         if (
             self.number_of_edges() != other.number_of_edges()

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -97,6 +97,28 @@ class Graph(nx.Graph):
         """
         return self.__str__()
 
+    def __eq__(self, other: Graph):
+        """
+        Return whether the other graph has the same vertices and edges.
+
+        Note
+        ----
+        :func:`~networkx.utils.misc.graphs_equal(self, other)`
+        behaves strange, hence it is not used.
+        """
+        if (
+            self.number_of_edges() != other.number_of_edges()
+            or self.number_of_nodes() != other.number_of_nodes()
+        ):
+            return False
+        for v in self.nodes:
+            if v not in other.nodes:
+                return False
+        for e in self.edges:
+            if not other.has_edge(*e):
+                return False
+        return True
+
     @classmethod
     @doc_category("Class methods")
     def from_vertices_and_edges(

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -101,6 +101,14 @@ class Graph(nx.Graph):
         """
         Return whether the other graph has the same vertices and edges.
 
+        Examples
+        --------
+        >>> from pyrigi import Graph
+        >>> G = Graph([[1,2]])
+        >>> H = Graph([[2,1]])
+        >>> G == H
+        True
+
         Note
         ----
         :func:`~networkx.utils.misc.graphs_equal(self, other)`


### PR DESCRIPTION
Do we want to be able to check whether two graphs are equal like `G == H`? This can be done in Python by implementing method `__eq__`, see the first commit of this branch. I think it would be useful for instance in tests.
If yes, when do we consider two graphs to be equal? Same vertex and edge sets? Could it happen in future that we have for instance some edge labelings?