### PR TITLE
Test notebook execution

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install poetry
         poetry config virtualenvs.create false
-        poetry install --without dev
+        poetry install --without dev --all-extras
     - name: Convert notebooks from md to ipynb
       run: |
         cd doc/userguide/tutorials/

--- a/.github/workflows/python-test-main.yml
+++ b/.github/workflows/python-test-main.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Install dependencies
-      run: poetry install --without doc  --all-extras
+      run: poetry install --all-extras
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -35,3 +35,6 @@ jobs:
       run: |
         poetry run pytest --doctest-modules -m 'not slow_main or slow_main'
         # --doctes-modules overrides the default --doctest-plus
+    - name: Test doc compilation
+      run: |
+        sphinx-build . _build

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,6 +122,8 @@ myst_substitutions = {
 myst_heading_anchors = 3
 
 nb_execution_mode = "cache"
+nb_execution_raise_on_error = True
+nb_execution_show_tb = True
 
 tippy_enable_mathjax = True
 tippy_props = {

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -2069,7 +2069,7 @@ class Framework(object):
         >>> G = Graph([(0,1), (1,2), (2,3), (0,3)])
         >>> F = Framework(G, {0:[0,0], 1:[1,0], 2:[1,'1/2 * sqrt(5)'], 3:[1/2,'4/3']})
         >>> F.generate_stl_bars(scale=20)
-        STL files for the bars have been generated in the chosen folder.
+        STL files for the bars have been generated in the folder `stl_output`.
         """
         from pathlib import Path as plPath
 
@@ -2100,7 +2100,7 @@ class Framework(object):
                 filename=f_name,
             )
 
-        print("STL files for the bars have been generated in the chosen folder.")
+        print(f"STL files for the bars have been generated in the folder `{output_dir}`.")
 
     @doc_category("Other")
     def _transform_inf_flex_to_pointwise(  # noqa: C901


### PR DESCRIPTION
This PR applies the fix #182 also to `dev`. Moreover, the setting of doc compilation is changed so that an error is raised when a compilation of a tutorial notebook fails. This doc compilation now has to pass without errors also when we merge to `main`.