### PR TITLE
Prestress stability and second-order rigidity

### DIFF
--- a/doc/math/rigidity.md
+++ b/doc/math/rigidity.md
@@ -79,4 +79,5 @@ rigidity/infinitesimal
 rigidity/generic
 rigidity/global
 rigidity/redundant
+rigidity/second-order
 :::

--- a/doc/math/rigidity/second-order.md
+++ b/doc/math/rigidity/second-order.md
@@ -3,7 +3,11 @@
 :::{prf:definition} Prestress Stability
 :label: def-prestress-stability
 
-Let $G=(V,E)$ be a graph and let $F=(G, p:V\rightarrow \mathbb{R}^d)$ be a $d$-dimensional {prf:ref}`framework <def-framework>` on $G$. $F$ is called _prestress stable_ if there exists an {prf:ref}`equilibrium stress <def-equilibrium-stress>` $\omega$ such that for every {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ it holds that
+Let $G=(V,E)$ be a graph and let $F=(G,\, p:V\rightarrow \mathbb{R}^d)$ be a 
+$d$-dimensional {prf:ref}`framework <def-framework>` on $G$. $F$ is called 
+_prestress stable_ if there exists an {prf:ref}`equilibrium stress <def-equilibrium-stress>` 
+$\omega$ such that for every {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ 
+it holds that
 \begin{equation*}
 \sum_{ij\in E} \omega_{ij}\cdot ||q_i-q_j||^2\,>\,0.
 \end{equation*} 
@@ -15,18 +19,28 @@ Let $G=(V,E)$ be a graph and let $F=(G, p:V\rightarrow \mathbb{R}^d)$ be a $d$-d
 :::{prf:definition} Second-order rigidity
 :label: def-second-order-rigid
 
-Let $G=(V,E)$ be a graph and let $F=(G, p:V\rightarrow \mathbb{R}^d)$ be a $d$-dimensional {prf:ref}`framework <def-framework>` on $G$. Let $q$ denote an {prf:ref}`infinitesimal flex <def-inf-flex>` of $F$. A _second-order flex_ $p''$ of $F$ corresponding to $q$ is defined by the equation
+Let $G=(V,E)$ be a graph and let $F=(G,\, p:V\rightarrow \mathbb{R}^d)$ be a $d$-dimensional 
+{prf:ref}`framework <def-framework>` on $G$. Let $q$ denote an 
+{prf:ref}`infinitesimal flex <def-inf-flex>` of $F$. A _second-order flex_ $p''$ 
+of $F$ corresponding to $q$ is defined by the equation
 \begin{equation*}
 R(G, p)\cdot p'' + R(G, q)\cdot q = 0
 \end{equation*} 
-for the {prf:ref}`rigidity matrix <def-rigidity-matrix>` $R(G, p)$ of $F$. If there is no second-order flex $p''$ for a {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$, we call $F$ _second-order rigid_.
+for the {prf:ref}`rigidity matrix <def-rigidity-matrix>` $R(G, p)$ of $F$. 
+If there is no second-order flex $p''$ for a 
+{prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$, we 
+call $F$ _second-order rigid_.
+
+{{pyrigi_crossref}} {meth}`~.Framework.is_second_order_rigid`
 :::
 
 
-:::{prf:theorem}
+:::{prf:theorem} Equivalent criterion for second-order rigidity 
 :label: thm-second-order-rigid
 
-A framework $F=(G,p)$ is second-order rigid in $\RR^d$ if and only if for every {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ of $F$ there is an {prf:ref}`equilibrium stress <def-equilibrium-stress>` $\omega$ such that 
+A framework $F=(G,p)$ is second-order rigid in $\RR^d$ if and only if for every 
+{prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ of $F$ there
+ is an {prf:ref}`equilibrium stress <def-equilibrium-stress>` $\omega$ such that 
 \begin{equation*}
 \sum_{ij\in E} \omega_{ij}\cdot ||q_i-q_j||^2\,>\,0.
 \end{equation*} 
@@ -35,10 +49,27 @@ A framework $F=(G,p)$ is second-order rigid in $\RR^d$ if and only if for every 
 :::
 
 
-:::{prf:theorem}
+:::{prf:theorem} Implications of the different types of rigidity
 :label: thm-second-order-implies-infinitesimal
 
-{prf:ref}`Infinitesimal rigidity<def-inf-rigid-framework>` in $\RR^d$ implies {prf:ref}`prestress stability<def-prestress-stability>` in $\RR^d$ which implies {prf:ref}`second-order rigidity<def-second-order-rigid>` in $\RR^d$ which implies {prf:ref}`continuous rigidity<def-cont-rigid-framework>` in $\RR^d$. None of these implications are reversible
+{prf:ref}`Infinitesimal rigidity<def-inf-rigid-framework>` in $\RR^d$ implies 
+{prf:ref}`prestress stability<def-prestress-stability>` in $\RR^d$ which implies 
+{prf:ref}`second-order rigidity<def-second-order-rigid>` in $\RR^d$ which implies 
+{prf:ref}`continuous rigidity<def-cont-rigid-framework>` in $\RR^d$. 
+None of these implications are reversible.
 
 {{references}} {cite:p}`Connelly2017{Thm 2.6}`
+:::
+
+
+:::{prf:theorem} Second-order rigidity and prestress stability in the case of one-dimensional stresses or flexes
+:label: thm-second-order-implies-prestress-stability
+
+Let $F=(G,p)$ denote a $d$-dimensional {prf:ref}`second-order rigid <def-second-order-rigid>` 
+{prf:ref}`framework <def-framework>` with a one-dimensional space of 
+{prf:ref}`nontrivial infinitesimal flexes <def-trivial-inf-flex>` or a one-dimensional space 
+of {prf:ref}`equilibrium stresses <def-equilibrium-stress>`. Then $F$ is 
+{prf:ref}`prestress stable <def-prestress-stability>`.
+
+{{references}} {cite:p}`Connelly1996{Prop 5.3.1}`
 :::

--- a/doc/math/rigidity/second-order.md
+++ b/doc/math/rigidity/second-order.md
@@ -1,0 +1,44 @@
+# Second-Order Theory
+
+:::{prf:definition} Prestress Stability
+:label: def-prestress-stability
+
+Let $G=(V,E)$ be a graph and let $F=(G, p:V\rightarrow \mathbb{R}^d)$ be a $d$-dimensional {prf:ref}`framework <def-framework>` on $G$. $F$ is called _prestress stable_ if there exists an {prf:ref}`equilibrium stress <def-equilibrium-stress>` $\omega$ such that for every {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ it holds that
+\begin{equation*}
+\sum_{ij\in E} \omega_{ij}\cdot ||q_i-q_j||^2\,>\,0.
+\end{equation*} 
+
+{{pyrigi_crossref}} {meth}`~.Framework.is_prestress_stable`
+:::
+
+
+:::{prf:definition} Second-order rigidity
+:label: def-second-order-rigid
+
+Let $G=(V,E)$ be a graph and let $F=(G, p:V\rightarrow \mathbb{R}^d)$ be a $d$-dimensional {prf:ref}`framework <def-framework>` on $G$. Let $q$ denote an {prf:ref}`infinitesimal flex <def-inf-flex>` of $F$. A _second-order flex_ $p''$ of $F$ corresponding to $q$ is defined by the equation
+\begin{equation*}
+R(G, p)\cdot p'' + R(G, q)\cdot q = 0
+\end{equation*} 
+for the {prf:ref}`rigidity matrix <def-rigidity-matrix>` $R(G, p)$ of $F$. If there is no second-order flex $p''$ for a {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$, we call $F$ _second-order rigid_.
+:::
+
+
+:::{prf:theorem}
+:label: thm-second-order-rigid
+
+A framework $F=(G,p)$ is second-order rigid in $\RR^d$ if and only if for every {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` $q$ of $F$ there is an {prf:ref}`equilibrium stress <def-equilibrium-stress>` $\omega$ such that 
+\begin{equation*}
+\sum_{ij\in E} \omega_{ij}\cdot ||q_i-q_j||^2\,>\,0.
+\end{equation*} 
+
+{{references}} {cite:p}`Connelly2017{Thm 2.5}`
+:::
+
+
+:::{prf:theorem}
+:label: thm-second-order-implies-infinitesimal
+
+{prf:ref}`Infinitesimal rigidity<def-inf-rigid-framework>` in $\RR^d$ implies {prf:ref}`prestress stability<def-prestress-stability>` in $\RR^d$ which implies {prf:ref}`second-order rigidity<def-second-order-rigid>` in $\RR^d$ which implies {prf:ref}`continuous rigidity<def-cont-rigid-framework>` in $\RR^d$. None of these implications are reversible
+
+{{references}} {cite:p}`Connelly2017{Thm 2.6}`
+:::

--- a/doc/refs.bib
+++ b/doc/refs.bib
@@ -179,3 +179,15 @@
   year = {2017},
   doi = {10.1137/15M1054833}
 }
+
+@article{
+  Connelly1996,
+  author = {Connelly, Robert and Whiteley, Walter},
+  title = {Second-order rigidity and prestress stability for tensegrity frameworks},
+  journal = {SIAM Journal on Discrete Mathematics},
+  volume = {9},
+  number = {3},
+  pages = {453-491},
+  year = {1996},
+  doi = {10.1137/S0895480192229236}
+}

--- a/doc/refs.bib
+++ b/doc/refs.bib
@@ -167,3 +167,15 @@
   primaryClass = {math.CO},
   year = {2024}
 }
+
+@article{
+  Connelly2017,
+  author = {Connelly, Robert and Gortler, Steven J.},
+  title = {Prestress Stability of Triangulated Convex Polytopes and Universal Second-Order Rigidity},
+  journal = {SIAM Journal on Discrete Mathematics},
+  volume = {31},
+  number = {4},
+  pages = {2735-2753},
+  year = {2017},
+  doi = {10.1137/15M1054833}
+}

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -1469,9 +1469,15 @@ class Framework(object):
         """
         stresses = self.stresses()
         inf_flexes = self.inf_flexes()
+        if self.is_inf_rigid():
+            return True
+        if len(inf_flexes)==0 or len(stresses)==0:
+            return False
         if len(stresses)>1 and len(inf_flexes)>1:
             raise ValueError("In this implementation, there must either only be 1 infinitesimal motion or 1 stress!")
-        
+        if len(stresses)==1:
+            stress = {self._graph.edge_list()[i]:(stresses[0])[i*self._dim:(i+1)*self._dim] for i in range(self._graph.number_of_edges())}
+            self.dim()
 
     @doc_category("Infinitesimal rigidity")
     def is_redundantly_rigid(self) -> bool:

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -1452,9 +1452,26 @@ class Framework(object):
         """
         return not self.is_independent()
 
-    @doc_category("Waiting for implementation")
+    @doc_category("Other")
     def is_prestress_stable(self) -> bool:
-        raise NotImplementedError()
+        """
+        Check whether the framework is prestress stable.
+
+        Definitions
+        ----------
+        :prf:ref:`Prestress-stability <def-prestress-stable>`.
+
+        Notes
+        -----
+        Checking prestress stability is generally computationally hard. In the case where
+        there is a single stress or infinitesimal motion, the problem becomes easier, so we
+        restrict ourselves to that case.
+        """
+        stresses = self.stresses()
+        inf_flexes = self.inf_flexes()
+        if len(stresses)>1 and len(inf_flexes)>1:
+            raise ValueError("In this implementation, there must either only be 1 infinitesimal motion or 1 stress!")
+        
 
     @doc_category("Infinitesimal rigidity")
     def is_redundantly_rigid(self) -> bool:

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -167,6 +167,34 @@ def test_is_independent(framework):
 
 
 @pytest.mark.parametrize(
+    "framework, bool_res",
+    [
+        [fws.Complete(4, d=2), True],
+        [fws.Frustum(3), True],
+        [fws.Frustum(4), True],
+        [fws.Square(), False],
+        [fws.ThreePrism(realization="flexible"), False],
+    ],
+)
+def test_is_prestress_stable(framework, bool_res):
+    assert framework.is_prestress_stable() == bool_res
+
+
+@pytest.mark.parametrize(
+    "framework, bool_res",
+    [
+        [fws.Complete(4, d=2), True],
+        [fws.Frustum(3), True],
+        [fws.Frustum(4), True],
+        [fws.Square(), False],
+        [fws.ThreePrism(realization="flexible"), False],
+    ],
+)
+def test_is_second_order_rigid(framework, bool_res):
+    assert framework.is_second_order_rigid() == bool_res
+
+
+@pytest.mark.parametrize(
     "framework",
     [
         fws.K33plusEdge(),


### PR DESCRIPTION
Implemented the methods `is_prestress_stable` and `is_second_order_rigid` together with their mathematical background documentation and tests. Since both properties are hard to check for general frameworks, we restrict ourselves to the case when either the space of infinitesimal flexes is one-dimensional or the space of equilibrium stresses is one-dimensional. In that case, prestress stability and second-order rigidity are equivalent.