### PR TITLE
Links to .ipynb notebooks of tutorials

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,6 +25,12 @@ jobs:
         pip install poetry
         poetry config virtualenvs.create false 
         poetry install --without dev
+    - name: Convert notebooks from md to ipynb
+      run: |
+        cd doc/userguide/tutorials/
+        jupytext --to notebook  *.md
+        mkdir ../../_static/tutorials
+        cp *.ipynb ../../_static/tutorials
     - id: deployment
       uses: sphinx-notes/pages@v3
       with:

--- a/doc/userguide/tutorials/framework_database.md
+++ b/doc/userguide/tutorials/framework_database.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -13,6 +13,10 @@ kernelspec:
 ---
 
 # Database of frameworks
+
++++
+
+This notebook can be downloaded [here](https://pyrigi.github.io/PyRigi/_static/tutorials/framework_database.ipynb).
 
 +++
 

--- a/doc/userguide/tutorials/graph_basics.md
+++ b/doc/userguide/tutorials/graph_basics.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.2
+    jupytext_version: 1.16.4
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -17,6 +17,7 @@ kernelspec:
 +++
 
 This notebook illustrates the basic functionality of {class}`pyrigi.graph.Graph`.
+It can be downloaded [here](https://pyrigi.github.io/PyRigi/_static/tutorials/graph_basics.ipynb).
 
 ```{code-cell} ipython3
 # The import will work if:

--- a/doc/userguide/tutorials/plotting.md
+++ b/doc/userguide/tutorials/plotting.md
@@ -13,6 +13,10 @@ kernelspec:
 
 # Plotting
 
++++
+
+This notebook can be downloaded [here](https://pyrigi.github.io/PyRigi/_static/tutorials/plotting.ipynb).
+
 ```{code-cell} ipython3
 # The import will work if:
 #     - the tutorial is in the root folder of the package, or

--- a/poetry.lock
+++ b/poetry.lock
@@ -1084,6 +1084,35 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphin
 test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "jupytext"
+version = "1.16.4"
+description = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupytext-1.16.4-py3-none-any.whl", hash = "sha256:76989d2690e65667ea6fb411d8056abe7cd0437c07bd774660b83d62acf9490a"},
+    {file = "jupytext-1.16.4.tar.gz", hash = "sha256:28e33f46f2ce7a41fb9d677a4a2c95327285579b64ca104437c4b9eb1e4174e9"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=1.0"
+mdit-py-plugins = "*"
+nbformat = "*"
+packaging = "*"
+pyyaml = "*"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["autopep8", "black", "flake8", "gitpython", "ipykernel", "isort", "jupyter-fs (>=1.0)", "jupyter-server (!=2.11)", "nbconvert", "pre-commit", "pytest", "pytest-cov (>=2.6.1)", "pytest-randomly", "pytest-xdist", "sphinx-gallery (<0.8)"]
+docs = ["myst-parser", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+test = ["pytest", "pytest-randomly", "pytest-xdist"]
+test-cov = ["ipykernel", "jupyter-server (!=2.11)", "nbconvert", "pytest", "pytest-cov (>=2.6.1)", "pytest-randomly", "pytest-xdist"]
+test-external = ["autopep8", "black", "flake8", "gitpython", "ipykernel", "isort", "jupyter-fs (>=1.0)", "jupyter-server (!=2.11)", "nbconvert", "pre-commit", "pytest", "pytest-randomly", "pytest-xdist", "sphinx-gallery (<0.8)"]
+test-functional = ["pytest", "pytest-randomly", "pytest-xdist"]
+test-integration = ["ipykernel", "jupyter-server (!=2.11)", "nbconvert", "pytest", "pytest-randomly", "pytest-xdist"]
+test-ui = ["calysto-bash"]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.5"
 description = "A fast implementation of the Cassowary constraint solver"
@@ -3210,4 +3239,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "93846a7a8071ca09e9f7fac906a4dc18c90225b62047e4ea94cdffa3c7127e43"
+content-hash = "47d962bd06f591b0fb4a8bd7f5355c668c21133a42a7e2ee8b943f063e6cac2b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ sphinxcontrib-bibtex = "^2.6.2"
 sphinxcontrib-napoleon = "^0.7"
 sphinx-autobuild = "^2024.4.16"
 setuptools = "^70.0.0"
+jupytext = "^1.16.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
To goal is to generate `.ipynb` versions of the tutorial notebooks so a user can download them via the online documentation.