### PR TITLE
Added missing methods to the docs

### DIFF
--- a/doc/math/graph-theory/known-families.md
+++ b/doc/math/graph-theory/known-families.md
@@ -15,8 +15,8 @@ typically realized as two regular $n$-sided polygons on circles
 centered in the origin of the Euclidean plane with radii $r_1<r_2$. 
 It has a {prf:ref}`nontrivial infinitesimal flex <def-trivial-inf-flex>` 
 given by the rotation of the outer polygon while the inner polygon remains 
-fixed. This motion does not extend to a 
-{prf:ref}`continuous flex <def-flex>`.
+fixed. This infinitesimal flex does not extend to a 
+{prf:ref}`continuous flex <def-motion>`.
 
 {{pyrigi_crossref}} {func}`.graphDB.Frustum`
 {func}`.frameworkDB.Frustum`

--- a/doc/math/rigidity.md
+++ b/doc/math/rigidity.md
@@ -48,18 +48,23 @@ Two $d$-dimensional {prf:ref}`frameworks <def-framework>` $(G, p)$ and $(G, p')$
  \left\| p_u - p_v \right\| = \left\| p'_u - p'_v \right\|
  \quad \text{ for all } u, v \in V \,.
 \end{equation*}
+
+{{pyrigi_crossref}} {meth}`~.Framework.is_equivalent`
+{meth}`~.Framework.is_equivalent_realization`
+{meth}`~.Framework.is_congruent`
+{meth}`~.Framework.is_congruent_realization`
 :::
 
 :::{prf:definition} Continuous flexes
-:label: def-flex
+:label: def-motion
 
 Let $(G, p)$ be a $d$-dimensional {prf:ref}`framework <def-framework>` with $G = (V, E)$.
-A _continuous flex_ is a continuous map $\alpha \colon [0, 1] \rightarrow (\RR^{d})^V$ such that
+A _motion (continuous flex)_ is a continuous map $\alpha \colon [0, 1] \rightarrow (\RR^{d})^V$ such that
 
 * $\alpha(0) = p$;
 * $(G, p)$ and $(G, \alpha(t))$ are equivalent for every $t \in [0,1]$.
 
-A continuous flex is called _trivial_ if $(G, p)$ and $(G, \alpha(t))$ are congruent for every $t \in [0,1]$.
+A motion is called _trivial_ if $(G, p)$ and $(G, \alpha(t))$ are congruent for every $t \in [0,1]$.
 :::
 
 

--- a/doc/math/rigidity/global.md
+++ b/doc/math/rigidity/global.md
@@ -9,6 +9,8 @@ all $d$-dimensional frameworks $(G,p')$ {prf:ref}`equivalent <def-equivalent-fra
 are {prf:ref}`congruent <def-equivalent-framework>` to $(G,p)$.
 
 {{references}} {cite:p}`Jackson2005`
+
+{meth}`~.Graph.is_globally_rigid`
 :::
 
 

--- a/doc/math/rigidity/infinitesimal.md
+++ b/doc/math/rigidity/infinitesimal.md
@@ -63,6 +63,7 @@ If $|V| \geq d+1$, the framework $(G, p)$ is infinitesimally rigid if and only i
 If $|V| \leq d+1$, the framework $(G, p)$ is infinitesimally rigid if and only if $G$ is complete, $p$ is injective and the set $\{ p_v \, : \, v \in V\}$ is affinely independent.
 
 {{pyrigi_crossref}} {meth}`~.Framework.is_inf_rigid`
+{meth}`~.Framework.is_inf_flexible`
 :::
 
 
@@ -86,13 +87,16 @@ A $d$-dimensional {prf:ref}`framework <def-framework>` $(G, p)$ with $G = (V, E)
 is called _independent_ if $\mathrm{rk} \, R(G, p) = |E|$,
 otherwise it is dependent.
 
-{{pyrigi_crossref}} {meth}`~.Framework.is_independent` {meth}`~.Framework.is_dependent`
+{{pyrigi_crossref}} {meth}`~.Framework.is_independent` 
+{meth}`~.Framework.is_dependent`
 :::
 
 :::{prf:definition} Isostatic frameworks
 :label: def-isostatic-frameworks
 
 A {prf:ref}`framework <def-framework>` $(G, p)$ is called _isostatic_ if it is {prf:ref}`infinitesimally rigid <def-inf-rigid-framework>` and {prf:ref}`independent <def-independent-framework>`.
+
+{{pyrigi_crossref}} {meth}`~.Framework.is_isostatic`
 :::
 
 

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -1650,6 +1650,14 @@ class Framework(object):
         """
         return not self.is_independent()
 
+    @doc_category("Infinitesimal rigidity")
+    def is_isostatic(self) -> bool:
+        """
+        Check whether the framework is :prf:ref:`independent <def-independent-framework>`
+        and :prf:ref:`infinitesimally rigid <def-inf-rigid-framework>`.
+        """
+        return self.is_independent() and self.is_inf_rigid()
+
     @doc_category("Waiting for implementation")
     def is_prestress_stable(self) -> bool:
         raise NotImplementedError()


### PR DESCRIPTION
Moreover, `is_isostatic` was referenced, but wasn't implemented yet, so I created a corresponding method. 