### PR TITLE
Detailed Installation Instructions created in the documentation

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -12,6 +12,7 @@
 :maxdepth: 2
 :caption: User guide
 userguide/getting_started
+userguide/installation_guide
 userguide/tutorial
 userguide/api
 :::

--- a/doc/userguide/getting_started.md
+++ b/doc/userguide/getting_started.md
@@ -26,7 +26,8 @@ pip install pyrigi
 
 Alternatively, one can clone/download the package
 from [this GitHub repository](https://github.com/pyRigi/PyRigi).
-Installation for development is done via [Poetry](#dev-dependencies).
+Installation for development is done via [Poetry](#dev-dependencies). 
+More detailed installation instructions depending on your operating system can be found [here](installation-guide).
 
 +++
 

--- a/doc/userguide/installation_guide.md
+++ b/doc/userguide/installation_guide.md
@@ -1,0 +1,36 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+(installation-guide)=
+
+# Installation Guide
+
+Depending on your operating system, the installation of the `PyRigi` package differs. 
+
+## Linux and Mac
+
+1. Make sure that your Python version exceeds 3.10. 
+2. The command `pip install pyrigi` installs PyRigi on your machine.
+3. If not already installed, you can install Jupyter notebooks via the command `pip install jupyterlabs`. It can be run by typing `jupyter lab`. Doing so provides a convenient user interface to use the functionality of PyRigi. 
+
+
+## Windows
+
+In this tutorial, we assume a clean Windows without Python installed. In case that you have `pip` already installed, you can skip the first 3 steps. This can be checked using the command `python -m pip -v`. Otherwise, we recommend uninstalling any existing Python installation in the "Add or Delete Programs" settings menu first. 
+
+1. Download Python with a Version >= 3.10 from the website https://www.python.org/downloads/.
+2. When installing, make sure that you tick the box "add to path variables" on the first installation page. You may need to tick the box that you run the installation as an Administrator as well.
+3. As soon as your installation is successful, go to the Windows command line tool by following Windows key > type "cmd" > Enter. You can check if your Python Installation has been added to the environment variables by typing `python -v`. This command opens Python. It can be closed again with the command `exit()`.
+4. Install PyRigi by typing `python -m pip install pyrigi`.
+5. If you want to use PyRigi in a Jupyter notebook, install Jupyter Labs via the command `python -m pip install jupyterlab`. You can open a Jupyter notebook by typing `jupyter lab`. This provides a convenient user interface for PyRigi.

--- a/doc/userguide/installation_guide.md
+++ b/doc/userguide/installation_guide.md
@@ -20,9 +20,9 @@ Depending on your operating system, the installation of the `PyRigi` package dif
 
 ## Linux and Mac
 
-1. Make sure that your Python version exceeds 3.10. 
+1. Make sure that your Python version is at least 3.10. 
 2. The command `pip install pyrigi` installs PyRigi on your machine.
-3. If not already installed, you can install Jupyter notebooks via the command `pip install jupyterlabs`. It can be run by typing `jupyter lab`. Doing so provides a convenient user interface to use the functionality of PyRigi. 
+3. If not already installed, you can install Jupyter notebooks via the command `pip install jupyterlab`. It can be run by typing `jupyter lab`. Doing so provides a convenient user interface to use the functionality of PyRigi. 
 
 
 ## Windows


### PR DESCRIPTION
Added detailed installation instructions based on today's installation session to the PyRigi documentation. The Windows instructions seemed to work on all (non-restricted) machines. I guess for machines restricted by the university, we do not need to provide instructions, as that probably works best on a case-by-case basis. 