### PR TITLE
Added missing edge width update for layer 1

### DIFF
--- a/pyrigi/graph_drawer.py
+++ b/pyrigi/graph_drawer.py
@@ -543,8 +543,8 @@ class GraphDrawer(object):
         incident with hvertex and repositioning hvertex while keeping other vertices
         and edges fixed on multicanvas in layer 2.
         """
+        self._mcanvas[1].line_width = self._ewidth
         self._mcanvas[2].line_width = self._ewidth
-        self._mcanvas[3].line_width = self._ewidth
         for u, v in self._graph.edges:
             # n below is the index of the layer to be used.
             # if the edge is incident with hvertex,


### PR DESCRIPTION
Edges incident with the selected vertex were drawn with the previous value of edge width when just pressed on a vertex without dragging if the edge width value was changed. Fixed this by updating the edge width value of layer 1 instead of layer 3(there are no edges in layer 3).