### PR TITLE
Refactor the codebase: consistent using of dim, type hinting

### DIFF
--- a/doc/math/rigidity/generic.md
+++ b/doc/math/rigidity/generic.md
@@ -21,7 +21,7 @@ The graph $G$ is called _(generically) $d$-rigid_ if any {prf:ref}`generic d-dim
 :::{prf:definition} Minimally generically rigid graphs
 :label: def-min-rigid-graph
 
-Let $G$ be a graph, let $d, k \in \NN$.
+Let $G$ be a graph, let $d \in \NN$.
 The graph $G$ is called _minimally (generically) $d$-rigid_ if a (equivalently, any) {prf:ref}`generic framework <def-gen-realization>` $(G, p)$ is {prf:ref}`minimally (infinitesimally) d-rigid <def-min-rigid-framework>`.
 
 {{pyrigi_crossref}} {meth}`~.Graph.is_min_rigid`

--- a/doc/userguide/tutorials/framework_database.md
+++ b/doc/userguide/tutorials/framework_database.md
@@ -39,15 +39,15 @@ frameworks.Complete(2)
 ```
 
 ```{code-cell} ipython3
-frameworks.Complete(3, d=1)
+frameworks.Complete(3, dim=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Complete(4, d=3)
+frameworks.Complete(4, dim=3)
 ```
 
 ```{code-cell} ipython3
-K4 = frameworks.Complete(4, d=2)
+K4 = frameworks.Complete(4, dim=2)
 print(K4)
 K4.plot()
 ```
@@ -56,7 +56,7 @@ Currently, for $d\geq 3$, the number of vertices must be at most $d+1$ so the gr
 
 ```{code-cell} ipython3
 try:
-    frameworks.Complete(5, d=3)
+    frameworks.Complete(5, dim=3)
 except ValueError as e:
     print(e)
 ```
@@ -95,11 +95,11 @@ C5.plot()
 ```
 
 ```{code-cell} ipython3
-frameworks.Cycle(5, d=1)
+frameworks.Cycle(5, dim=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Cycle(5, d=4)
+frameworks.Cycle(5, dim=4)
 ```
 
 ## Path frameworks
@@ -116,11 +116,11 @@ P5.plot()
 ```
 
 ```{code-cell} ipython3
-frameworks.Path(5, d=1)
+frameworks.Path(5, dim=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Path(5, d=4)
+frameworks.Path(5, dim=4)
 ```
 
 ## 3-prism

--- a/doc/userguide/tutorials/framework_database.md
+++ b/doc/userguide/tutorials/framework_database.md
@@ -39,15 +39,15 @@ frameworks.Complete(2)
 ```
 
 ```{code-cell} ipython3
-frameworks.Complete(3, dim=1)
+frameworks.Complete(3, d=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Complete(4, dim=3)
+frameworks.Complete(4, d=3)
 ```
 
 ```{code-cell} ipython3
-K4 = frameworks.Complete(4, dim=2)
+K4 = frameworks.Complete(4, d=2)
 print(K4)
 K4.plot()
 ```
@@ -56,7 +56,7 @@ Currently, for $d\geq 3$, the number of vertices must be at most $d+1$ so the gr
 
 ```{code-cell} ipython3
 try:
-    frameworks.Complete(5, dim=3)
+    frameworks.Complete(5, d=3)
 except ValueError as e:
     print(e)
 ```
@@ -95,11 +95,11 @@ C5.plot()
 ```
 
 ```{code-cell} ipython3
-frameworks.Cycle(5, dim=1)
+frameworks.Cycle(5, d=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Cycle(5, dim=4)
+frameworks.Cycle(5, d=4)
 ```
 
 ## Path frameworks
@@ -116,11 +116,11 @@ P5.plot()
 ```
 
 ```{code-cell} ipython3
-frameworks.Path(5, dim=1)
+frameworks.Path(5, d=1)
 ```
 
 ```{code-cell} ipython3
-frameworks.Path(5, dim=4)
+frameworks.Path(5, d=4)
 ```
 
 ## 3-prism

--- a/pyrigi/data_type.py
+++ b/pyrigi/data_type.py
@@ -6,7 +6,7 @@ Module for defining data type used for type hinting.
 
 from sympy import Matrix, MatrixBase
 import numpy as np
-from typing import Tuple, Hashable
+from typing import Hashable
 from collections.abc import Sequence
 from numbers import Number
 
@@ -16,12 +16,12 @@ Vertex = Hashable
 Any hashable type can be used for a Vertex.
 """
 
-Edge = set[Vertex] | Tuple[Vertex, Vertex] | list[Vertex]
+Edge = set[Vertex] | tuple[Vertex, Vertex] | list[Vertex]
 """
 An Edge is an unordered pair of :obj:`Vertices <pyrigi.data_type.Vertex>`.
 """
 
-DirectedEdge = Tuple[Vertex, Vertex] | list[Vertex]
+DirectedEdge = tuple[Vertex, Vertex] | list[Vertex]
 """
 A DirectedEdge is an ordered pair of :obj:`Vertices <pyrigi.data_type.Vertex>`.
 """

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -13,7 +13,6 @@ Classes:
 """
 
 from __future__ import annotations
-from typing import List, Dict, Union
 
 from copy import deepcopy
 from itertools import combinations
@@ -97,11 +96,11 @@ class Framework(object):
 
     Notes
     -----
-    Internally, the realization is represented as ``Dict[Vertex,Matrix]``.
-    However, :meth:`~Framework.realization` can also return ``Dict[Vertex,Point]``.
+    Internally, the realization is represented as ``dict[Vertex,Matrix]``.
+    However, :meth:`~Framework.realization` can also return ``dict[Vertex,Point]``.
     """
 
-    def __init__(self, graph: Graph, realization: Dict[Vertex, Point]) -> None:
+    def __init__(self, graph: Graph, realization: dict[Vertex, Point]) -> None:
         if not isinstance(graph, Graph):
             raise TypeError("The graph has to be an instance of class Graph.")
         if nx.number_of_selfloops(graph) > 0:
@@ -211,7 +210,9 @@ class Framework(object):
         self._graph.add_node(vertex)
 
     @doc_category("Framework manipulation")
-    def add_vertices(self, points: List[Point], vertices: List[Vertex] = []) -> None:
+    def add_vertices(
+        self, points: Sequence[Point], vertices: Sequence[Vertex] = []
+    ) -> None:
         r"""
         Add a list of vertices to the framework.
 
@@ -261,7 +262,7 @@ class Framework(object):
         self._graph.add_edge(*(edge))
 
     @doc_category("Framework manipulation")
-    def add_edges(self, edges: List[Edge]) -> None:
+    def add_edges(self, edges: Sequence[Edge]) -> None:
         """
         Add a list of edges to the framework.
 
@@ -288,8 +289,8 @@ class Framework(object):
     @doc_category("Other")
     def _plot_with_2D_realization(
         self,
-        realization: Dict[Vertex, Point],
-        inf_flex: Dict[Vertex, Sequence[Coordinate]] = None,
+        realization: dict[Vertex, Point],
+        inf_flex: dict[Vertex, Sequence[Coordinate]] = None,
         vertex_color="#ff8c00",
         edge_width=1.5,
         **kwargs,
@@ -305,7 +306,7 @@ class Framework(object):
             The realization in the plane used for plotting.
         inf_flex:
             Optional parameter for plotting an infinitesimal flex. We expect
-            it to have the same format as `realization`: `Dict[Vertex, Point]`.
+            it to have the same format as `realization`: `dict[Vertex, Point]`.
         """
 
         self._graph.plot(
@@ -346,8 +347,8 @@ class Framework(object):
     @doc_category("Other")
     def plot2D(  # noqa: C901
         self,
-        coordinates: Union[tuple, List] = None,
-        inf_flex: Matrix | int | Dict[Vertex, Sequence[Coordinate]] = None,
+        coordinates: Sequence = None,
+        inf_flex: Matrix | int | dict[Vertex, Sequence[Coordinate]] = None,
         projection_matrix: Matrix = None,
         return_matrix: bool = False,
         random_seed: int = None,
@@ -382,7 +383,7 @@ class Framework(object):
             from :meth:`.Graph.vertex_list`.
             Alternatively, an ``int`` can be specified to choose the 0,1,2,...-th
             nontrivial infinitesimal flex for plotting.
-            Lastly, a ``Dict[Vertex, Sequence[Coordinate]]`` can be provided, which
+            Lastly, a ``dict[Vertex, Sequence[Coordinate]]`` can be provided, which
             maps the vertex labels to vectors (i.e. a sequence of coordinates).
         return_matrix:
             If True the matrix used for projection into 2D is returned.
@@ -407,7 +408,7 @@ class Framework(object):
             elif isinstance(inf_flex, Matrix):
                 inf_flex_pointwise = self._transform_inf_flex_to_pointwise(inf_flex)
             elif isinstance(inf_flex, dict) and all(
-                isinstance(inf_flex[key], Sequence) for key in inf_flex.keys()
+                isinstance(inf_flex[key], list | tuple) for key in inf_flex.keys()
             ):
                 inf_flex_pointwise = inf_flex
             else:
@@ -507,8 +508,8 @@ class Framework(object):
     @doc_category("Other")
     def to_tikz(
         self,
-        vertex_style: Union(str, dict[str : list[Vertex]]) = "fvertex",
-        edge_style: Union(str, dict[str : list[Edge]]) = "edge",
+        vertex_style: str | dict[str : Sequence[Vertex]] = "fvertex",
+        edge_style: str | dict[str : Sequence[Edge]] = "edge",
         label_style: str = "labelsty",
         figure_opts: str = "",
         vertex_in_labels: bool = False,
@@ -619,7 +620,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def from_points(cls, points: List[Point]) -> Framework:
+    def from_points(cls, points: Sequence[Point]) -> Framework:
         """
         Generate a framework from a list of points.
 
@@ -648,7 +649,7 @@ class Framework(object):
     @classmethod
     @doc_category("Class methods")
     def Random(
-        cls, graph: Graph, dim: int = 2, rand_range: int | List[int] = None
+        cls, graph: Graph, dim: int = 2, rand_range: int | Sequence[int] = None
     ) -> Framework:
         """
         Return a framework with random realization.
@@ -685,7 +686,7 @@ class Framework(object):
         if rand_range is None:
             b = 10**4 * graph.number_of_nodes() ** 2 * dim
             a = -b
-        if isinstance(rand_range, list):
+        if isinstance(rand_range, list | tuple):
             if not len(rand_range) == 2:
                 raise ValueError("If `rand_range` is a list, it must be of length 2.")
             a, b = rand_range
@@ -732,7 +733,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Collinear(cls, graph: Graph, d: int = 1) -> Framework:
+    def Collinear(cls, graph: Graph, dim: int = 1) -> Framework:
         """
         Return the framework with a realization on the x-axis in the d-dimensional space.
 
@@ -744,23 +745,23 @@ class Framework(object):
         Examples
         --------
         >>> import pyrigi.graphDB as graphs
-        >>> Framework.Collinear(graphs.Complete(3), d=2)
+        >>> Framework.Collinear(graphs.Complete(3), dim=2)
         Framework in 2-dimensional space consisting of:
         Graph with vertices [0, 1, 2] and edges [[0, 1], [0, 2], [1, 2]]
         Realization {0:(0, 0), 1:(1, 0), 2:(2, 0)}
         """
-        check_integrality_and_range(d, "dimension d", 1)
+        check_integrality_and_range(dim, "dimension d", 1)
         return Framework(
             graph,
             {
-                v: [i] + [0 for _ in range(d - 1)]
+                v: [i] + [0 for _ in range(dim - 1)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
 
     @classmethod
     @doc_category("Class methods")
-    def Simplicial(cls, graph: Graph, d: int = None) -> Framework:
+    def Simplicial(cls, graph: Graph, dim: int = None) -> Framework:
         """
         Return the framework with a realization on the d-simplex.
 
@@ -768,10 +769,10 @@ class Framework(object):
         ----------
         graph:
             Underlying graph on which the framework is constructed.
-        d:
-            The dimension ``d`` has to be at least the number of vertices
+        dim:
+            The dimension ``dim`` has to be at least the number of vertices
             of the ``graph`` minus one.
-            If ``d`` is not specified, then the least possible one is used.
+            If ``dim`` is not specified, then the least possible one is used.
 
         Examples
         ----
@@ -782,15 +783,15 @@ class Framework(object):
         >>> F.realization(as_points=True)
         {0: [0, 0, 0], 1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]}
         """
-        if d is None:
-            d = graph.number_of_nodes() - 1
+        if dim is None:
+            dim = graph.number_of_nodes() - 1
         check_integrality_and_range(
-            d, "dimension d", max([1, graph.number_of_nodes() - 1])
+            dim, "dimension d", max([1, graph.number_of_nodes() - 1])
         )
         return Framework(
             graph,
             {
-                v: [1 if j == i - 1 else 0 for j in range(d)]
+                v: [1 if j == i - 1 else 0 for j in range(dim)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
@@ -824,7 +825,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Complete(cls, points: List[Point]) -> Framework:
+    def Complete(cls, points: Sequence[Point]) -> Framework:
         """
         Generate a framework on the complete graph from a given list of points.
 
@@ -859,7 +860,7 @@ class Framework(object):
         del self._realization[vertex]
 
     @doc_category("Framework manipulation")
-    def delete_vertices(self, vertices: List[Vertex]) -> None:
+    def delete_vertices(self, vertices: Sequence[Vertex]) -> None:
         """
         Delete a list of vertices from the framework.
         """
@@ -874,7 +875,7 @@ class Framework(object):
         self._graph.delete_edge(edge)
 
     @doc_category("Framework manipulation")
-    def delete_edges(self, edges: List[Edge]) -> None:
+    def delete_edges(self, edges: Sequence[Edge]) -> None:
         """
         Delete a list of edges from the framework.
         """
@@ -883,7 +884,7 @@ class Framework(object):
     @doc_category("Attribute getters")
     def realization(
         self, as_points: bool = False, numerical: bool = False
-    ) -> Dict[Vertex, Point]:
+    ) -> dict[Vertex, Point]:
         """
         Return a copy of the realization.
 
@@ -984,7 +985,7 @@ class Framework(object):
         return True
 
     @doc_category("Framework manipulation")
-    def set_realization(self, realization: Dict[Vertex, Point]) -> None:
+    def set_realization(self, realization: dict[Vertex, Point]) -> None:
         r"""
         Change the realization of the framework.
 
@@ -1046,7 +1047,7 @@ class Framework(object):
 
     @doc_category("Framework manipulation")
     def set_vertex_positions_from_lists(
-        self, vertices: List[Vertex], points: List[Point]
+        self, vertices: Sequence[Vertex], points: Sequence[Point]
     ) -> None:
         """
         Change the coordinates of a given list of vertices.
@@ -1076,7 +1077,7 @@ class Framework(object):
         self.set_vertex_positions({v: pos for v, pos in zip(vertices, points)})
 
     @doc_category("Framework manipulation")
-    def set_vertex_positions(self, subset_of_realization: Dict[Vertex, Point]):
+    def set_vertex_positions(self, subset_of_realization: dict[Vertex, Point]):
         """
         Change the coordinates of vertices given by a dictionary.
 
@@ -1099,8 +1100,8 @@ class Framework(object):
     @doc_category("Infinitesimal rigidity")
     def rigidity_matrix(
         self,
-        vertex_order: List[Vertex] = None,
-        edge_order: List[Edge] = None,
+        vertex_order: Sequence[Vertex] = None,
+        edge_order: Sequence[Edge] = None,
     ) -> Matrix:
         r"""
         Construct the rigidity matrix of the framework.
@@ -1157,9 +1158,9 @@ class Framework(object):
 
     def pinned_rigidity_matrix(
         self,
-        pinned_vertices: Dict[Vertex, List[int]] = None,
-        vertex_order: List[Vertex] = None,
-        edge_order: List[Edge] = None,
+        pinned_vertices: dict[Vertex, Sequence[int]] = None,
+        vertex_order: Sequence[Vertex] = None,
+        edge_order: Sequence[Edge] = None,
     ) -> Matrix:
         r"""
         Construct the rigidity matrix of the framework.
@@ -1235,7 +1236,7 @@ class Framework(object):
     def is_stress(
         self,
         stress: Stress,
-        edge_order: List[Edge] = None,
+        edge_order: Sequence[Edge] = None,
         numerical: bool = False,
         tolerance=1e-9,
     ) -> bool:
@@ -1284,8 +1285,8 @@ class Framework(object):
     def stress_matrix(
         self,
         stress: Stress,
-        edge_order: List[Edge] = None,
-        vertex_order: List[Vertex] = None,
+        edge_order: Sequence[Edge] = None,
+        vertex_order: Sequence[Vertex] = None,
     ) -> Matrix:
         r"""
         Construct the stress matrix from a stress of from its support.
@@ -1342,7 +1343,7 @@ class Framework(object):
         return stress_matr
 
     @doc_category("Infinitesimal rigidity")
-    def trivial_inf_flexes(self, vertex_order: List[Vertex] = None) -> List[Matrix]:
+    def trivial_inf_flexes(self, vertex_order: Sequence[Vertex] = None) -> list[Matrix]:
         r"""
         Return a basis of the vector subspace of trivial infinitesimal flexes.
 
@@ -1401,7 +1402,9 @@ class Framework(object):
         return matrix_inf_flexes.transpose().echelon_form().transpose().columnspace()
 
     @doc_category("Infinitesimal rigidity")
-    def nontrivial_inf_flexes(self, vertex_order: List[Vertex] = None) -> List[Matrix]:
+    def nontrivial_inf_flexes(
+        self, vertex_order: Sequence[Vertex] = None
+    ) -> list[Matrix]:
         """
         Return non-trivial infinitesimal flexes.
 
@@ -1443,8 +1446,8 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def inf_flexes(
-        self, include_trivial: bool = False, vertex_order: List[Vertex] = None
-    ) -> List[Matrix]:
+        self, include_trivial: bool = False, vertex_order: Sequence[Vertex] = None
+    ) -> list[Matrix]:
         r"""
         Return a basis of the space of infinitesimal flexes.
 
@@ -1516,7 +1519,7 @@ class Framework(object):
         return basis[s:]
 
     @doc_category("Infinitesimal rigidity")
-    def stresses(self, edge_order: List[Edge] = None) -> List[Matrix]:
+    def stresses(self, edge_order: Sequence[Edge] = None) -> list[Matrix]:
         r"""
         Return a basis of the space of equilibrium stresses.
 
@@ -1586,7 +1589,7 @@ class Framework(object):
         >>> F1 = frameworkDB.CompleteBipartite(4,4)
         >>> F1.is_inf_rigid()
         True
-        >>> F2 = frameworkDB.Cycle(4,d=2)
+        >>> F2 = frameworkDB.Cycle(4,dim=2)
         >>> F2.is_inf_rigid()
         False
         """
@@ -1717,7 +1720,7 @@ class Framework(object):
     @doc_category("Framework properties")
     def is_congruent_realization(
         self,
-        other_realization: Dict[Vertex, Point],
+        other_realization: dict[Vertex, Point],
         numerical: bool = False,
         tolerance: float = 1e-9,
     ) -> bool:
@@ -1782,7 +1785,7 @@ class Framework(object):
     @doc_category("Framework properties")
     def is_equivalent_realization(
         self,
-        other_realization: Dict[Vertex, Point],
+        other_realization: dict[Vertex, Point],
         numerical: bool = False,
         tolerance: float = 1e-9,
     ) -> bool:
@@ -1844,7 +1847,7 @@ class Framework(object):
         )
 
     @doc_category("Framework manipulation")
-    def translate(self, vector: Point, inplace: bool = True) -> Union[None, Framework]:
+    def translate(self, vector: Point, inplace: bool = True) -> None | Framework:
         """
         Translate the framework.
 
@@ -1873,7 +1876,7 @@ class Framework(object):
         return new_framework
 
     @doc_category("Framework manipulation")
-    def rotate2D(self, angle: float, inplace: bool = True) -> Union[None, Framework]:
+    def rotate2D(self, angle: float, inplace: bool = True) -> None | Framework:
         """
         Rotate the planar framework counter clockwise.
 
@@ -1903,7 +1906,7 @@ class Framework(object):
         return new_framework
 
     @doc_category("Other")
-    def edge_lengths(self, numerical: bool = False) -> Dict[Edge, Coordinate]:
+    def edge_lengths(self, numerical: bool = False) -> dict[Edge, Coordinate]:
         """
         Return the dictionary of the edge lengths.
 
@@ -2100,12 +2103,14 @@ class Framework(object):
                 filename=f_name,
             )
 
-        print(f"STL files for the bars have been generated in the folder `{output_dir}`.")
+        print(
+            f"STL files for the bars have been generated in the folder `{output_dir}`."
+        )
 
     @doc_category("Other")
     def _transform_inf_flex_to_pointwise(  # noqa: C901
-        self, inf_flex: Matrix, vertex_order: List[Vertex] = None
-    ) -> Dict[Vertex, Sequence[Coordinate]]:
+        self, inf_flex: Matrix, vertex_order: Sequence[Vertex] = None
+    ) -> dict[Vertex, list[Coordinate]]:
         r"""
         Transform the natural data type of a flex (Matrix) to a
         dictionary that maps a vertex to a Sequence of coordinates
@@ -2142,8 +2147,8 @@ class Framework(object):
     @doc_category("Infinitesimal rigidity")
     def is_vector_inf_flex(
         self,
-        inf_flex: List[Coordinate],
-        vertex_order: List[Vertex] = None,
+        inf_flex: Sequence[Coordinate],
+        vertex_order: Sequence[Vertex] = None,
         numerical: bool = False,
         tolerance: float = 1e-9,
     ) -> bool:
@@ -2193,7 +2198,7 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def is_dict_inf_flex(
-        self, vert_to_flex: Dict[Vertex, Sequence[Coordinate]], **kwargs
+        self, vert_to_flex: dict[Vertex, Sequence[Coordinate]], **kwargs
     ) -> bool:
         """
         Return whether a dictionary specifies an infinitesimal flex of the framework.
@@ -2237,8 +2242,8 @@ class Framework(object):
     @doc_category("Infinitesimal rigidity")
     def is_vector_nontrivial_inf_flex(
         self,
-        inf_flex: List[Coordinate],
-        vertex_order: List[Vertex] = None,
+        inf_flex: Sequence[Coordinate],
+        vertex_order: Sequence[Vertex] = None,
         numerical: bool = False,
         tolerance: float = 1e-9,
     ) -> bool:
@@ -2320,7 +2325,7 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def is_dict_nontrivial_inf_flex(
-        self, vert_to_flex: Dict[Vertex, Sequence[Coordinate]], **kwargs
+        self, vert_to_flex: dict[Vertex, Sequence[Coordinate]], **kwargs
     ) -> bool:
         r"""
         Return whether a dictionary specifies an infinitesimal flex which is nontrivial.
@@ -2366,7 +2371,9 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def is_nontrivial_flex(
-        self, inf_flex: List[Coordinate] | Dict[Vertex, Sequence[Coordinate]], **kwargs
+        self,
+        inf_flex: Sequence[Coordinate] | dict[Vertex, Sequence[Coordinate]],
+        **kwargs,
     ) -> bool:
         """
         Alias for :meth:`Framework.is_vector_nontrivial_inf_flex` and
@@ -2377,7 +2384,7 @@ class Framework(object):
         We distinguish between instances of ``list`` and instances of ``dict`` to
         call one of the alias methods.
         """
-        if isinstance(inf_flex, list):
+        if isinstance(inf_flex, list | tuple):
             return self.is_vector_nontrivial_inf_flex(inf_flex, **kwargs)
         elif isinstance(inf_flex, dict):
             return self.is_dict_nontrivial_inf_flex(inf_flex, **kwargs)
@@ -2387,7 +2394,9 @@ class Framework(object):
             )
 
     @doc_category("Infinitesimal rigidity")
-    def is_vector_trivial_inf_flex(self, inf_flex: List[Coordinate], **kwargs) -> bool:
+    def is_vector_trivial_inf_flex(
+        self, inf_flex: Sequence[Coordinate], **kwargs
+    ) -> bool:
         r"""
         Return whether an infinitesimal flex is trivial.
 
@@ -2422,7 +2431,7 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def is_dict_trivial_inf_flex(
-        self, vert_to_flex: Dict[Vertex, Sequence[Coordinate]], **kwargs
+        self, vert_to_flex: dict[Vertex, Sequence[Coordinate]], **kwargs
     ) -> bool:
         r"""
         Return whether an infinitesimal flex specified by a dictionary is trivial.
@@ -2468,7 +2477,9 @@ class Framework(object):
 
     @doc_category("Infinitesimal rigidity")
     def is_trivial_flex(
-        self, inf_flex: List[Coordinate] | Dict[Vertex, Sequence[Coordinate]], **kwargs
+        self,
+        inf_flex: Sequence[Coordinate] | dict[Vertex, Sequence[Coordinate]],
+        **kwargs,
     ) -> bool:
         """
         Alias for :meth:`Framework.is_vector_trivial_inf_flex` and
@@ -2479,7 +2490,7 @@ class Framework(object):
         We distinguish between instances of ``list`` and instances of ``dict`` to
         call one of the alias methods.
         """
-        if isinstance(inf_flex, list):
+        if isinstance(inf_flex, list | tuple):
             return self.is_vector_trivial_inf_flex(inf_flex, **kwargs)
         elif isinstance(inf_flex, dict):
             return self.is_dict_trivial_inf_flex(inf_flex, **kwargs)
@@ -2489,7 +2500,7 @@ class Framework(object):
             )
 
     @doc_category("Other")
-    def _check_vertex_order(self, vertex_order=List[Vertex]) -> List[Vertex]:
+    def _check_vertex_order(self, vertex_order=Sequence[Vertex]) -> list[Vertex]:
         """
         Checks whether the provided `vertex_order` contains the same elements
         as the graph's vertex set.
@@ -2514,10 +2525,10 @@ class Framework(object):
                     "New vertex set must contain exactly "
                     + "the same vertices as the underlying graph!"
                 )
-            return vertex_order
+            return list(vertex_order)
 
     @doc_category("Other")
-    def _check_edge_order(self, edge_order=List[Vertex]) -> List[Edge]:
+    def _check_edge_order(self, edge_order=Sequence[Edge]) -> list[Edge]:
         """
         Checks whether the provided `edge_order` contains the same elements
         as the graph's edge set.
@@ -2544,7 +2555,7 @@ class Framework(object):
                 raise ValueError(
                     "edge_order must contain exactly the same edges as the graph!"
                 )
-            return edge_order
+            return list(edge_order)
 
 
 Framework.__doc__ = Framework.__doc__.replace(

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -189,7 +189,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(d=2)
+        >>> F = Framework.Empty(dim=2)
         >>> F.add_vertex((1.5,2), 'a')
         >>> F.add_vertex((3,1))
         >>> F
@@ -229,7 +229,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(d=2)
+        >>> F = Framework.Empty(dim=2)
         >>> F.add_vertices([(1.5,2), (3,1)], ['a',0])
         >>> print(F)
         Framework in 2-dimensional space consisting of:
@@ -332,8 +332,8 @@ class Framework(object):
         ----------
         projection_matrix:
             The matrix used for projection.
-            The matrix must have dimensions ``(2, d)``,
-            where ``d`` is the dimension of the framework.
+            The matrix must have dimensions ``(2, dim)``,
+            where ``dim`` is the dimension of the framework.
         """
 
         placement = {}
@@ -369,8 +369,8 @@ class Framework(object):
         projection_matrix:
             The matrix used for projecting the placement of vertices
             only when they are in dimension higher than 2.
-            The matrix must have dimensions (2, d),
-            where ``d`` is the dimension of the currect placements of vertices.
+            The matrix must have dimensions (2, dim),
+            where dim is the dimension of the currect placements of vertices.
             If None, a random projection matrix is generated.
         random_seed:
             The random seed used for generating the projection matrix.
@@ -456,7 +456,7 @@ class Framework(object):
             if np.max(coordinates) >= self._dim:
                 raise ValueError(
                     f"Index {np.max(coordinates)} out of range"
-                    + f" with placement in dimension: {self._dim}."
+                    + f" with placement in dim: {self._dim}."
                 )
             projection_matrix = np.zeros((2, self._dim))
             projection_matrix[0, coordinates[0]] = 1
@@ -649,7 +649,7 @@ class Framework(object):
     @classmethod
     @doc_category("Class methods")
     def Random(
-        cls, graph: Graph, d: int = 2, rand_range: int | Sequence[int] = None
+        cls, graph: Graph, dim: int = 2, rand_range: int | Sequence[int] = None
     ) -> Framework:
         """
         Return a framework with random realization.
@@ -679,25 +679,25 @@ class Framework(object):
         ----
         Set the correct default range value.
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if rand_range is None:
-            _b = 10**4 * graph.number_of_nodes() ** 2 * d
-            _a = -_b
+            b = 10**4 * graph.number_of_nodes() ** 2 * dim
+            a = -b
         if isinstance(rand_range, list | tuple):
             if not len(rand_range) == 2:
                 raise ValueError("If `rand_range` is a list, it must be of length 2.")
-            _a, _b = rand_range
+            a, b = rand_range
         if isinstance(rand_range, int):
             if rand_range <= 0:
                 raise ValueError("If `rand_range` is an int, it must be positive")
-            _b = rand_range
-            _a = -_b
+            b = rand_range
+            a = -b
 
         realization = {
-            vertex: [randrange(_a, _b) for _ in range(d)] for vertex in graph.nodes
+            vertex: [randrange(a, b) for _ in range(dim)] for vertex in graph.nodes
         }
 
         return Framework(graph, realization)
@@ -733,7 +733,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Collinear(cls, graph: Graph, d: int = 1) -> Framework:
+    def Collinear(cls, graph: Graph, dim: int = 1) -> Framework:
         """
         Return the framework with a realization on the x-axis in the d-dimensional space.
 
@@ -745,23 +745,23 @@ class Framework(object):
         Examples
         --------
         >>> import pyrigi.graphDB as graphs
-        >>> Framework.Collinear(graphs.Complete(3), d=2)
+        >>> Framework.Collinear(graphs.Complete(3), dim=2)
         Framework in 2-dimensional space consisting of:
         Graph with vertices [0, 1, 2] and edges [[0, 1], [0, 2], [1, 2]]
         Realization {0:(0, 0), 1:(1, 0), 2:(2, 0)}
         """
-        check_integrality_and_range(d, "dimension d", 1)
+        check_integrality_and_range(dim, "dimension d", 1)
         return Framework(
             graph,
             {
-                v: [i] + [0 for _ in range(d - 1)]
+                v: [i] + [0 for _ in range(dim - 1)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
 
     @classmethod
     @doc_category("Class methods")
-    def Simplicial(cls, graph: Graph, d: int = None) -> Framework:
+    def Simplicial(cls, graph: Graph, dim: int = None) -> Framework:
         """
         Return the framework with a realization on the d-simplex.
 
@@ -769,10 +769,10 @@ class Framework(object):
         ----------
         graph:
             Underlying graph on which the framework is constructed.
-        d:
-            The dimension ``d`` has to be at least the number of vertices
+        dim:
+            The dimension ``dim`` has to be at least the number of vertices
             of the ``graph`` minus one.
-            If ``d`` is not specified, then the least possible one is used.
+            If ``dim`` is not specified, then the least possible one is used.
 
         Examples
         ----
@@ -783,44 +783,44 @@ class Framework(object):
         >>> F.realization(as_points=True)
         {0: [0, 0, 0], 1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]}
         """
-        if d is None:
-            d = graph.number_of_nodes() - 1
+        if dim is None:
+            dim = graph.number_of_nodes() - 1
         check_integrality_and_range(
-            d, "dimension d", max([1, graph.number_of_nodes() - 1])
+            dim, "dimension d", max([1, graph.number_of_nodes() - 1])
         )
         return Framework(
             graph,
             {
-                v: [1 if j == i - 1 else 0 for j in range(d)]
+                v: [1 if j == i - 1 else 0 for j in range(dim)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
 
     @classmethod
     @doc_category("Class methods")
-    def Empty(cls, d: int = 2) -> Framework:
+    def Empty(cls, dim: int = 2) -> Framework:
         """
         Generate an empty framework.
 
         Parameters
         ----------
-        d:
+        dim:
             a natural number that determines the dimension
             in which the framework is realized
 
         Examples
         ----
-        >>> F = Framework.Empty(d=1); F
+        >>> F = Framework.Empty(dim=1); F
         Framework in 1-dimensional space consisting of:
         Graph with vertices [] and edges []
         Realization {}
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         F = Framework(graph=Graph(), realization={})
-        F._dim = d
+        F._dim = dim
         return F
 
     @classmethod
@@ -1382,15 +1382,15 @@ class Framework(object):
         [ 0]])]
         """
         vertex_order = self._check_vertex_order(vertex_order)
-        d = self._dim
+        dim = self._dim
         translations = [
             Matrix.vstack(*[A for _ in vertex_order])
-            for A in Matrix.eye(d).columnspace()
+            for A in Matrix.eye(dim).columnspace()
         ]
         basis_skew_symmetric = []
-        for i in range(1, d):
+        for i in range(1, dim):
             for j in range(i):
-                A = Matrix.zeros(d)
+                A = Matrix.zeros(dim)
                 A[i, j] = 1
                 A[j, i] = -1
                 basis_skew_symmetric += [A]
@@ -1589,7 +1589,7 @@ class Framework(object):
         >>> F1 = frameworkDB.CompleteBipartite(4,4)
         >>> F1.is_inf_rigid()
         True
-        >>> F2 = frameworkDB.Cycle(4,d=2)
+        >>> F2 = frameworkDB.Cycle(4,dim=2)
         >>> F2.is_inf_rigid()
         False
         """
@@ -1700,7 +1700,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(d=2)
+        >>> F = Framework.Empty(dim=2)
         >>> F.add_vertices([(1,0), (1,1), (0,3), (-1,1)], ['a','b','c','d'])
         >>> F.add_edges([('a','b'), ('b','c'), ('c','d'), ('a','d'), ('a','c'), ('b','d')])
         >>> F.is_redundantly_rigid()

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -189,7 +189,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(dim=2)
+        >>> F = Framework.Empty(d=2)
         >>> F.add_vertex((1.5,2), 'a')
         >>> F.add_vertex((3,1))
         >>> F
@@ -229,7 +229,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(dim=2)
+        >>> F = Framework.Empty(d=2)
         >>> F.add_vertices([(1.5,2), (3,1)], ['a',0])
         >>> print(F)
         Framework in 2-dimensional space consisting of:
@@ -332,8 +332,8 @@ class Framework(object):
         ----------
         projection_matrix:
             The matrix used for projection.
-            The matrix must have dimensions ``(2, dim)``,
-            where ``dim`` is the dimension of the framework.
+            The matrix must have dimensions ``(2, d)``,
+            where ``d`` is the dimension of the framework.
         """
 
         placement = {}
@@ -369,8 +369,8 @@ class Framework(object):
         projection_matrix:
             The matrix used for projecting the placement of vertices
             only when they are in dimension higher than 2.
-            The matrix must have dimensions (2, dim),
-            where dim is the dimension of the currect placements of vertices.
+            The matrix must have dimensions (2, d),
+            where ``d`` is the dimension of the currect placements of vertices.
             If None, a random projection matrix is generated.
         random_seed:
             The random seed used for generating the projection matrix.
@@ -456,7 +456,7 @@ class Framework(object):
             if np.max(coordinates) >= self._dim:
                 raise ValueError(
                     f"Index {np.max(coordinates)} out of range"
-                    + f" with placement in dim: {self._dim}."
+                    + f" with placement in dimension: {self._dim}."
                 )
             projection_matrix = np.zeros((2, self._dim))
             projection_matrix[0, coordinates[0]] = 1
@@ -649,7 +649,7 @@ class Framework(object):
     @classmethod
     @doc_category("Class methods")
     def Random(
-        cls, graph: Graph, dim: int = 2, rand_range: int | Sequence[int] = None
+        cls, graph: Graph, d: int = 2, rand_range: int | Sequence[int] = None
     ) -> Framework:
         """
         Return a framework with random realization.
@@ -679,25 +679,25 @@ class Framework(object):
         ----
         Set the correct default range value.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if rand_range is None:
-            b = 10**4 * graph.number_of_nodes() ** 2 * dim
-            a = -b
+            _b = 10**4 * graph.number_of_nodes() ** 2 * d
+            _a = -_b
         if isinstance(rand_range, list | tuple):
             if not len(rand_range) == 2:
                 raise ValueError("If `rand_range` is a list, it must be of length 2.")
-            a, b = rand_range
+            _a, _b = rand_range
         if isinstance(rand_range, int):
             if rand_range <= 0:
                 raise ValueError("If `rand_range` is an int, it must be positive")
-            b = rand_range
-            a = -b
+            _b = rand_range
+            _a = -_b
 
         realization = {
-            vertex: [randrange(a, b) for _ in range(dim)] for vertex in graph.nodes
+            vertex: [randrange(_a, _b) for _ in range(d)] for vertex in graph.nodes
         }
 
         return Framework(graph, realization)
@@ -733,7 +733,7 @@ class Framework(object):
 
     @classmethod
     @doc_category("Class methods")
-    def Collinear(cls, graph: Graph, dim: int = 1) -> Framework:
+    def Collinear(cls, graph: Graph, d: int = 1) -> Framework:
         """
         Return the framework with a realization on the x-axis in the d-dimensional space.
 
@@ -745,23 +745,23 @@ class Framework(object):
         Examples
         --------
         >>> import pyrigi.graphDB as graphs
-        >>> Framework.Collinear(graphs.Complete(3), dim=2)
+        >>> Framework.Collinear(graphs.Complete(3), d=2)
         Framework in 2-dimensional space consisting of:
         Graph with vertices [0, 1, 2] and edges [[0, 1], [0, 2], [1, 2]]
         Realization {0:(0, 0), 1:(1, 0), 2:(2, 0)}
         """
-        check_integrality_and_range(dim, "dimension d", 1)
+        check_integrality_and_range(d, "dimension d", 1)
         return Framework(
             graph,
             {
-                v: [i] + [0 for _ in range(dim - 1)]
+                v: [i] + [0 for _ in range(d - 1)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
 
     @classmethod
     @doc_category("Class methods")
-    def Simplicial(cls, graph: Graph, dim: int = None) -> Framework:
+    def Simplicial(cls, graph: Graph, d: int = None) -> Framework:
         """
         Return the framework with a realization on the d-simplex.
 
@@ -769,10 +769,10 @@ class Framework(object):
         ----------
         graph:
             Underlying graph on which the framework is constructed.
-        dim:
-            The dimension ``dim`` has to be at least the number of vertices
+        d:
+            The dimension ``d`` has to be at least the number of vertices
             of the ``graph`` minus one.
-            If ``dim`` is not specified, then the least possible one is used.
+            If ``d`` is not specified, then the least possible one is used.
 
         Examples
         ----
@@ -783,44 +783,44 @@ class Framework(object):
         >>> F.realization(as_points=True)
         {0: [0, 0, 0], 1: [1, 0, 0], 2: [0, 1, 0], 3: [0, 0, 1]}
         """
-        if dim is None:
-            dim = graph.number_of_nodes() - 1
+        if d is None:
+            d = graph.number_of_nodes() - 1
         check_integrality_and_range(
-            dim, "dimension d", max([1, graph.number_of_nodes() - 1])
+            d, "dimension d", max([1, graph.number_of_nodes() - 1])
         )
         return Framework(
             graph,
             {
-                v: [1 if j == i - 1 else 0 for j in range(dim)]
+                v: [1 if j == i - 1 else 0 for j in range(d)]
                 for i, v in enumerate(graph.vertex_list())
             },
         )
 
     @classmethod
     @doc_category("Class methods")
-    def Empty(cls, dim: int = 2) -> Framework:
+    def Empty(cls, d: int = 2) -> Framework:
         """
         Generate an empty framework.
 
         Parameters
         ----------
-        dim:
+        d:
             a natural number that determines the dimension
             in which the framework is realized
 
         Examples
         ----
-        >>> F = Framework.Empty(dim=1); F
+        >>> F = Framework.Empty(d=1); F
         Framework in 1-dimensional space consisting of:
         Graph with vertices [] and edges []
         Realization {}
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         F = Framework(graph=Graph(), realization={})
-        F._dim = dim
+        F._dim = d
         return F
 
     @classmethod
@@ -1382,15 +1382,15 @@ class Framework(object):
         [ 0]])]
         """
         vertex_order = self._check_vertex_order(vertex_order)
-        dim = self._dim
+        d = self._dim
         translations = [
             Matrix.vstack(*[A for _ in vertex_order])
-            for A in Matrix.eye(dim).columnspace()
+            for A in Matrix.eye(d).columnspace()
         ]
         basis_skew_symmetric = []
-        for i in range(1, dim):
+        for i in range(1, d):
             for j in range(i):
-                A = Matrix.zeros(dim)
+                A = Matrix.zeros(d)
                 A[i, j] = 1
                 A[j, i] = -1
                 basis_skew_symmetric += [A]
@@ -1589,7 +1589,7 @@ class Framework(object):
         >>> F1 = frameworkDB.CompleteBipartite(4,4)
         >>> F1.is_inf_rigid()
         True
-        >>> F2 = frameworkDB.Cycle(4,dim=2)
+        >>> F2 = frameworkDB.Cycle(4,d=2)
         >>> F2.is_inf_rigid()
         False
         """
@@ -1700,7 +1700,7 @@ class Framework(object):
 
         Examples
         --------
-        >>> F = Framework.Empty(dim=2)
+        >>> F = Framework.Empty(d=2)
         >>> F.add_vertices([(1,0), (1,1), (0,3), (-1,1)], ['a','b','c','d'])
         >>> F.add_edges([('a','b'), ('b','c'), ('c','d'), ('a','d'), ('a','c'), ('b','d')])
         >>> F.is_redundantly_rigid()

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -9,19 +9,19 @@ import pyrigi.misc as misc
 import sympy as sp
 
 
-def Cycle(n: int, d: int = 2) -> Framework:
+def Cycle(n: int, dim: int = 2) -> Framework:
     """Return d-dimensional framework of the n-cycle."""
     misc.check_integrality_and_range(n, "number of vertices n", 3)
-    misc.check_integrality_and_range(d, "dimension d", 1)
-    if n - 1 <= d:
-        return Framework.Simplicial(graphs.Cycle(n), d)
-    elif d == 1:
+    misc.check_integrality_and_range(dim, "dimension d", 1)
+    if n - 1 <= dim:
+        return Framework.Simplicial(graphs.Cycle(n), dim)
+    elif dim == 1:
         return Framework.Collinear(graphs.Cycle(n), 1)
-    elif d == 2:
+    elif dim == 2:
         return Framework.Circular(graphs.Cycle(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({d}, {n})."
+        f"(now (d, n) = ({dim}, {n})."
     )
 
 
@@ -35,7 +35,7 @@ def Diamond() -> Framework:
     return Framework(graphs.Diamond(), {0: [0, 0], 1: [1, 0], 2: [1, 1], 3: [0, 1]})
 
 
-def Complete(n: int, d: int = 2) -> Framework:
+def Complete(n: int, dim: int = 2) -> Framework:
     """
     Return d-dimensional framework of the complete graph on n vertices.
 
@@ -44,32 +44,32 @@ def Complete(n: int, d: int = 2) -> Framework:
     Describe the generated realization.
     """
     misc.check_integrality_and_range(n, "number of vertices n", 1)
-    misc.check_integrality_and_range(d, "dimension d", 1)
-    if n - 1 <= d:
-        return Framework.Simplicial(graphs.Complete(n), d)
-    elif d == 1:
+    misc.check_integrality_and_range(dim, "dimension d", 1)
+    if n - 1 <= dim:
+        return Framework.Simplicial(graphs.Complete(n), dim)
+    elif dim == 1:
         return Framework.Collinear(graphs.Complete(n), 1)
-    elif d == 2:
+    elif dim == 2:
         return Framework.Circular(graphs.Complete(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({d}, {n})."
+        f"(now (d, n) = ({dim}, {n})."
     )
 
 
-def Path(n: int, d: int = 2) -> Framework:
+def Path(n: int, dim: int = 2) -> Framework:
     """Return d-dimensional framework of the path graph on n vertices."""
     misc.check_integrality_and_range(n, "number of vertices n", 2)
-    misc.check_integrality_and_range(d, "dimension d", 1)
-    if n - 1 <= d:
-        return Framework.Simplicial(graphs.Path(n), d)
-    elif d == 1:
+    misc.check_integrality_and_range(dim, "dimension d", 1)
+    if n - 1 <= dim:
+        return Framework.Simplicial(graphs.Path(n), dim)
+    elif dim == 1:
         return Framework.Collinear(graphs.Path(n), 1)
-    elif d == 2:
+    elif dim == 2:
         return Framework.Circular(graphs.Path(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({d}, {n})."
+        f"(now (d, n) = ({dim}, {n})."
     )
 
 

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -9,19 +9,19 @@ import pyrigi.misc as misc
 import sympy as sp
 
 
-def Cycle(n: int, dim: int = 2) -> Framework:
+def Cycle(n: int, d: int = 2) -> Framework:
     """Return d-dimensional framework of the n-cycle."""
     misc.check_integrality_and_range(n, "number of vertices n", 3)
-    misc.check_integrality_and_range(dim, "dimension d", 1)
-    if n - 1 <= dim:
-        return Framework.Simplicial(graphs.Cycle(n), dim)
-    elif dim == 1:
+    misc.check_integrality_and_range(d, "dimension d", 1)
+    if n - 1 <= d:
+        return Framework.Simplicial(graphs.Cycle(n), d)
+    elif d == 1:
         return Framework.Collinear(graphs.Cycle(n), 1)
-    elif dim == 2:
+    elif d == 2:
         return Framework.Circular(graphs.Cycle(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({dim}, {n})."
+        f"(now (d, n) = ({d}, {n})."
     )
 
 
@@ -35,7 +35,7 @@ def Diamond() -> Framework:
     return Framework(graphs.Diamond(), {0: [0, 0], 1: [1, 0], 2: [1, 1], 3: [0, 1]})
 
 
-def Complete(n: int, dim: int = 2) -> Framework:
+def Complete(n: int, d: int = 2) -> Framework:
     """
     Return d-dimensional framework of the complete graph on n vertices.
 
@@ -44,32 +44,32 @@ def Complete(n: int, dim: int = 2) -> Framework:
     Describe the generated realization.
     """
     misc.check_integrality_and_range(n, "number of vertices n", 1)
-    misc.check_integrality_and_range(dim, "dimension d", 1)
-    if n - 1 <= dim:
-        return Framework.Simplicial(graphs.Complete(n), dim)
-    elif dim == 1:
+    misc.check_integrality_and_range(d, "dimension d", 1)
+    if n - 1 <= d:
+        return Framework.Simplicial(graphs.Complete(n), d)
+    elif d == 1:
         return Framework.Collinear(graphs.Complete(n), 1)
-    elif dim == 2:
+    elif d == 2:
         return Framework.Circular(graphs.Complete(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({dim}, {n})."
+        f"(now (d, n) = ({d}, {n})."
     )
 
 
-def Path(n: int, dim: int = 2) -> Framework:
+def Path(n: int, d: int = 2) -> Framework:
     """Return d-dimensional framework of the path graph on n vertices."""
     misc.check_integrality_and_range(n, "number of vertices n", 2)
-    misc.check_integrality_and_range(dim, "dimension d", 1)
-    if n - 1 <= dim:
-        return Framework.Simplicial(graphs.Path(n), dim)
-    elif dim == 1:
+    misc.check_integrality_and_range(d, "dimension d", 1)
+    if n - 1 <= d:
+        return Framework.Simplicial(graphs.Path(n), d)
+    elif d == 1:
         return Framework.Collinear(graphs.Path(n), 1)
-    elif dim == 2:
+    elif d == 2:
         return Framework.Circular(graphs.Path(n))
     raise ValueError(
         "The number of vertices n has to be at most d+1, or d must be 1 or 2 "
-        f"(now (d, n) = ({dim}, {n})."
+        f"(now (d, n) = ({d}, {n})."
     )
 
 

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -665,23 +665,23 @@ class Graph(nx.Graph):
         self,
         vertices: Sequence[Vertex],
         new_vertex: Vertex = None,
-        dim: int = 2,
+        d: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`dim-dimensional 0-extension <def-k-extension>`.
+        Return a :prf:ref:`d-dimensional 0-extension <def-k-extension>`.
 
         Parameters
         ----------
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``dim`` of them.
+            and there must be ``d`` of them.
         new_vertex:
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        dim:
+        d:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -700,12 +700,12 @@ class Graph(nx.Graph):
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [2, 5]]
         >>> G
         Graph with vertices [0, 1, 2] and edges [[0, 1], [0, 2], [1, 2]]
-        >>> G.zero_extension([0, 1, 2], 5, dim=3, inplace=True);
+        >>> G.zero_extension([0, 1, 2], 5, d=3, inplace=True);
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5]]
         """  # noqa: E501
-        return self.k_extension(0, vertices, [], new_vertex, dim, inplace)
+        return self.k_extension(0, vertices, [], new_vertex, d, inplace)
 
     @doc_category("Graph manipulation")
     def one_extension(
@@ -713,18 +713,18 @@ class Graph(nx.Graph):
         vertices: Sequence[Vertex],
         edge: Edge,
         new_vertex: Vertex = None,
-        dim: int = 2,
+        d: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`dim-dimensional 1-extension <def-k-extension>`.
+        Return a :prf:ref:`d-dimensional 1-extension <def-k-extension>`.
 
         Parameters
         ----------
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``dim + 1`` of them.
+            and there must be ``d + 1`` of them.
         edge:
             An edge with endvertices from the list ``vertices`` that will be deleted.
             The edge must be contained in the graph.
@@ -732,7 +732,7 @@ class Graph(nx.Graph):
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        dim:
+        d:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -752,17 +752,17 @@ class Graph(nx.Graph):
         >>> G = graphs.ThreePrism()
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]
-        >>> G.one_extension([0, 1], [0, 1], dim=1)
+        >>> G.one_extension([0, 1], [0, 1], d=1)
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 2], [0, 3], [0, 6], [1, 2], [1, 4], [1, 6], [2, 5], [3, 4], [3, 5], [4, 5]]
         >>> G = graphs.CompleteBipartite(3, 2)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4] and edges [[0, 3], [0, 4], [1, 3], [1, 4], [2, 3], [2, 4]]
-        >>> G.one_extension([0, 1, 2, 3, 4], [0, 3], dim=4, inplace = True)
+        >>> G.one_extension([0, 1, 2, 3, 4], [0, 3], d=4, inplace = True)
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 5], [4, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 5], [4, 5]]
         """  # noqa: E501
-        return self.k_extension(1, vertices, [edge], new_vertex, dim, inplace)
+        return self.k_extension(1, vertices, [edge], new_vertex, d, inplace)
 
     @doc_category("Graph manipulation")
     def k_extension(
@@ -771,11 +771,11 @@ class Graph(nx.Graph):
         vertices: Sequence[Vertex],
         edges: Sequence[Edge],
         new_vertex: Vertex = None,
-        dim: int = 2,
+        d: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`dim-dimensional k-extension <def-k-extension>`.
+        Return a :prf:ref:`d-dimensional k-extension <def-k-extension>`.
 
         Parameters
         ----------
@@ -783,7 +783,7 @@ class Graph(nx.Graph):
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``dim + k`` of them.
+            and there must be ``d + k`` of them.
         edges:
             A list of edges that will be deleted.
             The endvertices of all the edges must be contained
@@ -793,7 +793,7 @@ class Graph(nx.Graph):
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        dim:
+        d:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -817,27 +817,25 @@ class Graph(nx.Graph):
         >>> G = graphs.Complete(5)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4] and edges [[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
-        >>> G.k_extension(2, [0, 1, 2, 3, 4], [[0, 1], [0,2]], dim = 3)
+        >>> G.k_extension(2, [0, 1, 2, 3, 4], [[0, 1], [0,2]], d=3)
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 3], [0, 4], [0, 5], [1, 2], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5]]
         >>> G = graphs.Path(6)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]]
-        >>> G.k_extension(2, [0, 1, 2], [[0, 1], [1,2]], dim = 1, inplace = True)
+        >>> G.k_extension(2, [0, 1, 2], [[0, 1], [1,2]], d=1, inplace = True)
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 6], [1, 6], [2, 3], [2, 6], [3, 4], [4, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 6], [1, 6], [2, 3], [2, 6], [3, 4], [4, 5]]
         """  # noqa: E501
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         for vertex in vertices:
             if vertex not in self.nodes:
                 raise ValueError(f"Vertex {vertex} is not contained in the graph")
-        if len(set(vertices)) != dim + k:
-            raise ValueError(
-                f"List of vertices must contain {dim + k} distinct vertices"
-            )
+        if len(set(vertices)) != d + k:
+            raise ValueError(f"List of vertices must contain {d + k} distinct vertices")
         self._check_edge_list(edges, vertices)
         if len(edges) != k:
             raise ValueError(f"List of edges must contain {k} distinct edges")
@@ -860,17 +858,17 @@ class Graph(nx.Graph):
     def all_k_extensions(
         self,
         k: int,
-        dim: int = 2,
+        d: int = 2,
         only_non_isomorphic: bool = False,
     ) -> Iterable[Graph]:
         """
         Return an iterator over all possible
-        :prf:ref:`dim-dimensional k-extensions <def-k-extension>`.
+        :prf:ref:`d-dimensional k-extensions <def-k-extension>`.
 
         Parameters
         ----------
         k
-        dim
+        d
         only_non_isomorphic:
             If True, only one graph per isomorphism class is included.
 
@@ -888,14 +886,14 @@ class Graph(nx.Graph):
         >>> len(list(graphs.Diamond().all_k_extensions(1, 2, only_non_isomorphic=True)))
         2
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
-        if self.number_of_nodes() < (dim + k):
+        if self.number_of_nodes() < (d + k):
             raise ValueError(
                 f"The number of nodes in the graph needs to be "
-                f"greater or equal than {dim + k}!"
+                f"greater or equal than {d + k}!"
             )
         if self.number_of_edges() < k:
             raise ValueError(
@@ -910,11 +908,11 @@ class Graph(nx.Graph):
                 s.discard(edge[1])
                 w.add(edge[0])
                 w.add(edge[1])
-            if len(w) > (dim + k):
+            if len(w) > (d + k):
                 break
             w = list(w)
-            for vertices in combinations(s, dim + k - len(w)):
-                current = self.k_extension(k, list(vertices) + w, edges, dim=dim)
+            for vertices in combinations(s, d + k - len(w)):
+                current = self.k_extension(k, list(vertices) + w, edges, d=d)
                 if only_non_isomorphic:
                     for other in solutions:
                         if current.is_isomorphic(other):
@@ -927,7 +925,7 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def extension_sequence(
-        self, dim: int = 2, return_solution: bool = False
+        self, d: int = 2, return_solution: bool = False
     ) -> list[Graph] | bool | None:
         """
         Check the existence of a sequence of
@@ -938,9 +936,9 @@ class Graph(nx.Graph):
 
         Parameters
         ----------
-        dim:
+        d:
             The dimension in which the extensions are created.
-            Currently implemented only for ``dim==2``.
+            Currently implemented only for ``d==2``.
         return_solution:
             If False, a boolean value indicating if the graph can be
             created by a sequence of extensions is returned.
@@ -971,11 +969,11 @@ class Graph(nx.Graph):
         >>> G.extension_sequence(return_solution=True)
         [Graph with vertices [2, 3] and edges [[2, 3]], Graph with vertices [0, 2, 3] and edges [[0, 2], [0, 3], [2, 3]], Graph with vertices [0, 1, 2, 3] and edges [[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]]
         """  # noqa: E501
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
-        if not dim == 2:
+        if not d == 2:
             raise NotImplementedError()
         if not self.number_of_edges() == 2 * self.number_of_nodes() - 3:
             return None if return_solution else False
@@ -987,7 +985,7 @@ class Graph(nx.Graph):
         if degrees[0][1] == 2:
             G = deepcopy(self)
             G.remove_node(degrees[0][0])
-            branch = G.extension_sequence(dim, return_solution)
+            branch = G.extension_sequence(d, return_solution)
             if return_solution:
                 if branch is not None:
                     return branch + [self]
@@ -1000,7 +998,7 @@ class Graph(nx.Graph):
             for i, j in [[0, 1], [0, 2], [1, 2]]:
                 if not G.has_edge(neighbors[i], neighbors[j]):
                     G.add_edge(neighbors[i], neighbors[j])
-                    branch = G.extension_sequence(dim, return_solution)
+                    branch = G.extension_sequence(d, return_solution)
                     if return_solution and branch is not None:
                         return branch + [self]
                     elif branch:
@@ -1102,26 +1100,26 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def is_vertex_redundantly_rigid(
-        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`vertex redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`vertex redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         See :meth:`.is_k_vertex_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
-        return self.is_k_vertex_redundantly_rigid(1, dim, combinatorial, prob)
+        return self.is_k_vertex_redundantly_rigid(1, d, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_k_vertex_redundantly_rigid(
-        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`k-vertex redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`k-vertex redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1138,7 +1136,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1160,9 +1158,9 @@ class Graph(nx.Graph):
         False
 
         """  # noqa: E501
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1171,12 +1169,12 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         m = self.number_of_edges()
-        if n >= dim + k + 1 and self.min_degree() < dim + k:
+        if n >= d + k + 1 and self.min_degree() < d + k:
             return False
-        if dim == 1:
+        if d == 1:
             return self.vertex_connectivity() >= k + 1
         if (
-            dim == 2
+            d == 2
             and (
                 # edge bound from :prf:ref:`thm-1-vertex-redundant-edge-bound-dim2`
                 (k == 1 and n >= 5 and m < 2 * n - 1)
@@ -1188,7 +1186,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m < ((k + 2) * n + 1) // 2)
             )
         ) or (
-            dim == 3
+            d == 3
             and (
                 # edge bound from :prf:ref:`thm-3-vertex-redundant-edge-bound-dim3`
                 (k == 3 and n >= 15 and m < 3 * n + 5)
@@ -1206,13 +1204,12 @@ class Graph(nx.Graph):
         # edge bound from :prf:ref:`thm-k-vertex-redundant-edge-bound-general`
         if (
             #
-            n >= dim * dim + dim + k + 1
-            and m
-            < dim * n - math.comb(dim + 1, 2) + k * dim + max(0, k - (dim + 1) // 2)
+            n >= d * d + d + k + 1
+            and m < d * n - math.comb(d + 1, 2) + k * d + max(0, k - (d + 1) // 2)
         ):
             return False
         # edge bound from :prf:ref:`thm-vertex-redundant-edge-bound-general2`
-        if k >= dim + 1 and n >= dim + k + 1 and m < ((dim + k) * n + 1) // 2:
+        if k >= d + 1 and n >= d + k + 1 and m < ((d + k) * n + 1) // 2:
             return False
 
         # in all other cases check by definition
@@ -1220,7 +1217,7 @@ class Graph(nx.Graph):
         for vertex_set in combinations(self.nodes, k):
             adj = [[v, list(G.neighbors(v))] for v in vertex_set]
             G.delete_vertices(vertex_set)
-            if not G.is_rigid(dim, combinatorial, prob):
+            if not G.is_rigid(d, combinatorial, prob):
                 return False
             # add vertices and edges back
             G.add_vertices(vertex_set)
@@ -1231,27 +1228,27 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def is_min_vertex_redundantly_rigid(
-        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
         Check whether the graph is
-        :prf:ref:`minimally vertex redundantly (generically) dim-rigid
+        :prf:ref:`minimally vertex redundantly (generically) d-rigid
         <def-min-redundantly-rigid-graph>`.
 
         See :meth:`.is_min_k_vertex_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
-        return self.is_min_k_vertex_redundantly_rigid(1, dim, combinatorial, prob)
+        return self.is_min_k_vertex_redundantly_rigid(1, d, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_min_k_vertex_redundantly_rigid(
-        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally k-vertex redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`minimally k-vertex redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1263,7 +1260,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1288,9 +1285,9 @@ class Graph(nx.Graph):
 
         """  # noqa: E501
 
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1300,19 +1297,19 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
         # edge bound from :prf:ref:`thm-minimal-k-vertex-redundant-upper-edge-bound`
-        if m > (dim + k) * n - math.comb(dim + k + 1, 2):
+        if m > (d + k) * n - math.comb(d + k + 1, 2):
             return False
         # edge bound from :prf:ref:`thm-minimal-k-vertex-redundant-upper-edge-bound-dim1`
-        if dim == 1:
+        if d == 1:
             if n >= 3 * (k + 1) - 1 and m > (k + 1) * n - (k + 1) * (k + 1):
                 return False
 
-        if not self.is_k_vertex_redundantly_rigid(k, dim, combinatorial, prob):
+        if not self.is_k_vertex_redundantly_rigid(k, d, combinatorial, prob):
             return False
 
         # for the following we need to know that the graph is k-vertex-redundantly rigid
         if (
-            dim == 2
+            d == 2
             and (
                 # edge bound from :prf:ref:`thm-1-vertex-redundant-edge-bound-dim2`
                 (k == 1 and n >= 5 and m == 2 * n - 1)
@@ -1324,7 +1321,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m == ((k + 2) * n + 1) // 2)
             )
         ) or (
-            dim == 3
+            d == 3
             and (
                 # edge bound from :prf:ref:`thm-3-vertex-redundant-edge-bound-dim3`
                 (k == 3 and n >= 15 and m == 3 * n + 5)
@@ -1342,42 +1339,41 @@ class Graph(nx.Graph):
         # edge bound from :prf:ref:`thm-k-vertex-redundant-edge-bound-general`
         if (
             #
-            n >= dim * dim + dim + k + 1
-            and m
-            == dim * n - math.comb(dim + 1, 2) + k * dim + max(0, k - (dim + 1) // 2)
+            n >= d * d + d + k + 1
+            and m == d * n - math.comb(d + 1, 2) + k * d + max(0, k - (d + 1) // 2)
         ):
             return True
         # edge bound from :prf:ref:`thm-vertex-redundant-edge-bound-general2`
-        if k >= dim + 1 and n >= dim + k + 1 and m == ((dim + k) * n + 1) // 2:
+        if k >= d + 1 and n >= d + k + 1 and m == ((d + k) * n + 1) // 2:
             return True
 
         # in all other cases check by definition
         G = deepcopy(self)
         for edge in self.edge_list():
             G.delete_edges([edge])
-            if G.is_k_vertex_redundantly_rigid(k, dim, combinatorial, prob):
+            if G.is_k_vertex_redundantly_rigid(k, d, combinatorial, prob):
                 return False
             G.add_edges([edge])
         return True
 
     @doc_category("Generic rigidity")
     def is_redundantly_rigid(
-        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         See :meth:`.is_k_redundantly_rigid` (using k = 1) for details.
         """
-        return self.is_k_redundantly_rigid(1, dim, combinatorial, prob)
+        return self.is_k_redundantly_rigid(1, d, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_k_redundantly_rigid(
-        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`k-redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`k-redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1393,7 +1389,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1419,9 +1415,9 @@ class Graph(nx.Graph):
         ----
         Improve with pebble games.
         """  # noqa: E501
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1431,15 +1427,15 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
 
-        if m < dim * n - math.comb(dim + 1, 2) + k:
+        if m < d * n - math.comb(d + 1, 2) + k:
             return False
-        if self.min_degree() < dim + k:
+        if self.min_degree() < d + k:
             return False
-        if dim == 1:
+        if d == 1:
             return nx.edge_connectivity(self) >= k + 1
         # edge bounds
         if (
-            dim == 2
+            d == 2
             and (
                 # basic edge bound
                 (k == 1 and m < 2 * n - 2)
@@ -1451,7 +1447,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m < ((k + 2) * n + 1) // 2)
             )
         ) or (
-            dim == 3
+            d == 3
             and (
                 # edge bound from :prf:ref:`thm-2-edge-redundant-edge-bound-dim3`
                 (k == 2 and n >= 14 and m < 3 * n - 4)
@@ -1468,40 +1464,40 @@ class Graph(nx.Graph):
             return False
         # use global rigidity property of :prf:ref:`thm-globally-redundant-3connected`
         # and :prf:ref:`thm-globally-mindeg6-dim2`
-        if dim == 2 and k == 1 and self.vertex_connectivity() >= 6:
+        if d == 2 and k == 1 and self.vertex_connectivity() >= 6:
             return True
 
         # in all other cases check by definition
         G = deepcopy(self)
         for edge_set in combinations(self.edge_list(), k):
             G.delete_edges(edge_set)
-            if not G.is_rigid(dim, combinatorial, prob):
+            if not G.is_rigid(d, combinatorial, prob):
                 return False
             G.add_edges(edge_set)
         return True
 
     @doc_category("Generic rigidity")
     def is_min_redundantly_rigid(
-        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`minimally redundantly (generically) d-rigid
         <def-min-redundantly-rigid-graph>`.
 
         See :meth:`.is_min_k_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
-        return self.is_min_k_redundantly_rigid(1, dim, combinatorial, prob)
+        return self.is_min_k_redundantly_rigid(1, d, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_min_k_redundantly_rigid(
-        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally k-redundantly (generically) dim-rigid
+        Check whether the graph is :prf:ref:`minimally k-redundantly (generically) d-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1512,7 +1508,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1538,9 +1534,9 @@ class Graph(nx.Graph):
 
         """  # noqa: E501
 
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1550,17 +1546,17 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
         # use bound from thm-minimal-1-edge-redundant-upper-edge-bound-dim2
-        if dim == 2:
+        if d == 2:
             if k == 1:
                 if n >= 7 and m > 3 * n - 9:
                     return False
 
-        if not self.is_k_redundantly_rigid(k, dim, combinatorial, prob):
+        if not self.is_k_redundantly_rigid(k, d, combinatorial, prob):
             return False
 
         # for the following we need to know that the graph is k-redundantly rigid
         if (
-            dim == 2
+            d == 2
             and (
                 # basic edge bound
                 (k == 1 and m == 2 * n - 2)
@@ -1572,7 +1568,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m == ((k + 2) * n + 1) // 2)
             )
         ) or (
-            dim == 3
+            d == 3
             and (
                 # edge bound from :prf:ref:`thm-2-edge-redundant-edge-bound-dim3`
                 (k == 2 and n >= 14 and m == 3 * n - 4)
@@ -1592,21 +1588,21 @@ class Graph(nx.Graph):
         G = deepcopy(self)
         for edge in self.edge_list():
             G.delete_edges([edge])
-            if G.is_k_redundantly_rigid(k, dim, combinatorial, prob):
+            if G.is_k_redundantly_rigid(k, d, combinatorial, prob):
                 return False
             G.add_edges([edge])
         return True
 
     @doc_category("Generic rigidity")
     def is_rigid(
-        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`(generically) dim-rigid <def-gen-rigid>`.
+        Check whether the graph is :prf:ref:`(generically) d-rigid <def-gen-rigid>`.
 
         Parameters
         ----------
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used
@@ -1631,14 +1627,14 @@ class Graph(nx.Graph):
 
         Notes
         -----
-         * dim=1: Connectivity
-         * dim=2: Pebble-game/(2,3)-rigidity
-         * dim>=1: Rigidity Matrix if ``combinatorial==False``
+         * d=1: Connectivity
+         * d=2: Pebble-game/(2,3)-rigidity
+         * d>=1: Rigidity Matrix if ``combinatorial==False``
         By default, the graph is in dimension two and a combinatorial check is employed.
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(combinatorial, bool):
             raise TypeError(
@@ -1650,15 +1646,15 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         # edge count, compare :prf:ref:`thm-gen-rigidity-tight`
-        if self.number_of_edges() < dim * n - math.comb(dim + 1, 2):
+        if self.number_of_edges() < d * n - math.comb(d + 1, 2):
             return False
         # small graphs are rigid iff complete :pref:ref:`thm-gen-rigidity-small-complete`
-        elif n <= dim + 1:
+        elif n <= d + 1:
             return self.number_of_edges() == math.comb(n, 2)
 
-        elif dim == 1 and combinatorial:
+        elif d == 1 and combinatorial:
             return nx.is_connected(self)
-        elif dim == 2 and combinatorial:
+        elif d == 2 and combinatorial:
             deficiency = -(2 * n - 3) + self.number_of_edges()
             if deficiency < 0:
                 return False
@@ -1666,34 +1662,34 @@ class Graph(nx.Graph):
                 self._build_pebble_digraph(2, 3)
                 return self._pebble_digraph.number_of_edges() == 2 * n - 3
         elif not combinatorial:
-            N = int((n * dim - math.comb(dim + 1, 2)) / prob)
+            N = int((n * d - math.comb(d + 1, 2)) / prob)
             if N < 1:
                 raise ValueError("The parameter prob is too large.")
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, dim, rand_range=[1, N])
+            F = Framework.Random(self, d, rand_range=[1, N])
             return F.is_inf_rigid()
         else:
             raise ValueError(
                 f"The Dimension for combinatorial computation must be either 1 or 2, "
-                f"but is {dim}"
+                f"but is {d}"
             )
 
     @doc_category("Generic rigidity")
     def is_min_rigid(
         self,
-        dim: int = 2,
+        d: int = 2,
         combinatorial: bool = True,
         use_precomputed_pebble_digraph: bool = False,
         prob: float = 0.0001,
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally (generically) dim-rigid
+        Check whether the graph is :prf:ref:`minimally (generically) d-rigid
         <def-min-rigid-graph>`.
 
         Parameters
         ----------
-        dim:
+        d:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used
@@ -1701,7 +1697,7 @@ class Graph(nx.Graph):
             Otherwise a probabilistic check is used that may give false negatives
             (see :prf:ref:`thm-probabilistic-rigidity-check`).
         use_precomputed_pebble_digraph:
-            Only relevant if ``dim=2`` and ``combinatorial=True``.
+            Only relevant if ``d=2`` and ``combinatorial=True``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1720,13 +1716,13 @@ class Graph(nx.Graph):
 
         Notes
         -----
-         * dim=1: Tree
-         * dim=2: Pebble-game/(2,3)-tight
-         * dim>=1: Probabilistic Rigidity Matrix (maybe symbolic?)
+         * d=1: Tree
+         * d=2: Pebble-game/(2,3)-tight
+         * d>=1: Probabilistic Rigidity Matrix (maybe symbolic?)
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if not isinstance(combinatorial, bool):
             raise TypeError(
@@ -1738,16 +1734,16 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         # edge count, compare :prf:ref:`thm-gen-rigidity-tight`
-        if self.number_of_edges() != dim * n - math.comb(dim + 1, 2):
+        if self.number_of_edges() != d * n - math.comb(d + 1, 2):
             return False
         # small graphs are minimally rigid iff complete
         # :pref:ref:`thm-gen-rigidity-small-complete`
-        elif n <= dim + 1:
+        elif n <= d + 1:
             return self.number_of_edges() == math.comb(n, 2)
 
-        elif dim == 1 and combinatorial:
+        elif d == 1 and combinatorial:
             return nx.is_tree(self)
-        elif dim == 2 and combinatorial:
+        elif d == 2 and combinatorial:
             return self.is_tight(
                 2,
                 3,
@@ -1755,28 +1751,28 @@ class Graph(nx.Graph):
                 use_precomputed_pebble_digraph=use_precomputed_pebble_digraph,
             )
         elif not combinatorial:
-            N = int((n * dim - math.comb(dim + 1, 2)) / prob)
+            N = int((n * d - math.comb(d + 1, 2)) / prob)
             if N < 1:
                 raise ValueError("The parameter prob is too large.")
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, dim, rand_range=[1, N])
+            F = Framework.Random(self, d, rand_range=[1, N])
             return F.is_min_inf_rigid()
         else:
             raise ValueError(
                 f"The dimension for combinatorial computation must be either 1 or 2, "
-                f"but is {dim}"
+                f"but is {d}"
             )
 
     @doc_category("Generic rigidity")
-    def is_globally_rigid(self, dim: int = 2, prob: float = 0.0001) -> bool:
+    def is_globally_rigid(self, d: int = 2, prob: float = 0.0001) -> bool:
         """
-        Check whether the graph is :prf:ref:`globally dim-rigid
+        Check whether the graph is :prf:ref:`globally d-rigid
         <def-globally-rigid-graph>`.
 
         Parameters
         ----------
-        dim: dimension d for which we test whether the graph is globally $d$-rigid
+        d: dimension d for which we test whether the graph is globally $d$-rigid
         prob: probability of getting a wrong `False` answer
 
         Definitions
@@ -1790,26 +1786,26 @@ class Graph(nx.Graph):
         True
         >>> import pyrigi.graphDB as graphs
         >>> J = graphs.ThreePrism()
-        >>> J.is_globally_rigid(dim=3)
+        >>> J.is_globally_rigid(d=3)
         False
         >>> J.is_globally_rigid()
         False
         >>> K = graphs.Complete(6)
         >>> K.is_globally_rigid()
         True
-        >>> K.is_globally_rigid(dim=3)
+        >>> K.is_globally_rigid(d=3)
         True
         >>> C = graphs.CompleteMinusOne(5)
         >>> C.is_globally_rigid()
         True
-        >>> C.is_globally_rigid(dim=3)
+        >>> C.is_globally_rigid(d=3)
         False
 
         Notes
         -----
-         * dim=1: 2-connectivity
-         * dim=2: :prf:ref:`Theorem globally 2-rigid graph <thm-globally-redundant-3connected>`
-         * dim>=3: :prf:ref:`Theorem randomize algorithm <thm-globally-randomize-algorithm>`
+         * d=1: 2-connectivity
+         * d=2: :prf:ref:`Theorem globally 2-rigid graph <thm-globally-redundant-3connected>`
+         * d>=3: :prf:ref:`Theorem randomize algorithm <thm-globally-randomize-algorithm>`
 
         By default, the graph is in dimension 2.
         A complete graph is automatically globally rigid
@@ -1819,20 +1815,20 @@ class Graph(nx.Graph):
         the graph is not generically globally d-rigid, and it will give a wrong answer
         `False` with probability less than `prob`, which is 0.0001 by default.
         """  # noqa: E501
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
 
-        elif dim == 1:
+        elif d == 1:
             if (self.number_of_nodes() == 2 and self.number_of_edges() == 1) or (
                 self.number_of_nodes() == 1 or self.number_of_nodes() == 0
             ):
                 return True
             return self.vertex_connectivity() >= 2
-        elif dim == 2:
+        elif d == 2:
             if (
                 (self.number_of_nodes() == 3 and self.number_of_edges() == 3)
                 or (self.number_of_nodes() == 2 and self.number_of_edges() == 1)
@@ -1843,9 +1839,9 @@ class Graph(nx.Graph):
         else:
             v = self.number_of_nodes()
             e = self.number_of_edges()
-            t = v * dim - math.comb(dim + 1, 2)  # rank of the rigidity matrix
+            t = v * d - math.comb(d + 1, 2)  # rank of the rigidity matrix
             N = int(1 / prob) * v * math.comb(v, 2) + 2
-            if v < dim + 2:
+            if v < d + 2:
                 return self.is_isomorphic(nx.complete_graph(v))
             elif self.is_isomorphic(nx.complete_graph(v)):
                 return True
@@ -1854,14 +1850,14 @@ class Graph(nx.Graph):
             # take a random framework with integer coordinates
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, dim=dim, rand_range=[1, N])
+            F = Framework.Random(self, d=d, rand_range=[1, N])
             w = F.stresses()
             if e == t:
                 omega = zeros(F.rigidity_matrix().rows, 1)
-                return F.stress_matrix(omega).rank() == v - dim - 1
+                return F.stress_matrix(omega).rank() == v - d - 1
             elif w:
                 omega = sum([randint(1, N) * u for u in w], w[0])
-                return F.stress_matrix(omega).rank() == v - dim - 1
+                return F.stress_matrix(omega).rank() == v - d - 1
             else:
                 raise ValueError(
                     "There must be at least one stress but none was found."
@@ -1869,19 +1865,19 @@ class Graph(nx.Graph):
 
     @doc_category("Partially implemented")
     def is_Rd_dependent(
-        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is dependent in the d-rigidity matroid.
 
         Notes
         -----
-         * dim=1: Graphic Matroid
-         * dim=2: not (2,3)-sparse
-         * dim>=1: Compute the rank of the rigidity matrix and compare with edge count
+         * d=1: Graphic Matroid
+         * d=2: not (2,3)-sparse
+         * d>=1: Compute the rank of the rigidity matrix and compare with edge count
 
         use_precomputed_pebble_digraph:
-            Only relevant if ``dim=2``.
+            Only relevant if ``d=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1892,24 +1888,24 @@ class Graph(nx.Graph):
          Add unit tests
         """
         return not self.is_Rd_independent(
-            dim, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
+            d, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
         )
 
     @doc_category("Partially implemented")
     def is_Rd_independent(
-        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is independent in the d-rigidity matroid.
 
         Notes
         -----
-         * dim=1: Graphic Matroid
-         * dim=2: (2,3)-sparse
-         * dim>=1: Compute the rank of the rigidity matrix and compare with edge count
+         * d=1: Graphic Matroid
+         * d=2: (2,3)-sparse
+         * d>=1: Compute the rank of the rigidity matrix and compare with edge count
 
         use_precomputed_pebble_digraph:
-            Only relevant if ``dim=2``.
+            Only relevant if ``d=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1919,16 +1915,16 @@ class Graph(nx.Graph):
         -----
          Add unit tests
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
-        if dim == 1:
+        if d == 1:
             return len(self.cycle_basis()) == 0
 
-        if dim == 2:
+        if d == 2:
             self.is_sparse(
                 2, 3, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
             )
@@ -1937,21 +1933,21 @@ class Graph(nx.Graph):
 
     @doc_category("Partially implemented")
     def is_Rd_circuit(
-        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is a circuit in the d-rigidity matroid.
 
         Notes
         -----
-         * dim=1: Graphic Matroid
-         * dim=2: It is not sparse, but remove any edge and it becomes sparse
+         * d=1: Graphic Matroid
+         * d=2: It is not sparse, but remove any edge and it becomes sparse
                   Fundamental circuit is the whole graph
          * Not combinatorially:
-         * dim>=1: Dependent + Remove every edge and compute the rigidity matrix' rank
+         * d>=1: Dependent + Remove every edge and compute the rigidity matrix' rank
 
          use_precomputed_pebble_digraph:
-            Only relevant if ``dim=2``.
+            Only relevant if ``d=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1962,13 +1958,13 @@ class Graph(nx.Graph):
          Add unit tests,
          make computation of ``remaining_edge`` more robust
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
-        if dim == 1:
+        if d == 1:
             if not nx.is_connected(self):
                 return False
 
@@ -1978,7 +1974,7 @@ class Graph(nx.Graph):
                     return False
             return True
 
-        if dim == 2:
+        if d == 2:
             # get max sparse sugraph and check the fundamental circuit of
             # the one last edge
             if self.number_of_edges() != 2 * self.number_of_nodes() - 2:
@@ -2007,26 +2003,26 @@ class Graph(nx.Graph):
         raise NotImplementedError()
 
     @doc_category("Waiting for implementation")
-    def is_Rd_closed(self, dim: int = 2) -> bool:
+    def is_Rd_closed(self, d: int = 2) -> bool:
         """
         Checks whether the graph's edge set is closed in the d-rigidity matroid.
 
         Notes
         -----
-         * dim=1: Graphic Matroid
-         * dim=2: ??
-         * dim>=1: Adding any edge does not increase the rigidity matrix rank
+         * d=1: Graphic Matroid
+         * d=2: ??
+         * d>=1: Adding any edge does not increase the rigidity matrix rank
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
         raise NotImplementedError()
 
     @doc_category("Generic rigidity")
-    def rigid_components(self, dim: int = 2) -> Sequence[Sequence[Vertex]]:
+    def rigid_components(self, d: int = 2) -> Sequence[Sequence[Vertex]]:
         """
         List the vertex sets inducing vertex-maximal rigid subgraphs.
 
@@ -2052,9 +2048,9 @@ class Graph(nx.Graph):
         >>> G.rigid_components()
         [[0, 5], [2, 3], [0, 1, 2], [3, 4, 5]]
         """
-        if not isinstance(dim, int) or dim < 1:
+        if not isinstance(d, int) or d < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {dim}!"
+                f"The dimension needs to be a positive integer, but is {d}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
@@ -2062,16 +2058,16 @@ class Graph(nx.Graph):
         if not nx.is_connected(self):
             res = []
             for comp in nx.connected_components(self):
-                res += self.subgraph(comp).rigid_components(dim)
+                res += self.subgraph(comp).rigid_components(d)
             return res
 
-        if self.is_rigid(dim, combinatorial=(dim < 3)):
+        if self.is_rigid(d, combinatorial=(d < 3)):
             return [list(self)]
         rigid_subgraphs = {
             tuple(vertex_subset): True
             for r in range(2, self.number_of_nodes() - 1)
             for vertex_subset in combinations(self.nodes, r)
-            if self.subgraph(vertex_subset).is_rigid(dim, combinatorial=(dim < 3))
+            if self.subgraph(vertex_subset).is_rigid(d, combinatorial=(d < 3))
         }
 
         sorted_rigid_subgraphs = sorted(
@@ -2301,7 +2297,7 @@ class Graph(nx.Graph):
         return Matrix(row_list)
 
     @doc_category("Other")
-    def random_framework(self, dim: int = 2, rand_range: int | Sequence[int] = None):
+    def random_framework(self, d: int = 2, rand_range: int | Sequence[int] = None):
         # the return type is intentionally omitted to avoid circular import
         """
         Return framework with random realization.
@@ -2310,7 +2306,7 @@ class Graph(nx.Graph):
         """
         from pyrigi.framework import Framework
 
-        return Framework.Random(self, dim, rand_range)
+        return Framework.Random(self, d, rand_range)
 
     @doc_category("Other")
     def to_tikz(

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -1084,15 +1084,15 @@ class Graph(nx.Graph):
             if self.number_of_nodes() == 2 and self.number_of_edges() == 1:
                 return 1
 
-            n = self.to_int()
+            graph_int = self.to_int()
             if count_reflection:
                 fac = 1
             else:
                 fac = 2
             if spherical_realizations:
-                return lnumber.lnumbers(n) // fac
+                return lnumber.lnumbers(graph_int) // fac
             else:
-                return lnumber.lnumber(n) // fac
+                return lnumber.lnumber(graph_int) // fac
         except ImportError:
             raise ImportError(
                 "For counting the number of realizations, "
@@ -1627,7 +1627,7 @@ class Graph(nx.Graph):
 
         TODO
         ----
-        Pebble game algorithm for d=2.
+        Pebble game algorithm for dim=2.
 
         Notes
         -----
@@ -1841,27 +1841,27 @@ class Graph(nx.Graph):
                 return True
             return self.is_redundantly_rigid() and self.vertex_connectivity() >= 3
         else:
-            v = self.number_of_nodes()
-            e = self.number_of_edges()
-            t = v * dim - math.comb(dim + 1, 2)  # rank of the rigidity matrix
-            N = int(1 / prob) * v * math.comb(v, 2) + 2
-            if v < dim + 2:
-                return self.is_isomorphic(nx.complete_graph(v))
-            elif self.is_isomorphic(nx.complete_graph(v)):
+            n = self.number_of_nodes()
+            m = self.number_of_edges()
+            t = n * dim - math.comb(dim + 1, 2)  # rank of the rigidity matrix
+            N = int(1 / prob) * n * math.comb(n, 2) + 2
+            if n < dim + 2:
+                return self.is_isomorphic(nx.complete_graph(n))
+            elif self.is_isomorphic(nx.complete_graph(n)):
                 return True
-            if e < t:
+            if m < t:
                 return False
             # take a random framework with integer coordinates
             from pyrigi.framework import Framework
 
             F = Framework.Random(self, dim=dim, rand_range=[1, N])
-            w = F.stresses()
-            if e == t:
+            stresses = F.stresses()
+            if m == t:
                 omega = zeros(F.rigidity_matrix().rows, 1)
-                return F.stress_matrix(omega).rank() == v - dim - 1
-            elif w:
-                omega = sum([randint(1, N) * u for u in w], w[0])
-                return F.stress_matrix(omega).rank() == v - dim - 1
+                return F.stress_matrix(omega).rank() == n - dim - 1
+            elif stresses:
+                omega = sum([randint(1, N) * w for w in stresses], stresses[0])
+                return F.stress_matrix(omega).rank() == n - dim - 1
             else:
                 raise ValueError(
                     "There must be at least one stress but none was found."
@@ -2118,19 +2118,19 @@ class Graph(nx.Graph):
         if not nx.is_connected(self):
             return 0
 
-        V = self.number_of_nodes()
-        E = self.number_of_edges()
+        n = self.number_of_nodes()
+        m = self.number_of_edges()
         # Only the complete graph is rigid in all dimensions
-        if E == V * (V - 1) / 2:
+        if m == n * (n - 1) / 2:
             return oo
-        # Find the largest d such that d*(d+1)/2 - d*V + E = 0
+        # Find the largest d such that d*(d+1)/2 - d*n + m = 0
         max_dim = int(
-            math.floor(0.5 * (2 * V + math.sqrt((1 - 2 * V) ** 2 - 8 * E) - 1))
+            math.floor(0.5 * (2 * n + math.sqrt((1 - 2 * n) ** 2 - 8 * m) - 1))
         )
 
-        for d in range(max_dim, 0, -1):
-            if self.is_rigid(d, combinatorial=False):
-                return d
+        for dim in range(max_dim, 0, -1):
+            if self.is_rigid(dim, combinatorial=False):
+                return dim
 
     @doc_category("General graph theoretical properties")
     def is_isomorphic(self, graph: Graph) -> bool:
@@ -2222,7 +2222,7 @@ class Graph(nx.Graph):
         L = "".join(["0" for _ in range(int(n * (n - 1) / 2) - len(L))]) + L
         for i in range(n):
             rows.append(
-                [0 for _ in range(i + 1)] + [int(k) for k in L[s : s + (n - i - 1)]]
+                [0 for _ in range(i + 1)] + [int(j) for j in L[s : s + (n - i - 1)]]
             )
             s += n - i - 1
         adjMatrix = Matrix(rows)

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -665,23 +665,23 @@ class Graph(nx.Graph):
         self,
         vertices: Sequence[Vertex],
         new_vertex: Vertex = None,
-        d: int = 2,
+        dim: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`d-dimensional 0-extension <def-k-extension>`.
+        Return a :prf:ref:`dim-dimensional 0-extension <def-k-extension>`.
 
         Parameters
         ----------
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``d`` of them.
+            and there must be ``dim`` of them.
         new_vertex:
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        d:
+        dim:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -700,12 +700,12 @@ class Graph(nx.Graph):
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [2, 5]]
         >>> G
         Graph with vertices [0, 1, 2] and edges [[0, 1], [0, 2], [1, 2]]
-        >>> G.zero_extension([0, 1, 2], 5, d=3, inplace=True);
+        >>> G.zero_extension([0, 1, 2], 5, dim=3, inplace=True);
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 5] and edges [[0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5]]
         """  # noqa: E501
-        return self.k_extension(0, vertices, [], new_vertex, d, inplace)
+        return self.k_extension(0, vertices, [], new_vertex, dim, inplace)
 
     @doc_category("Graph manipulation")
     def one_extension(
@@ -713,18 +713,18 @@ class Graph(nx.Graph):
         vertices: Sequence[Vertex],
         edge: Edge,
         new_vertex: Vertex = None,
-        d: int = 2,
+        dim: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`d-dimensional 1-extension <def-k-extension>`.
+        Return a :prf:ref:`dim-dimensional 1-extension <def-k-extension>`.
 
         Parameters
         ----------
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``d + 1`` of them.
+            and there must be ``dim + 1`` of them.
         edge:
             An edge with endvertices from the list ``vertices`` that will be deleted.
             The edge must be contained in the graph.
@@ -732,7 +732,7 @@ class Graph(nx.Graph):
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        d:
+        dim:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -752,17 +752,17 @@ class Graph(nx.Graph):
         >>> G = graphs.ThreePrism()
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]
-        >>> G.one_extension([0, 1], [0, 1], d=1)
+        >>> G.one_extension([0, 1], [0, 1], dim=1)
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 2], [0, 3], [0, 6], [1, 2], [1, 4], [1, 6], [2, 5], [3, 4], [3, 5], [4, 5]]
         >>> G = graphs.CompleteBipartite(3, 2)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4] and edges [[0, 3], [0, 4], [1, 3], [1, 4], [2, 3], [2, 4]]
-        >>> G.one_extension([0, 1, 2, 3, 4], [0, 3], d=4, inplace = True)
+        >>> G.one_extension([0, 1, 2, 3, 4], [0, 3], dim=4, inplace = True)
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 5], [4, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 5], [4, 5]]
         """  # noqa: E501
-        return self.k_extension(1, vertices, [edge], new_vertex, d, inplace)
+        return self.k_extension(1, vertices, [edge], new_vertex, dim, inplace)
 
     @doc_category("Graph manipulation")
     def k_extension(
@@ -771,11 +771,11 @@ class Graph(nx.Graph):
         vertices: Sequence[Vertex],
         edges: Sequence[Edge],
         new_vertex: Vertex = None,
-        d: int = 2,
+        dim: int = 2,
         inplace: bool = False,
     ) -> Graph:
         """
-        Return a :prf:ref:`d-dimensional k-extension <def-k-extension>`.
+        Return a :prf:ref:`dim-dimensional k-extension <def-k-extension>`.
 
         Parameters
         ----------
@@ -783,7 +783,7 @@ class Graph(nx.Graph):
         vertices:
             A new vertex will be connected to these vertices.
             All the vertices must be contained in the graph
-            and there must be ``d + k`` of them.
+            and there must be ``dim + k`` of them.
         edges:
             A list of edges that will be deleted.
             The endvertices of all the edges must be contained
@@ -793,7 +793,7 @@ class Graph(nx.Graph):
             Newly added vertex will be named according to this parameter.
             If None, the name will be set as the lowest possible integer value
             greater or equal than the number of nodes.
-        d:
+        dim:
             The dimension in which the k-extension is created.
         inplace:
             If True, the graph will be modified,
@@ -817,25 +817,27 @@ class Graph(nx.Graph):
         >>> G = graphs.Complete(5)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4] and edges [[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
-        >>> G.k_extension(2, [0, 1, 2, 3, 4], [[0, 1], [0,2]], d=3)
+        >>> G.k_extension(2, [0, 1, 2, 3, 4], [[0, 1], [0,2]], dim = 3)
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 3], [0, 4], [0, 5], [1, 2], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5]]
         >>> G = graphs.Path(6)
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5] and edges [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]]
-        >>> G.k_extension(2, [0, 1, 2], [[0, 1], [1,2]], d=1, inplace = True)
+        >>> G.k_extension(2, [0, 1, 2], [[0, 1], [1,2]], dim = 1, inplace = True)
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 6], [1, 6], [2, 3], [2, 6], [3, 4], [4, 5]]
         >>> G
         Graph with vertices [0, 1, 2, 3, 4, 5, 6] and edges [[0, 6], [1, 6], [2, 3], [2, 6], [3, 4], [4, 5]]
         """  # noqa: E501
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         for vertex in vertices:
             if vertex not in self.nodes:
                 raise ValueError(f"Vertex {vertex} is not contained in the graph")
-        if len(set(vertices)) != d + k:
-            raise ValueError(f"List of vertices must contain {d + k} distinct vertices")
+        if len(set(vertices)) != dim + k:
+            raise ValueError(
+                f"List of vertices must contain {dim + k} distinct vertices"
+            )
         self._check_edge_list(edges, vertices)
         if len(edges) != k:
             raise ValueError(f"List of edges must contain {k} distinct edges")
@@ -858,17 +860,17 @@ class Graph(nx.Graph):
     def all_k_extensions(
         self,
         k: int,
-        d: int = 2,
+        dim: int = 2,
         only_non_isomorphic: bool = False,
     ) -> Iterable[Graph]:
         """
         Return an iterator over all possible
-        :prf:ref:`d-dimensional k-extensions <def-k-extension>`.
+        :prf:ref:`dim-dimensional k-extensions <def-k-extension>`.
 
         Parameters
         ----------
         k
-        d
+        dim
         only_non_isomorphic:
             If True, only one graph per isomorphism class is included.
 
@@ -886,14 +888,14 @@ class Graph(nx.Graph):
         >>> len(list(graphs.Diamond().all_k_extensions(1, 2, only_non_isomorphic=True)))
         2
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
-        if self.number_of_nodes() < (d + k):
+        if self.number_of_nodes() < (dim + k):
             raise ValueError(
                 f"The number of nodes in the graph needs to be "
-                f"greater or equal than {d + k}!"
+                f"greater or equal than {dim + k}!"
             )
         if self.number_of_edges() < k:
             raise ValueError(
@@ -908,11 +910,11 @@ class Graph(nx.Graph):
                 s.discard(edge[1])
                 w.add(edge[0])
                 w.add(edge[1])
-            if len(w) > (d + k):
+            if len(w) > (dim + k):
                 break
             w = list(w)
-            for vertices in combinations(s, d + k - len(w)):
-                current = self.k_extension(k, list(vertices) + w, edges, d=d)
+            for vertices in combinations(s, dim + k - len(w)):
+                current = self.k_extension(k, list(vertices) + w, edges, dim=dim)
                 if only_non_isomorphic:
                     for other in solutions:
                         if current.is_isomorphic(other):
@@ -925,7 +927,7 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def extension_sequence(
-        self, d: int = 2, return_solution: bool = False
+        self, dim: int = 2, return_solution: bool = False
     ) -> list[Graph] | bool | None:
         """
         Check the existence of a sequence of
@@ -936,9 +938,9 @@ class Graph(nx.Graph):
 
         Parameters
         ----------
-        d:
+        dim:
             The dimension in which the extensions are created.
-            Currently implemented only for ``d==2``.
+            Currently implemented only for ``dim==2``.
         return_solution:
             If False, a boolean value indicating if the graph can be
             created by a sequence of extensions is returned.
@@ -969,11 +971,11 @@ class Graph(nx.Graph):
         >>> G.extension_sequence(return_solution=True)
         [Graph with vertices [2, 3] and edges [[2, 3]], Graph with vertices [0, 2, 3] and edges [[0, 2], [0, 3], [2, 3]], Graph with vertices [0, 1, 2, 3] and edges [[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]]
         """  # noqa: E501
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
-        if not d == 2:
+        if not dim == 2:
             raise NotImplementedError()
         if not self.number_of_edges() == 2 * self.number_of_nodes() - 3:
             return None if return_solution else False
@@ -985,7 +987,7 @@ class Graph(nx.Graph):
         if degrees[0][1] == 2:
             G = deepcopy(self)
             G.remove_node(degrees[0][0])
-            branch = G.extension_sequence(d, return_solution)
+            branch = G.extension_sequence(dim, return_solution)
             if return_solution:
                 if branch is not None:
                     return branch + [self]
@@ -998,7 +1000,7 @@ class Graph(nx.Graph):
             for i, j in [[0, 1], [0, 2], [1, 2]]:
                 if not G.has_edge(neighbors[i], neighbors[j]):
                     G.add_edge(neighbors[i], neighbors[j])
-                    branch = G.extension_sequence(d, return_solution)
+                    branch = G.extension_sequence(dim, return_solution)
                     if return_solution and branch is not None:
                         return branch + [self]
                     elif branch:
@@ -1100,26 +1102,26 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def is_vertex_redundantly_rigid(
-        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`vertex redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`vertex redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         See :meth:`.is_k_vertex_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
-        return self.is_k_vertex_redundantly_rigid(1, d, combinatorial, prob)
+        return self.is_k_vertex_redundantly_rigid(1, dim, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_k_vertex_redundantly_rigid(
-        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`k-vertex redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`k-vertex redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1136,7 +1138,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1158,9 +1160,9 @@ class Graph(nx.Graph):
         False
 
         """  # noqa: E501
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1169,12 +1171,12 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         m = self.number_of_edges()
-        if n >= d + k + 1 and self.min_degree() < d + k:
+        if n >= dim + k + 1 and self.min_degree() < dim + k:
             return False
-        if d == 1:
+        if dim == 1:
             return self.vertex_connectivity() >= k + 1
         if (
-            d == 2
+            dim == 2
             and (
                 # edge bound from :prf:ref:`thm-1-vertex-redundant-edge-bound-dim2`
                 (k == 1 and n >= 5 and m < 2 * n - 1)
@@ -1186,7 +1188,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m < ((k + 2) * n + 1) // 2)
             )
         ) or (
-            d == 3
+            dim == 3
             and (
                 # edge bound from :prf:ref:`thm-3-vertex-redundant-edge-bound-dim3`
                 (k == 3 and n >= 15 and m < 3 * n + 5)
@@ -1204,12 +1206,13 @@ class Graph(nx.Graph):
         # edge bound from :prf:ref:`thm-k-vertex-redundant-edge-bound-general`
         if (
             #
-            n >= d * d + d + k + 1
-            and m < d * n - math.comb(d + 1, 2) + k * d + max(0, k - (d + 1) // 2)
+            n >= dim * dim + dim + k + 1
+            and m
+            < dim * n - math.comb(dim + 1, 2) + k * dim + max(0, k - (dim + 1) // 2)
         ):
             return False
         # edge bound from :prf:ref:`thm-vertex-redundant-edge-bound-general2`
-        if k >= d + 1 and n >= d + k + 1 and m < ((d + k) * n + 1) // 2:
+        if k >= dim + 1 and n >= dim + k + 1 and m < ((dim + k) * n + 1) // 2:
             return False
 
         # in all other cases check by definition
@@ -1217,7 +1220,7 @@ class Graph(nx.Graph):
         for vertex_set in combinations(self.nodes, k):
             adj = [[v, list(G.neighbors(v))] for v in vertex_set]
             G.delete_vertices(vertex_set)
-            if not G.is_rigid(d, combinatorial, prob):
+            if not G.is_rigid(dim, combinatorial, prob):
                 return False
             # add vertices and edges back
             G.add_vertices(vertex_set)
@@ -1228,27 +1231,27 @@ class Graph(nx.Graph):
 
     @doc_category("Generic rigidity")
     def is_min_vertex_redundantly_rigid(
-        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
         Check whether the graph is
-        :prf:ref:`minimally vertex redundantly (generically) d-rigid
+        :prf:ref:`minimally vertex redundantly (generically) dim-rigid
         <def-min-redundantly-rigid-graph>`.
 
         See :meth:`.is_min_k_vertex_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
-        return self.is_min_k_vertex_redundantly_rigid(1, d, combinatorial, prob)
+        return self.is_min_k_vertex_redundantly_rigid(1, dim, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_min_k_vertex_redundantly_rigid(
-        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally k-vertex redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`minimally k-vertex redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1260,7 +1263,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1285,9 +1288,9 @@ class Graph(nx.Graph):
 
         """  # noqa: E501
 
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1297,19 +1300,19 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
         # edge bound from :prf:ref:`thm-minimal-k-vertex-redundant-upper-edge-bound`
-        if m > (d + k) * n - math.comb(d + k + 1, 2):
+        if m > (dim + k) * n - math.comb(dim + k + 1, 2):
             return False
         # edge bound from :prf:ref:`thm-minimal-k-vertex-redundant-upper-edge-bound-dim1`
-        if d == 1:
+        if dim == 1:
             if n >= 3 * (k + 1) - 1 and m > (k + 1) * n - (k + 1) * (k + 1):
                 return False
 
-        if not self.is_k_vertex_redundantly_rigid(k, d, combinatorial, prob):
+        if not self.is_k_vertex_redundantly_rigid(k, dim, combinatorial, prob):
             return False
 
         # for the following we need to know that the graph is k-vertex-redundantly rigid
         if (
-            d == 2
+            dim == 2
             and (
                 # edge bound from :prf:ref:`thm-1-vertex-redundant-edge-bound-dim2`
                 (k == 1 and n >= 5 and m == 2 * n - 1)
@@ -1321,7 +1324,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m == ((k + 2) * n + 1) // 2)
             )
         ) or (
-            d == 3
+            dim == 3
             and (
                 # edge bound from :prf:ref:`thm-3-vertex-redundant-edge-bound-dim3`
                 (k == 3 and n >= 15 and m == 3 * n + 5)
@@ -1339,41 +1342,42 @@ class Graph(nx.Graph):
         # edge bound from :prf:ref:`thm-k-vertex-redundant-edge-bound-general`
         if (
             #
-            n >= d * d + d + k + 1
-            and m == d * n - math.comb(d + 1, 2) + k * d + max(0, k - (d + 1) // 2)
+            n >= dim * dim + dim + k + 1
+            and m
+            == dim * n - math.comb(dim + 1, 2) + k * dim + max(0, k - (dim + 1) // 2)
         ):
             return True
         # edge bound from :prf:ref:`thm-vertex-redundant-edge-bound-general2`
-        if k >= d + 1 and n >= d + k + 1 and m == ((d + k) * n + 1) // 2:
+        if k >= dim + 1 and n >= dim + k + 1 and m == ((dim + k) * n + 1) // 2:
             return True
 
         # in all other cases check by definition
         G = deepcopy(self)
         for edge in self.edge_list():
             G.delete_edges([edge])
-            if G.is_k_vertex_redundantly_rigid(k, d, combinatorial, prob):
+            if G.is_k_vertex_redundantly_rigid(k, dim, combinatorial, prob):
                 return False
             G.add_edges([edge])
         return True
 
     @doc_category("Generic rigidity")
     def is_redundantly_rigid(
-        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         See :meth:`.is_k_redundantly_rigid` (using k = 1) for details.
         """
-        return self.is_k_redundantly_rigid(1, d, combinatorial, prob)
+        return self.is_k_redundantly_rigid(1, dim, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_k_redundantly_rigid(
-        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`k-redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`k-redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1389,7 +1393,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1415,9 +1419,9 @@ class Graph(nx.Graph):
         ----
         Improve with pebble games.
         """  # noqa: E501
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1427,15 +1431,15 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
 
-        if m < d * n - math.comb(d + 1, 2) + k:
+        if m < dim * n - math.comb(dim + 1, 2) + k:
             return False
-        if self.min_degree() < d + k:
+        if self.min_degree() < dim + k:
             return False
-        if d == 1:
+        if dim == 1:
             return nx.edge_connectivity(self) >= k + 1
         # edge bounds
         if (
-            d == 2
+            dim == 2
             and (
                 # basic edge bound
                 (k == 1 and m < 2 * n - 2)
@@ -1447,7 +1451,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m < ((k + 2) * n + 1) // 2)
             )
         ) or (
-            d == 3
+            dim == 3
             and (
                 # edge bound from :prf:ref:`thm-2-edge-redundant-edge-bound-dim3`
                 (k == 2 and n >= 14 and m < 3 * n - 4)
@@ -1464,40 +1468,40 @@ class Graph(nx.Graph):
             return False
         # use global rigidity property of :prf:ref:`thm-globally-redundant-3connected`
         # and :prf:ref:`thm-globally-mindeg6-dim2`
-        if d == 2 and k == 1 and self.vertex_connectivity() >= 6:
+        if dim == 2 and k == 1 and self.vertex_connectivity() >= 6:
             return True
 
         # in all other cases check by definition
         G = deepcopy(self)
         for edge_set in combinations(self.edge_list(), k):
             G.delete_edges(edge_set)
-            if not G.is_rigid(d, combinatorial, prob):
+            if not G.is_rigid(dim, combinatorial, prob):
                 return False
             G.add_edges(edge_set)
         return True
 
     @doc_category("Generic rigidity")
     def is_min_redundantly_rigid(
-        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`minimally redundantly (generically) dim-rigid
         <def-min-redundantly-rigid-graph>`.
 
         See :meth:`.is_min_k_redundantly_rigid` (using k = 1) for details.
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
-        return self.is_min_k_redundantly_rigid(1, d, combinatorial, prob)
+        return self.is_min_k_redundantly_rigid(1, dim, combinatorial, prob)
 
     @doc_category("Generic rigidity")
     def is_min_k_redundantly_rigid(
-        self, k: int, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, k: int, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally k-redundantly (generically) d-rigid
+        Check whether the graph is :prf:ref:`minimally k-redundantly (generically) dim-rigid
         <def-redundantly-rigid-graph>`.
 
         Preliminary checks from
@@ -1508,7 +1512,7 @@ class Graph(nx.Graph):
         ----------
         k:
             level of redundancy
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used in rigidity checking.
@@ -1534,9 +1538,9 @@ class Graph(nx.Graph):
 
         """  # noqa: E501
 
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(k, int):
             raise TypeError(f"k needs to be a nonnegative integer, but is {k}!")
@@ -1546,17 +1550,17 @@ class Graph(nx.Graph):
         n = self.number_of_nodes()
         m = self.number_of_edges()
         # use bound from thm-minimal-1-edge-redundant-upper-edge-bound-dim2
-        if d == 2:
+        if dim == 2:
             if k == 1:
                 if n >= 7 and m > 3 * n - 9:
                     return False
 
-        if not self.is_k_redundantly_rigid(k, d, combinatorial, prob):
+        if not self.is_k_redundantly_rigid(k, dim, combinatorial, prob):
             return False
 
         # for the following we need to know that the graph is k-redundantly rigid
         if (
-            d == 2
+            dim == 2
             and (
                 # basic edge bound
                 (k == 1 and m == 2 * n - 2)
@@ -1568,7 +1572,7 @@ class Graph(nx.Graph):
                 (k >= 3 and n >= 6 * (k + 1) + 23 and m == ((k + 2) * n + 1) // 2)
             )
         ) or (
-            d == 3
+            dim == 3
             and (
                 # edge bound from :prf:ref:`thm-2-edge-redundant-edge-bound-dim3`
                 (k == 2 and n >= 14 and m == 3 * n - 4)
@@ -1588,21 +1592,21 @@ class Graph(nx.Graph):
         G = deepcopy(self)
         for edge in self.edge_list():
             G.delete_edges([edge])
-            if G.is_k_redundantly_rigid(k, d, combinatorial, prob):
+            if G.is_k_redundantly_rigid(k, dim, combinatorial, prob):
                 return False
             G.add_edges([edge])
         return True
 
     @doc_category("Generic rigidity")
     def is_rigid(
-        self, d: int = 2, combinatorial: bool = True, prob: float = 0.0001
+        self, dim: int = 2, combinatorial: bool = True, prob: float = 0.0001
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`(generically) d-rigid <def-gen-rigid>`.
+        Check whether the graph is :prf:ref:`(generically) dim-rigid <def-gen-rigid>`.
 
         Parameters
         ----------
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used
@@ -1627,14 +1631,14 @@ class Graph(nx.Graph):
 
         Notes
         -----
-         * d=1: Connectivity
-         * d=2: Pebble-game/(2,3)-rigidity
-         * d>=1: Rigidity Matrix if ``combinatorial==False``
+         * dim=1: Connectivity
+         * dim=2: Pebble-game/(2,3)-rigidity
+         * dim>=1: Rigidity Matrix if ``combinatorial==False``
         By default, the graph is in dimension two and a combinatorial check is employed.
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(combinatorial, bool):
             raise TypeError(
@@ -1646,15 +1650,15 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         # edge count, compare :prf:ref:`thm-gen-rigidity-tight`
-        if self.number_of_edges() < d * n - math.comb(d + 1, 2):
+        if self.number_of_edges() < dim * n - math.comb(dim + 1, 2):
             return False
         # small graphs are rigid iff complete :pref:ref:`thm-gen-rigidity-small-complete`
-        elif n <= d + 1:
+        elif n <= dim + 1:
             return self.number_of_edges() == math.comb(n, 2)
 
-        elif d == 1 and combinatorial:
+        elif dim == 1 and combinatorial:
             return nx.is_connected(self)
-        elif d == 2 and combinatorial:
+        elif dim == 2 and combinatorial:
             deficiency = -(2 * n - 3) + self.number_of_edges()
             if deficiency < 0:
                 return False
@@ -1662,34 +1666,34 @@ class Graph(nx.Graph):
                 self._build_pebble_digraph(2, 3)
                 return self._pebble_digraph.number_of_edges() == 2 * n - 3
         elif not combinatorial:
-            N = int((n * d - math.comb(d + 1, 2)) / prob)
+            N = int((n * dim - math.comb(dim + 1, 2)) / prob)
             if N < 1:
                 raise ValueError("The parameter prob is too large.")
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, d, rand_range=[1, N])
+            F = Framework.Random(self, dim, rand_range=[1, N])
             return F.is_inf_rigid()
         else:
             raise ValueError(
                 f"The Dimension for combinatorial computation must be either 1 or 2, "
-                f"but is {d}"
+                f"but is {dim}"
             )
 
     @doc_category("Generic rigidity")
     def is_min_rigid(
         self,
-        d: int = 2,
+        dim: int = 2,
         combinatorial: bool = True,
         use_precomputed_pebble_digraph: bool = False,
         prob: float = 0.0001,
     ) -> bool:
         """
-        Check whether the graph is :prf:ref:`minimally (generically) d-rigid
+        Check whether the graph is :prf:ref:`minimally (generically) dim-rigid
         <def-min-rigid-graph>`.
 
         Parameters
         ----------
-        d:
+        dim:
             dimension
         combinatorial:
             determines whether a combinatinatorial algorithm shall be used
@@ -1697,7 +1701,7 @@ class Graph(nx.Graph):
             Otherwise a probabilistic check is used that may give false negatives
             (see :prf:ref:`thm-probabilistic-rigidity-check`).
         use_precomputed_pebble_digraph:
-            Only relevant if ``d=2`` and ``combinatorial=True``.
+            Only relevant if ``dim=2`` and ``combinatorial=True``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1716,13 +1720,13 @@ class Graph(nx.Graph):
 
         Notes
         -----
-         * d=1: Tree
-         * d=2: Pebble-game/(2,3)-tight
-         * d>=1: Probabilistic Rigidity Matrix (maybe symbolic?)
+         * dim=1: Tree
+         * dim=2: Pebble-game/(2,3)-tight
+         * dim>=1: Probabilistic Rigidity Matrix (maybe symbolic?)
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if not isinstance(combinatorial, bool):
             raise TypeError(
@@ -1734,16 +1738,16 @@ class Graph(nx.Graph):
 
         n = self.number_of_nodes()
         # edge count, compare :prf:ref:`thm-gen-rigidity-tight`
-        if self.number_of_edges() != d * n - math.comb(d + 1, 2):
+        if self.number_of_edges() != dim * n - math.comb(dim + 1, 2):
             return False
         # small graphs are minimally rigid iff complete
         # :pref:ref:`thm-gen-rigidity-small-complete`
-        elif n <= d + 1:
+        elif n <= dim + 1:
             return self.number_of_edges() == math.comb(n, 2)
 
-        elif d == 1 and combinatorial:
+        elif dim == 1 and combinatorial:
             return nx.is_tree(self)
-        elif d == 2 and combinatorial:
+        elif dim == 2 and combinatorial:
             return self.is_tight(
                 2,
                 3,
@@ -1751,28 +1755,28 @@ class Graph(nx.Graph):
                 use_precomputed_pebble_digraph=use_precomputed_pebble_digraph,
             )
         elif not combinatorial:
-            N = int((n * d - math.comb(d + 1, 2)) / prob)
+            N = int((n * dim - math.comb(dim + 1, 2)) / prob)
             if N < 1:
                 raise ValueError("The parameter prob is too large.")
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, d, rand_range=[1, N])
+            F = Framework.Random(self, dim, rand_range=[1, N])
             return F.is_min_inf_rigid()
         else:
             raise ValueError(
                 f"The dimension for combinatorial computation must be either 1 or 2, "
-                f"but is {d}"
+                f"but is {dim}"
             )
 
     @doc_category("Generic rigidity")
-    def is_globally_rigid(self, d: int = 2, prob: float = 0.0001) -> bool:
+    def is_globally_rigid(self, dim: int = 2, prob: float = 0.0001) -> bool:
         """
-        Check whether the graph is :prf:ref:`globally d-rigid
+        Check whether the graph is :prf:ref:`globally dim-rigid
         <def-globally-rigid-graph>`.
 
         Parameters
         ----------
-        d: dimension d for which we test whether the graph is globally $d$-rigid
+        dim: dimension d for which we test whether the graph is globally $d$-rigid
         prob: probability of getting a wrong `False` answer
 
         Definitions
@@ -1786,26 +1790,26 @@ class Graph(nx.Graph):
         True
         >>> import pyrigi.graphDB as graphs
         >>> J = graphs.ThreePrism()
-        >>> J.is_globally_rigid(d=3)
+        >>> J.is_globally_rigid(dim=3)
         False
         >>> J.is_globally_rigid()
         False
         >>> K = graphs.Complete(6)
         >>> K.is_globally_rigid()
         True
-        >>> K.is_globally_rigid(d=3)
+        >>> K.is_globally_rigid(dim=3)
         True
         >>> C = graphs.CompleteMinusOne(5)
         >>> C.is_globally_rigid()
         True
-        >>> C.is_globally_rigid(d=3)
+        >>> C.is_globally_rigid(dim=3)
         False
 
         Notes
         -----
-         * d=1: 2-connectivity
-         * d=2: :prf:ref:`Theorem globally 2-rigid graph <thm-globally-redundant-3connected>`
-         * d>=3: :prf:ref:`Theorem randomize algorithm <thm-globally-randomize-algorithm>`
+         * dim=1: 2-connectivity
+         * dim=2: :prf:ref:`Theorem globally 2-rigid graph <thm-globally-redundant-3connected>`
+         * dim>=3: :prf:ref:`Theorem randomize algorithm <thm-globally-randomize-algorithm>`
 
         By default, the graph is in dimension 2.
         A complete graph is automatically globally rigid
@@ -1815,20 +1819,20 @@ class Graph(nx.Graph):
         the graph is not generically globally d-rigid, and it will give a wrong answer
         `False` with probability less than `prob`, which is 0.0001 by default.
         """  # noqa: E501
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
 
-        elif d == 1:
+        elif dim == 1:
             if (self.number_of_nodes() == 2 and self.number_of_edges() == 1) or (
                 self.number_of_nodes() == 1 or self.number_of_nodes() == 0
             ):
                 return True
             return self.vertex_connectivity() >= 2
-        elif d == 2:
+        elif dim == 2:
             if (
                 (self.number_of_nodes() == 3 and self.number_of_edges() == 3)
                 or (self.number_of_nodes() == 2 and self.number_of_edges() == 1)
@@ -1839,9 +1843,9 @@ class Graph(nx.Graph):
         else:
             v = self.number_of_nodes()
             e = self.number_of_edges()
-            t = v * d - math.comb(d + 1, 2)  # rank of the rigidity matrix
+            t = v * dim - math.comb(dim + 1, 2)  # rank of the rigidity matrix
             N = int(1 / prob) * v * math.comb(v, 2) + 2
-            if v < d + 2:
+            if v < dim + 2:
                 return self.is_isomorphic(nx.complete_graph(v))
             elif self.is_isomorphic(nx.complete_graph(v)):
                 return True
@@ -1850,14 +1854,14 @@ class Graph(nx.Graph):
             # take a random framework with integer coordinates
             from pyrigi.framework import Framework
 
-            F = Framework.Random(self, d=d, rand_range=[1, N])
+            F = Framework.Random(self, dim=dim, rand_range=[1, N])
             w = F.stresses()
             if e == t:
                 omega = zeros(F.rigidity_matrix().rows, 1)
-                return F.stress_matrix(omega).rank() == v - d - 1
+                return F.stress_matrix(omega).rank() == v - dim - 1
             elif w:
                 omega = sum([randint(1, N) * u for u in w], w[0])
-                return F.stress_matrix(omega).rank() == v - d - 1
+                return F.stress_matrix(omega).rank() == v - dim - 1
             else:
                 raise ValueError(
                     "There must be at least one stress but none was found."
@@ -1865,19 +1869,19 @@ class Graph(nx.Graph):
 
     @doc_category("Partially implemented")
     def is_Rd_dependent(
-        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is dependent in the d-rigidity matroid.
 
         Notes
         -----
-         * d=1: Graphic Matroid
-         * d=2: not (2,3)-sparse
-         * d>=1: Compute the rank of the rigidity matrix and compare with edge count
+         * dim=1: Graphic Matroid
+         * dim=2: not (2,3)-sparse
+         * dim>=1: Compute the rank of the rigidity matrix and compare with edge count
 
         use_precomputed_pebble_digraph:
-            Only relevant if ``d=2``.
+            Only relevant if ``dim=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1888,24 +1892,24 @@ class Graph(nx.Graph):
          Add unit tests
         """
         return not self.is_Rd_independent(
-            d, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
+            dim, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
         )
 
     @doc_category("Partially implemented")
     def is_Rd_independent(
-        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is independent in the d-rigidity matroid.
 
         Notes
         -----
-         * d=1: Graphic Matroid
-         * d=2: (2,3)-sparse
-         * d>=1: Compute the rank of the rigidity matrix and compare with edge count
+         * dim=1: Graphic Matroid
+         * dim=2: (2,3)-sparse
+         * dim>=1: Compute the rank of the rigidity matrix and compare with edge count
 
         use_precomputed_pebble_digraph:
-            Only relevant if ``d=2``.
+            Only relevant if ``dim=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1915,16 +1919,16 @@ class Graph(nx.Graph):
         -----
          Add unit tests
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
-        if d == 1:
+        if dim == 1:
             return len(self.cycle_basis()) == 0
 
-        if d == 2:
+        if dim == 2:
             self.is_sparse(
                 2, 3, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
             )
@@ -1933,21 +1937,21 @@ class Graph(nx.Graph):
 
     @doc_category("Partially implemented")
     def is_Rd_circuit(
-        self, d: int = 2, use_precomputed_pebble_digraph: bool = False
+        self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
         Checks whether the graph's edge set is a circuit in the d-rigidity matroid.
 
         Notes
         -----
-         * d=1: Graphic Matroid
-         * d=2: It is not sparse, but remove any edge and it becomes sparse
+         * dim=1: Graphic Matroid
+         * dim=2: It is not sparse, but remove any edge and it becomes sparse
                   Fundamental circuit is the whole graph
          * Not combinatorially:
-         * d>=1: Dependent + Remove every edge and compute the rigidity matrix' rank
+         * dim>=1: Dependent + Remove every edge and compute the rigidity matrix' rank
 
          use_precomputed_pebble_digraph:
-            Only relevant if ``d=2``.
+            Only relevant if ``dim=2``.
             If ``True``, the pebble digraph present in the cache is used.
             If ``False``, recompute the pebble digraph.
             Use ``True`` only if you are certain that the pebble game digraph
@@ -1958,13 +1962,13 @@ class Graph(nx.Graph):
          Add unit tests,
          make computation of ``remaining_edge`` more robust
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
-        if d == 1:
+        if dim == 1:
             if not nx.is_connected(self):
                 return False
 
@@ -1974,7 +1978,7 @@ class Graph(nx.Graph):
                     return False
             return True
 
-        if d == 2:
+        if dim == 2:
             # get max sparse sugraph and check the fundamental circuit of
             # the one last edge
             if self.number_of_edges() != 2 * self.number_of_nodes() - 2:
@@ -2003,26 +2007,26 @@ class Graph(nx.Graph):
         raise NotImplementedError()
 
     @doc_category("Waiting for implementation")
-    def is_Rd_closed(self, d: int = 2) -> bool:
+    def is_Rd_closed(self, dim: int = 2) -> bool:
         """
         Checks whether the graph's edge set is closed in the d-rigidity matroid.
 
         Notes
         -----
-         * d=1: Graphic Matroid
-         * d=2: ??
-         * d>=1: Adding any edge does not increase the rigidity matrix rank
+         * dim=1: Graphic Matroid
+         * dim=2: ??
+         * dim>=1: Adding any edge does not increase the rigidity matrix rank
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
         raise NotImplementedError()
 
     @doc_category("Generic rigidity")
-    def rigid_components(self, d: int = 2) -> Sequence[Sequence[Vertex]]:
+    def rigid_components(self, dim: int = 2) -> Sequence[Sequence[Vertex]]:
         """
         List the vertex sets inducing vertex-maximal rigid subgraphs.
 
@@ -2048,9 +2052,9 @@ class Graph(nx.Graph):
         >>> G.rigid_components()
         [[0, 5], [2, 3], [0, 1, 2], [3, 4, 5]]
         """
-        if not isinstance(d, int) or d < 1:
+        if not isinstance(dim, int) or dim < 1:
             raise TypeError(
-                f"The dimension needs to be a positive integer, but is {d}!"
+                f"The dimension needs to be a positive integer, but is {dim}!"
             )
         if nx.number_of_selfloops(self) > 0:
             raise LoopError()
@@ -2058,16 +2062,16 @@ class Graph(nx.Graph):
         if not nx.is_connected(self):
             res = []
             for comp in nx.connected_components(self):
-                res += self.subgraph(comp).rigid_components(d)
+                res += self.subgraph(comp).rigid_components(dim)
             return res
 
-        if self.is_rigid(d, combinatorial=(d < 3)):
+        if self.is_rigid(dim, combinatorial=(dim < 3)):
             return [list(self)]
         rigid_subgraphs = {
             tuple(vertex_subset): True
             for r in range(2, self.number_of_nodes() - 1)
             for vertex_subset in combinations(self.nodes, r)
-            if self.subgraph(vertex_subset).is_rigid(d, combinatorial=(d < 3))
+            if self.subgraph(vertex_subset).is_rigid(dim, combinatorial=(dim < 3))
         }
 
         sorted_rigid_subgraphs = sorted(
@@ -2297,7 +2301,7 @@ class Graph(nx.Graph):
         return Matrix(row_list)
 
     @doc_category("Other")
-    def random_framework(self, d: int = 2, rand_range: int | Sequence[int] = None):
+    def random_framework(self, dim: int = 2, rand_range: int | Sequence[int] = None):
         # the return type is intentionally omitted to avoid circular import
         """
         Return framework with random realization.
@@ -2306,7 +2310,7 @@ class Graph(nx.Graph):
         """
         from pyrigi.framework import Framework
 
-        return Framework.Random(self, d, rand_range)
+        return Framework.Random(self, dim, rand_range)
 
     @doc_category("Other")
     def to_tikz(

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from itertools import combinations
-from typing import List, Dict, Union, Iterable
+from typing import Iterable
 
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -160,7 +160,7 @@ class Graph(nx.Graph):
     @classmethod
     @doc_category("Class methods")
     def from_vertices_and_edges(
-        cls, vertices: List[Vertex], edges: List[Edge]
+        cls, vertices: Sequence[Vertex], edges: Sequence[Edge]
     ) -> Graph:
         """
         Create a graph from a list of vertices and edges.
@@ -187,7 +187,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def from_vertices(cls, vertices: List[Vertex]) -> Graph:
+    def from_vertices(cls, vertices: Sequence[Vertex]) -> Graph:
         """
         Create a graph with no edges from a list of vertices.
 
@@ -202,7 +202,7 @@ class Graph(nx.Graph):
 
     @classmethod
     @doc_category("Class methods")
-    def CompleteOnVertices(cls, vertices: List[Vertex]) -> Graph:
+    def CompleteOnVertices(cls, vertices: Sequence[Vertex]) -> Graph:
         """
         Generate a complete graph on ``vertices``.
 
@@ -220,10 +220,7 @@ class Graph(nx.Graph):
         """
         Check if an input_pair is a pair of distinct vertices of the graph.
         """
-        if (
-            not (isinstance(input_pair, tuple) or isinstance(input_pair, list))
-            or not len(input_pair) == 2
-        ):
+        if not isinstance(input_pair, list | tuple) or not len(input_pair) == 2:
             raise TypeError(
                 f"The input {input_pair} must be a tuple or list of length 2."
             )
@@ -234,7 +231,7 @@ class Graph(nx.Graph):
         if input_pair[0] == input_pair[1]:
             raise LoopError("The input {input_pair} must be two distinct vertices.")
 
-    def _check_edge(self, edge: Edge, vertices: List[Vertex] = None) -> None:
+    def _check_edge(self, edge: Edge, vertices: Sequence[Vertex] = None) -> None:
         """
         Check if the given input is an edge of the graph with endvertices in vertices.
 
@@ -255,7 +252,7 @@ class Graph(nx.Graph):
             raise ValueError(f"Edge {edge} is not contained in the graph.")
 
     def _check_edge_list(
-        self, edges: List[Edge], vertices: List[Vertex] = None
+        self, edges: Sequence[Edge], vertices: Sequence[Vertex] = None
     ) -> None:
         """
         Apply _check_edge to all edges in a list.
@@ -271,7 +268,7 @@ class Graph(nx.Graph):
         for edge in edges:
             self._check_edge(edge, vertices)
 
-    def _check_edge_format_list(self, pairs: List[Edge]) -> None:
+    def _check_edge_format_list(self, pairs: Sequence[Edge]) -> None:
         """
         Apply _check_edge_format to all pairs in a list.
 
@@ -284,10 +281,12 @@ class Graph(nx.Graph):
             self._check_edge_format(pair)
 
     @doc_category("Attribute getters")
-    def vertex_list(self) -> List[Vertex]:
+    def vertex_list(self) -> list[Vertex]:
         """
         Return the list of vertices.
 
+        Notes
+        -----
         The output is sorted if possible,
         otherwise, the internal order is used instead.
 
@@ -311,10 +310,12 @@ class Graph(nx.Graph):
             return list(self.nodes)
 
     @doc_category("Attribute getters")
-    def edge_list(self) -> List[Edge]:
+    def edge_list(self) -> list[Edge]:
         """
         Return the list of edges.
 
+        Notes
+        -----
         The output is sorted if possible,
         otherwise, the internal order is used instead.
 
@@ -347,7 +348,7 @@ class Graph(nx.Graph):
         self.remove_node(vertex)
 
     @doc_category("Graph manipulation")
-    def delete_vertices(self, vertices: List[Vertex]) -> None:
+    def delete_vertices(self, vertices: Sequence[Vertex]) -> None:
         """Alias for :meth:`networkx.Graph.remove_nodes_from`."""
         self.remove_nodes_from(vertices)
 
@@ -357,7 +358,7 @@ class Graph(nx.Graph):
         self.remove_edge(*edge)
 
     @doc_category("Graph manipulation")
-    def delete_edges(self, edges: List[Edge]) -> None:
+    def delete_edges(self, edges: Sequence[Edge]) -> None:
         """Alias for :meth:`networkx.Graph.remove_edges_from`."""
         self.remove_edges_from(edges)
 
@@ -367,12 +368,12 @@ class Graph(nx.Graph):
         self.add_node(vertex)
 
     @doc_category("Graph manipulation")
-    def add_vertices(self, vertices: List[Vertex]) -> None:
+    def add_vertices(self, vertices: Sequence[Vertex]) -> None:
         """Alias for :meth:`networkx.Graph.add_nodes_from`."""
         self.add_nodes_from(vertices)
 
     @doc_category("Graph manipulation")
-    def add_edges(self, edges: List[Edge]) -> None:
+    def add_edges(self, edges: Sequence[Edge]) -> None:
         """Alias for :meth:`networkx.Graph.add_edges_from`."""
         self.add_edges_from(edges)
 
@@ -387,7 +388,7 @@ class Graph(nx.Graph):
         return nx.node_connectivity(self)
 
     @doc_category("General graph theoretical properties")
-    def degree_sequence(self, vertex_order: List[Vertex] = None) -> List[int]:
+    def degree_sequence(self, vertex_order: Sequence[Vertex] = None) -> list[int]:
         """
         Return a list of degrees of the vertices of the graph.
 
@@ -662,7 +663,7 @@ class Graph(nx.Graph):
     @doc_category("Graph manipulation")
     def zero_extension(
         self,
-        vertices: List[Vertex],
+        vertices: Sequence[Vertex],
         new_vertex: Vertex = None,
         dim: int = 2,
         inplace: bool = False,
@@ -709,7 +710,7 @@ class Graph(nx.Graph):
     @doc_category("Graph manipulation")
     def one_extension(
         self,
-        vertices: List[Vertex],
+        vertices: Sequence[Vertex],
         edge: Edge,
         new_vertex: Vertex = None,
         dim: int = 2,
@@ -767,8 +768,8 @@ class Graph(nx.Graph):
     def k_extension(
         self,
         k: int,
-        vertices: List[Vertex],
-        edges: List[Edge],
+        vertices: Sequence[Vertex],
+        edges: Sequence[Edge],
         new_vertex: Vertex = None,
         dim: int = 2,
         inplace: bool = False,
@@ -927,7 +928,7 @@ class Graph(nx.Graph):
     @doc_category("Generic rigidity")
     def extension_sequence(
         self, dim: int = 2, return_solution: bool = False
-    ) -> Union[List[Graph], bool]:
+    ) -> list[Graph] | bool | None:
         """
         Check the existence of a sequence of
         :prf:ref:`0 and 1-extensions <def-k-extension>`.
@@ -1871,6 +1872,8 @@ class Graph(nx.Graph):
         self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
+        Checks whether the graph's edge set is dependent in the d-rigidity matroid.
+
         Notes
         -----
          * dim=1: Graphic Matroid
@@ -1897,6 +1900,8 @@ class Graph(nx.Graph):
         self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
+        Checks whether the graph's edge set is independent in the d-rigidity matroid.
+
         Notes
         -----
          * dim=1: Graphic Matroid
@@ -1935,6 +1940,8 @@ class Graph(nx.Graph):
         self, dim: int = 2, use_precomputed_pebble_digraph: bool = False
     ) -> bool:
         """
+        Checks whether the graph's edge set is a circuit in the d-rigidity matroid.
+
         Notes
         -----
          * dim=1: Graphic Matroid
@@ -2002,6 +2009,8 @@ class Graph(nx.Graph):
     @doc_category("Waiting for implementation")
     def is_Rd_closed(self, dim: int = 2) -> bool:
         """
+        Checks whether the graph's edge set is closed in the d-rigidity matroid.
+
         Notes
         -----
          * dim=1: Graphic Matroid
@@ -2017,7 +2026,7 @@ class Graph(nx.Graph):
         raise NotImplementedError()
 
     @doc_category("Generic rigidity")
-    def rigid_components(self, dim: int = 2) -> List[List[Vertex]]:
+    def rigid_components(self, dim: int = 2) -> Sequence[Sequence[Vertex]]:
         """
         List the vertex sets inducing vertex-maximal rigid subgraphs.
 
@@ -2142,7 +2151,7 @@ class Graph(nx.Graph):
         return nx.is_isomorphic(self, graph)
 
     @doc_category("Other")
-    def to_int(self, vertex_order: List[Vertex] = None) -> int:
+    def to_int(self, vertex_order: Sequence[Vertex] = None) -> int:
         r"""
         Return the integer representation of the graph.
 
@@ -2249,7 +2258,7 @@ class Graph(nx.Graph):
         return Graph.from_vertices_and_edges(vertices, edges)
 
     @doc_category("General graph theoretical properties")
-    def adjacency_matrix(self, vertex_order: List[Vertex] = None) -> Matrix:
+    def adjacency_matrix(self, vertex_order: Sequence[Vertex] = None) -> Matrix:
         """
         Return the adjacency matrix of the graph.
 
@@ -2292,7 +2301,7 @@ class Graph(nx.Graph):
         return Matrix(row_list)
 
     @doc_category("Other")
-    def random_framework(self, dim: int = 2, rand_range: Union(int, List[int]) = None):
+    def random_framework(self, dim: int = 2, rand_range: int | Sequence[int] = None):
         # the return type is intentionally omitted to avoid circular import
         """
         Return framework with random realization.
@@ -2308,8 +2317,8 @@ class Graph(nx.Graph):
         self,
         layout_type: str = "spring",
         placement: dict[Vertex, Point] = None,
-        vertex_style: Union(str, dict[str : list[Vertex]]) = "gvertex",
-        edge_style: Union(str, dict[str : list[Edge]]) = "edge",
+        vertex_style: str | list[str : Sequence[Vertex]] = "gvertex",
+        edge_style: str | dict[str : Sequence[Edge]] = "edge",
         label_style: str = "labelsty",
         figure_opts: str = "",
         vertex_in_labels: bool = False,
@@ -2521,8 +2530,8 @@ class Graph(nx.Graph):
         )
 
     def _resolve_edge_colors(
-        self, edge_color: str | List[List[Edge]] | Dict[str : List[Edge]]
-    ) -> tuple[List, List]:
+        self, edge_color: str | Sequence[Sequence[Edge]] | dict[str : Sequence[Edge]]
+    ) -> tuple[list, list]:
         """
         Return the lists of colors and edges in the format for plotting.
         """
@@ -2641,7 +2650,7 @@ class Graph(nx.Graph):
         )
 
     @doc_category("Other")
-    def layout(self, layout_type: str = "spring") -> Dict[Vertex, Point]:
+    def layout(self, layout_type: str = "spring") -> dict[Vertex, Point]:
         """
         Generate a placement of the vertices.
 
@@ -2671,19 +2680,23 @@ class Graph(nx.Graph):
     @doc_category("Other")
     def plot(
         self,
-        placement: Dict[Vertex, Point] = None,
-        inf_flex: Dict[Vertex, Sequence[Coordinate]] = None,
+        placement: dict[Vertex, Point] = None,
+        inf_flex: dict[Vertex, Sequence[Coordinate]] = None,
         layout: str = "spring",
         vertex_size: int = 300,
         vertex_color: str = "#4169E1",
         vertex_shape: str = "o",
         vertex_labels: bool = True,
         edge_width: float = 2.5,
-        edge_color: str | List[List[Edge]] | Dict[str : List[Edge]] = "black",
+        edge_color: (
+            str | Sequence[Sequence[Edge]] | dict[str : Sequence[Edge]]
+        ) = "black",
         edge_style: str = "solid",
         flex_width: float = 2.5,
         flex_length: float = 0.15,
-        flex_color: str | List[List[Edge]] | Dict[str : List[Edge]] = "limegreen",
+        flex_color: (
+            str | Sequence[Sequence[Edge]] | dict[str : Sequence[Edge]]
+        ) = "limegreen",
         flex_style: str = "solid",
         flex_arrowsize: int = 20,
         font_color: str = "whitesmoke",
@@ -2704,7 +2717,7 @@ class Graph(nx.Graph):
             then it is generated depending on parameter ``layout``.
         inf_flex:
             It is possible to plot an infinitesimal flex alongside the
-            realization of your graph. It is specified as a ``Dict`` of
+            realization of your graph. It is specified as a ``dict`` of
             flexes.
         layout:
             The possibilities are ``spring`` (default), ``circular``,

--- a/pyrigi/graphDB.py
+++ b/pyrigi/graphDB.py
@@ -62,14 +62,14 @@ def CubeWithDiagonal() -> Graph:
     )
 
 
-def DoubleBanana(d: int = 3, t: int = 2) -> Graph:
+def DoubleBanana(dim: int = 3, t: int = 2) -> Graph:
     r"""
     Return the d-dimensional double banana graph.
 
     Parameters
     ----------
-    d: integer, must be at least 3
-    t: integer, must be 2 <= t <= d-1
+    dim: integer, must be at least 3
+    t: integer, must be 2 <= t <= dim-1
 
     Definitions
     -----
@@ -79,20 +79,22 @@ def DoubleBanana(d: int = 3, t: int = 2) -> Graph:
     --------
     >>> DoubleBanana()
     Graph with vertices [0, 1, 2, 3, 4, 5, 6, 7] and edges [[0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [2, 3], [2, 4], [3, 4], [5, 6], [5, 7], [6, 7]]
-    >>> DoubleBanana(d = 4)
+    >>> DoubleBanana(dim = 4)
     Graph with vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] and edges [[0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [1, 8], [1, 9], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5], [6, 7], [6, 8], [6, 9], [7, 8], [7, 9], [8, 9]]
     """  # noqa: E501
-    if d < 3:
-        raise ValueError(f"The parameter d must be at least 3, instead it is {d}.")
-    if t < 2 or t > d - 1:
-        raise ValueError(f"The parameter t must be 2 <= t <= {d-1}, instead it is {t}.")
-    r = (d + 2) - t
+    if dim < 3:
+        raise ValueError(f"The parameter d must be at least 3, instead it is {dim}.")
+    if t < 2 or t > dim - 1:
+        raise ValueError(
+            f"The parameter t must be 2 <= t <= {dim-1}, instead it is {t}."
+        )
+    r = (dim + 2) - t
     K = Complete(t)
     K1 = K.copy()
-    for i in range(t, d + 2):
+    for i in range(t, dim + 2):
         K1.add_edges([[i, v] for v in K1.nodes])
     K2 = K.copy()
-    for i in range(d + 2, d + 2 + r):
+    for i in range(dim + 2, dim + 2 + r):
         K2.add_edges([[i, v] for v in K2.nodes])
     return K1.sum_t(K2, [0, 1], t)
 

--- a/pyrigi/graphDB.py
+++ b/pyrigi/graphDB.py
@@ -62,14 +62,14 @@ def CubeWithDiagonal() -> Graph:
     )
 
 
-def DoubleBanana(dim: int = 3, t: int = 2) -> Graph:
+def DoubleBanana(d: int = 3, t: int = 2) -> Graph:
     r"""
     Return the d-dimensional double banana graph.
 
     Parameters
     ----------
-    dim: integer, must be at least 3
-    t: integer, must be 2 <= t <= dim-1
+    d: integer, must be at least 3
+    t: integer, must be 2 <= t <= d-1
 
     Definitions
     -----
@@ -79,22 +79,20 @@ def DoubleBanana(dim: int = 3, t: int = 2) -> Graph:
     --------
     >>> DoubleBanana()
     Graph with vertices [0, 1, 2, 3, 4, 5, 6, 7] and edges [[0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [2, 3], [2, 4], [3, 4], [5, 6], [5, 7], [6, 7]]
-    >>> DoubleBanana(dim = 4)
+    >>> DoubleBanana(d = 4)
     Graph with vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] and edges [[0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7], [0, 8], [0, 9], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [1, 8], [1, 9], [2, 3], [2, 4], [2, 5], [3, 4], [3, 5], [4, 5], [6, 7], [6, 8], [6, 9], [7, 8], [7, 9], [8, 9]]
     """  # noqa: E501
-    if dim < 3:
-        raise ValueError(f"The parameter d must be at least 3, instead it is {dim}.")
-    if t < 2 or t > dim - 1:
-        raise ValueError(
-            f"The parameter t must be 2 <= t <= {dim-1}, instead it is {t}."
-        )
-    r = (dim + 2) - t
+    if d < 3:
+        raise ValueError(f"The parameter d must be at least 3, instead it is {d}.")
+    if t < 2 or t > d - 1:
+        raise ValueError(f"The parameter t must be 2 <= t <= {d-1}, instead it is {t}.")
+    r = (d + 2) - t
     K = Complete(t)
     K1 = K.copy()
-    for i in range(t, dim + 2):
+    for i in range(t, d + 2):
         K1.add_edges([[i, v] for v in K1.nodes])
     K2 = K.copy()
-    for i in range(dim + 2, dim + 2 + r):
+    for i in range(d + 2, d + 2 + r):
         K2.add_edges([[i, v] for v in K2.nodes])
     return K1.sum_t(K2, [0, 1], t)
 

--- a/pyrigi/graph_drawer.py
+++ b/pyrigi/graph_drawer.py
@@ -188,7 +188,7 @@ class GraphDrawer(object):
         with self._out:
             print("press and hold ctrl key to move vertices around with mouse.")
 
-    def _handle_event(self, event):
+    def _handle_event(self, event) -> None:
         """
         This function handles keyboard events and double click event using ``ipyevents``.
         """
@@ -200,7 +200,7 @@ class GraphDrawer(object):
             x, y = event["relativeX"], event["relativeY"]
             self._handle_dblclick(x, y)
 
-    def _assign_pos(self, x, y, place):
+    def _assign_pos(self, x, y, place) -> None:
         """
         This function converts layout positions which are between -1 and 1
         to canvas positions according to the chosen place by scaling.
@@ -256,7 +256,7 @@ class GraphDrawer(object):
                 int(height * 3 / 4 + y * (height / 4 - r - 3)),
             ]
 
-    def _set_graph(self, graph: Graph, layout_type, place):
+    def _set_graph(self, graph: Graph, layout_type, place) -> None:
         vertex_map = {}
         for vertex in graph:
             if not isinstance(vertex, int) or vertex < 0:
@@ -334,7 +334,7 @@ class GraphDrawer(object):
                 self._mcanvas[2].clear()
                 self._redraw_graph()
 
-    def _handle_mouse_down(self, x, y):
+    def _handle_mouse_down(self, x, y) -> None:
         """
         Handler for :meth:`ipycanvas.MultiCanvas.on_mouse_down`.
 
@@ -360,7 +360,7 @@ class GraphDrawer(object):
 
         self._mouse_down = True
 
-    def _handle_mouse_up(self, x, y):
+    def _handle_mouse_up(self, x, y) -> None:
         """
         Handler for :meth:`ipycanvas.MultiCanvas.on_mouse_up`.
 
@@ -395,7 +395,7 @@ class GraphDrawer(object):
             self._redraw_graph()
         self._mouse_down = False
 
-    def _handle_dblclick(self, x, y):
+    def _handle_dblclick(self, x, y) -> None:
         """
         This function is the handler for double click event (using ipyevents).
 
@@ -413,7 +413,7 @@ class GraphDrawer(object):
             self._redraw_graph()
         self._selected_vertex = None
 
-    def _handle_mouse_move(self, x, y):
+    def _handle_mouse_move(self, x, y) -> None:
         """
         Handler for :meth:`ipycanvas.MultiCanvas.on_mouse_move`.
 
@@ -449,11 +449,15 @@ class GraphDrawer(object):
                 self._mcanvas[3].clear()
                 self._redraw_vertex(vertex)
 
-    def _handle_mouse_out(self, x, y):
+    def _handle_mouse_out(self, x, y) -> None:
         """
         Handler for :meth:`ipycanvas.MultiCanvas.on_mouse_out`.
 
         It determines what to do when the mouse leaves multicanvas.
+
+        TODO
+        ----
+        x,y are unused
         """
         self._selected_vertex = None
         self._vertexmove_on = False
@@ -474,7 +478,7 @@ class GraphDrawer(object):
                 return vertex
         return None
 
-    def _collided_edge(self, x, y):
+    def _collided_edge(self, x, y) -> None:
         """
         Return the edge containing the point (x,y) on canvas.
         """
@@ -490,7 +494,7 @@ class GraphDrawer(object):
                 return edge
         return None
 
-    def _point_distance_to_segment(self, a, b, p):
+    def _point_distance_to_segment(self, a, b, p) -> None:
         """
         Return the distance between point 'p' and line segment given by 'a' and 'b'.
         """
@@ -504,7 +508,7 @@ class GraphDrawer(object):
         closest_point = a + t * ab
         return np.linalg.norm(p - closest_point)
 
-    def _redraw_vertex(self, vertex):
+    def _redraw_vertex(self, vertex) -> None:
         """
         Update the position of a specific vertex and its incident edges
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -50,7 +50,7 @@ def generate_category_tables(cls, tabs, cat_order=[], include_all=False) -> str:
     return ("\n" + indent).join(res.splitlines())
 
 
-def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
+def generate_two_orthonormal_vectors(d: int, random_seed: int = None) -> Matrix:
     """
     Generate two random numeric orthonormal vectors in the given dimension.
 
@@ -58,7 +58,7 @@ def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matri
 
     Parameters
     ----------
-    dim:
+    d:
         The dimension in which the vectors are generated.
     random_seed:
         Seed for generating random vectors.
@@ -68,10 +68,10 @@ def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matri
     if random_seed is not None:
         np.random.seed(random_seed)
 
-    matrix = np.random.randn(dim, 2)
+    matrix = np.random.randn(d, 2)
 
     # for numerical stability regenerate some elements
-    tmp = np.random.randint(0, dim - 1)
+    tmp = np.random.randint(0, d - 1)
     while abs(matrix[tmp, 1]) < 1e-6:
         matrix[tmp, 1] = np.random.randn(1, 1)
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -3,8 +3,7 @@ Module for miscellaneous functions.
 """
 
 import math
-from pyrigi.data_type import Coordinate, point_to_vector
-from typing import List, Sequence
+from pyrigi.data_type import Sequence, Coordinate, point_to_vector
 from sympy import Matrix
 import numpy as np
 from math import isclose, log10
@@ -135,7 +134,7 @@ def is_zero_vector(
 
 def eval_sympy_vector(
     vector: Sequence[Coordinate], tolerance: float = 1e-9
-) -> List[float]:
+) -> list[float]:
     """
     Converts a sympy vector to a (numerical) list of floats.
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -50,7 +50,7 @@ def generate_category_tables(cls, tabs, cat_order=[], include_all=False) -> str:
     return ("\n" + indent).join(res.splitlines())
 
 
-def generate_two_orthonormal_vectors(d: int, random_seed: int = None) -> Matrix:
+def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
     """
     Generate two random numeric orthonormal vectors in the given dimension.
 
@@ -58,7 +58,7 @@ def generate_two_orthonormal_vectors(d: int, random_seed: int = None) -> Matrix:
 
     Parameters
     ----------
-    d:
+    dim:
         The dimension in which the vectors are generated.
     random_seed:
         Seed for generating random vectors.
@@ -68,10 +68,10 @@ def generate_two_orthonormal_vectors(d: int, random_seed: int = None) -> Matrix:
     if random_seed is not None:
         np.random.seed(random_seed)
 
-    matrix = np.random.randn(d, 2)
+    matrix = np.random.randn(dim, 2)
 
     # for numerical stability regenerate some elements
-    tmp = np.random.randint(0, d - 1)
+    tmp = np.random.randint(0, dim - 1)
     while abs(matrix[tmp, 1]) < 1e-6:
         matrix[tmp, 1] = np.random.randn(1, 1)
 

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -3,7 +3,7 @@ This module contains functionality related to motions (continuous flexes).
 """
 
 from pyrigi.graph import Graph
-from pyrigi.data_type import Vertex, Point
+from pyrigi.data_type import Vertex, Point, Sequence
 from sympy import simplify
 from pyrigi.misc import point_to_vector
 import numpy as np
@@ -104,7 +104,7 @@ class ParametricMotion(Motion):
             raise ValueError("The given interval is not a valid interval!")
 
         symbols = set()
-        for vertex, position in self._parametrization.items():
+        for _, position in self._parametrization.items():
             for coord in position:
                 for symbol in coord.free_symbols:
                     if symbol.is_Symbol:
@@ -185,7 +185,10 @@ class ParametricMotion(Motion):
 
     @staticmethod
     def _normalize_realizations(
-        realizations: list[dict[Vertex, Point]], width: int, height: int, spacing: int
+        realizations: Sequence[dict[Vertex, Point]],
+        width: int,
+        height: int,
+        spacing: int,
     ) -> list[dict[Vertex, Point]]:
         """
         Normalize a given list of realizations

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -14,16 +14,16 @@ from sympy import Matrix, pi, sqrt, sympify
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, dim=1),
-        fws.Complete(3, dim=1),
-        fws.Complete(4, dim=1),
-        fws.Cycle(4, dim=1),
-        fws.Cycle(5, dim=1),
-        fws.Path(3, dim=1),
-        fws.Path(4, dim=1),
-        fws.Complete(2, dim=2),
-        fws.Complete(3, dim=2),
-        fws.Complete(4, dim=2),
+        fws.Complete(2, d=1),
+        fws.Complete(3, d=1),
+        fws.Complete(4, d=1),
+        fws.Cycle(4, d=1),
+        fws.Cycle(5, d=1),
+        fws.Path(3, d=1),
+        fws.Path(4, d=1),
+        fws.Complete(2, d=2),
+        fws.Complete(3, d=2),
+        fws.Complete(4, d=2),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
@@ -31,14 +31,14 @@ from sympy import Matrix, pi, sqrt, sympify
         fws.K33plusEdge(),
         fws.ThreePrism(),
         fws.ThreePrismPlusEdge(),
-        fws.Complete(3, dim=3),
-        fws.Complete(4, dim=3),
+        fws.Complete(3, d=3),
+        fws.Complete(4, d=3),
     ]
-    + [fws.Complete(2, dim=n) for n in range(1, 10)]
-    + [fws.Complete(3, dim=n) for n in range(1, 10)]
-    + [fws.Complete(n - 1, dim=n) for n in range(2, 10)]
-    + [fws.Complete(n, dim=n) for n in range(1, 10)]
-    + [fws.Complete(n + 1, dim=n) for n in range(1, 10)],
+    + [fws.Complete(2, d=n) for n in range(1, 10)]
+    + [fws.Complete(3, d=n) for n in range(1, 10)]
+    + [fws.Complete(n - 1, d=n) for n in range(2, 10)]
+    + [fws.Complete(n, d=n) for n in range(1, 10)]
+    + [fws.Complete(n + 1, d=n) for n in range(1, 10)],
 )
 def test_inf_rigid(framework):
     assert framework.is_inf_rigid()
@@ -61,24 +61,24 @@ def test_check_vertex_and_edge_order():
     "framework",
     [
         Framework.from_points([[i] for i in range(4)]),
-        Framework.Collinear(graphs.Complete(3), dim=2),
+        Framework.Collinear(graphs.Complete(3), d=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
-        fws.Cycle(4, dim=2),
-        fws.Cycle(5, dim=2),
-        fws.Path(3, dim=2),
-        fws.Path(4, dim=2),
+        fws.Cycle(4, d=2),
+        fws.Cycle(5, d=2),
+        fws.Path(3, d=2),
+        fws.Path(4, d=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, dim=3),
-        fws.Path(3, dim=3),
-        fws.Path(4, dim=3),
+        fws.Cycle(4, d=3),
+        fws.Path(3, d=3),
+        fws.Path(4, d=3),
         fws.Frustum(3),
     ]
-    + [fws.Cycle(n - 1, dim=n) for n in range(5, 10)]
-    + [fws.Cycle(n, dim=n) for n in range(4, 10)]
-    + [fws.Cycle(n + 1, dim=n) for n in range(3, 10)],
+    + [fws.Cycle(n - 1, d=n) for n in range(5, 10)]
+    + [fws.Cycle(n, d=n) for n in range(4, 10)]
+    + [fws.Cycle(n + 1, d=n) for n in range(3, 10)],
 )
 def test_not_inf_rigid(framework):
     assert not framework.is_inf_rigid()
@@ -87,22 +87,22 @@ def test_not_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, dim=1),
-        fws.Path(3, dim=1),
-        fws.Path(4, dim=1),
-        fws.Complete(2, dim=2),
-        fws.Complete(3, dim=2),
+        fws.Complete(2, d=1),
+        fws.Path(3, d=1),
+        fws.Path(4, d=1),
+        fws.Complete(2, d=2),
+        fws.Complete(3, d=2),
         fws.CompleteBipartite(3, 3),
         fws.Diamond(),
         fws.ThreePrism(),
-        fws.Complete(3, dim=3),
-        fws.Complete(4, dim=3),
+        fws.Complete(3, d=3),
+        fws.Complete(4, d=3),
     ]
-    + [fws.Complete(2, dim=n) for n in range(1, 7)]
-    + [fws.Complete(3, dim=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
-    + [fws.Complete(n, dim=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)],
+    + [fws.Complete(2, d=n) for n in range(1, 7)]
+    + [fws.Complete(3, d=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
+    + [fws.Complete(n, d=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, d=n) for n in range(1, 7)],
 )
 def test_inf_min_rigid(framework):
     assert framework.is_min_inf_rigid()
@@ -114,30 +114,30 @@ def test_inf_min_rigid(framework):
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Complete(3, dim=1),
-        fws.Complete(4, dim=1),
-        fws.Cycle(4, dim=1),
-        fws.Cycle(5, dim=1),
-        Framework.Collinear(graphs.Complete(3), dim=2),
-        fws.Complete(4, dim=2),
+        fws.Complete(3, d=1),
+        fws.Complete(4, d=1),
+        fws.Cycle(4, d=1),
+        fws.Cycle(5, d=1),
+        Framework.Collinear(graphs.Complete(3), d=2),
+        fws.Complete(4, d=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
-        fws.Cycle(4, dim=2),
-        fws.Cycle(5, dim=2),
-        fws.Path(3, dim=2),
-        fws.Path(4, dim=2),
+        fws.Cycle(4, d=2),
+        fws.Cycle(5, d=2),
+        fws.Path(3, d=2),
+        fws.Path(4, d=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, dim=3),
-        fws.Path(3, dim=3),
-        fws.Path(4, dim=3),
+        fws.Cycle(4, d=3),
+        fws.Path(3, d=3),
+        fws.Path(4, d=3),
     ]
-    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
-    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
+    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
+    + [fws.Cycle(n, d=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
 )
 def test_not_min_inf_rigid(framework):
     assert not framework.is_min_inf_rigid()
@@ -146,34 +146,34 @@ def test_not_min_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, dim=1),
-        fws.Complete(2, dim=2),
-        fws.Complete(3, dim=2),
-        fws.Complete(3, dim=3),
-        fws.Complete(4, dim=3),
+        fws.Complete(2, d=1),
+        fws.Complete(2, d=2),
+        fws.Complete(3, d=2),
+        fws.Complete(3, d=3),
+        fws.Complete(4, d=3),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.Diamond(),
         fws.ThreePrism(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Cycle(4, dim=2),
-        fws.Cycle(5, dim=2),
-        fws.Cycle(4, dim=2),
-        fws.Path(3, dim=1),
-        fws.Path(3, dim=2),
-        fws.Path(4, dim=2),
-        fws.Path(3, dim=3),
-        fws.Path(4, dim=3),
+        fws.Cycle(4, d=2),
+        fws.Cycle(5, d=2),
+        fws.Cycle(4, d=2),
+        fws.Path(3, d=1),
+        fws.Path(3, d=2),
+        fws.Path(4, d=2),
+        fws.Path(3, d=3),
+        fws.Path(4, d=3),
     ]
-    + [fws.Complete(2, dim=n) for n in range(1, 7)]
-    + [fws.Complete(3, dim=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
-    + [fws.Complete(n, dim=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)]
-    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
-    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
+    + [fws.Complete(2, d=n) for n in range(1, 7)]
+    + [fws.Complete(3, d=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
+    + [fws.Complete(n, d=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, d=n) for n in range(1, 7)]
+    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
+    + [fws.Cycle(n, d=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
 )
 def test_is_independent(framework):
     assert framework.is_independent()
@@ -184,19 +184,19 @@ def test_is_independent(framework):
     [
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
-        Framework.Collinear(graphs.Complete(3), dim=2),
-        fws.Complete(3, dim=1),
-        fws.Complete(4, dim=1),
-        fws.Complete(4, dim=2),
+        Framework.Collinear(graphs.Complete(3), d=2),
+        fws.Complete(3, d=1),
+        fws.Complete(4, d=1),
+        fws.Complete(4, d=2),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, dim=1),
-        fws.Cycle(5, dim=1),
+        fws.Cycle(4, d=1),
+        fws.Cycle(5, d=1),
     ]
-    + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
+    + [Framework.Random(graphs.Complete(n), d=n - 2) for n in range(3, 8)],
 )
 def test_is_dependent(framework):
     assert framework.is_dependent()
@@ -205,7 +205,7 @@ def test_is_dependent(framework):
 def test_dimension():
     assert fws.Complete(2, 2).dim() == fws.Complete(2, 2).dimension()
     assert fws.Complete(2, 2).dim() == 2
-    assert Framework.Empty(dim=3).dim() == 3
+    assert Framework.Empty(d=3).dim() == 3
 
 
 def test_vertex_addition():
@@ -299,7 +299,7 @@ def test_inf_flexes():
     F_all = F.inf_flexes(include_trivial=True)
     assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
 
-    F = Framework.Random(graphs.DoubleBanana(), dim=3)
+    F = Framework.Random(graphs.DoubleBanana(), d=3)
     inf_flexes = F.nontrivial_inf_flexes()
     dict_flex = F._transform_inf_flex_to_pointwise(inf_flexes[0])
     assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
@@ -634,10 +634,10 @@ def test_rigidity_matrix():
     F = fws.Path(3)
     assert F.rigidity_matrix() == Matrix([[-1, 0, 1, 0, 0, 0], [0, 0, 1, -1, -1, 1]])
 
-    F = fws.Complete(3, dim=1)
+    F = fws.Complete(3, d=1)
     assert F.rigidity_matrix() == Matrix([[-1, 1, 0], [-2, 0, 2], [0, -1, 1]])
 
-    F = fws.Complete(4, dim=3)
+    F = fws.Complete(4, d=3)
     assert F.rigidity_matrix().shape == (6, 12)
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -14,16 +14,16 @@ from sympy import Matrix, pi, sqrt, sympify
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
-        fws.Path(3, d=1),
-        fws.Path(4, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
-        fws.Complete(4, d=2),
+        fws.Complete(2, dim=1),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
+        fws.Path(3, dim=1),
+        fws.Path(4, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
@@ -31,14 +31,14 @@ from sympy import Matrix, pi, sqrt, sympify
         fws.K33plusEdge(),
         fws.ThreePrism(),
         fws.ThreePrismPlusEdge(),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 10)]
-    + [fws.Complete(3, d=n) for n in range(1, 10)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 10)]
-    + [fws.Complete(n, d=n) for n in range(1, 10)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 10)],
+    + [fws.Complete(2, dim=n) for n in range(1, 10)]
+    + [fws.Complete(3, dim=n) for n in range(1, 10)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 10)]
+    + [fws.Complete(n, dim=n) for n in range(1, 10)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 10)],
 )
 def test_inf_rigid(framework):
     assert framework.is_inf_rigid()
@@ -61,24 +61,24 @@ def test_check_vertex_and_edge_order():
     "framework",
     [
         Framework.from_points([[i] for i in range(4)]),
-        Framework.Collinear(graphs.Complete(3), d=2),
+        Framework.Collinear(graphs.Complete(3), dim=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=3),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=3),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
         fws.Frustum(3),
     ]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 10)]
-    + [fws.Cycle(n, d=n) for n in range(4, 10)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 10)],
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 10)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 10)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 10)],
 )
 def test_not_inf_rigid(framework):
     assert not framework.is_inf_rigid()
@@ -87,22 +87,22 @@ def test_not_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Path(3, d=1),
-        fws.Path(4, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
+        fws.Complete(2, dim=1),
+        fws.Path(3, dim=1),
+        fws.Path(4, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
         fws.CompleteBipartite(3, 3),
         fws.Diamond(),
         fws.ThreePrism(),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 7)]
-    + [fws.Complete(3, d=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
-    + [fws.Complete(n, d=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 7)],
+    + [fws.Complete(2, dim=n) for n in range(1, 7)]
+    + [fws.Complete(3, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n, dim=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)],
 )
 def test_inf_min_rigid(framework):
     assert framework.is_min_inf_rigid()
@@ -114,30 +114,30 @@ def test_inf_min_rigid(framework):
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
-        Framework.Collinear(graphs.Complete(3), d=2),
-        fws.Complete(4, d=2),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
+        Framework.Collinear(graphs.Complete(3), dim=2),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=3),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=3),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
     ]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
-    + [fws.Cycle(n, d=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_not_min_inf_rigid(framework):
     assert not framework.is_min_inf_rigid()
@@ -146,34 +146,34 @@ def test_not_min_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(2, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.Diamond(),
         fws.ThreePrism(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Cycle(4, d=2),
-        fws.Path(3, d=1),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Cycle(4, dim=2),
+        fws.Path(3, dim=1),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 7)]
-    + [fws.Complete(3, d=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
-    + [fws.Complete(n, d=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 7)]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
-    + [fws.Cycle(n, d=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
+    + [fws.Complete(2, dim=n) for n in range(1, 7)]
+    + [fws.Complete(3, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n, dim=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)]
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_independent(framework):
     assert framework.is_independent()
@@ -184,19 +184,19 @@ def test_is_independent(framework):
     [
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
-        Framework.Collinear(graphs.Complete(3), d=2),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Complete(4, d=2),
+        Framework.Collinear(graphs.Complete(3), dim=2),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
     ]
-    + [Framework.Random(graphs.Complete(n), d=n - 2) for n in range(3, 8)],
+    + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
 def test_is_dependent(framework):
     assert framework.is_dependent()
@@ -205,7 +205,7 @@ def test_is_dependent(framework):
 def test_dimension():
     assert fws.Complete(2, 2).dim() == fws.Complete(2, 2).dimension()
     assert fws.Complete(2, 2).dim() == 2
-    assert Framework.Empty(d=3).dim() == 3
+    assert Framework.Empty(dim=3).dim() == 3
 
 
 def test_vertex_addition():
@@ -299,7 +299,7 @@ def test_inf_flexes():
     F_all = F.inf_flexes(include_trivial=True)
     assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
 
-    F = Framework.Random(graphs.DoubleBanana(), d=3)
+    F = Framework.Random(graphs.DoubleBanana(), dim=3)
     inf_flexes = F.nontrivial_inf_flexes()
     dict_flex = F._transform_inf_flex_to_pointwise(inf_flexes[0])
     assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
@@ -634,10 +634,10 @@ def test_rigidity_matrix():
     F = fws.Path(3)
     assert F.rigidity_matrix() == Matrix([[-1, 0, 1, 0, 0, 0], [0, 0, 1, -1, -1, 1]])
 
-    F = fws.Complete(3, d=1)
+    F = fws.Complete(3, dim=1)
     assert F.rigidity_matrix() == Matrix([[-1, 1, 0], [-2, 0, 2], [0, -1, 1]])
 
-    F = fws.Complete(4, d=3)
+    F = fws.Complete(4, dim=3)
     assert F.rigidity_matrix().shape == (6, 12)
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -14,16 +14,16 @@ from sympy import Matrix, pi, sqrt, sympify
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
-        fws.Path(3, d=1),
-        fws.Path(4, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
-        fws.Complete(4, d=2),
+        fws.Complete(2, dim=1),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
+        fws.Path(3, dim=1),
+        fws.Path(4, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
@@ -31,14 +31,14 @@ from sympy import Matrix, pi, sqrt, sympify
         fws.K33plusEdge(),
         fws.ThreePrism(),
         fws.ThreePrismPlusEdge(),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 10)]
-    + [fws.Complete(3, d=n) for n in range(1, 10)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 10)]
-    + [fws.Complete(n, d=n) for n in range(1, 10)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 10)],
+    + [fws.Complete(2, dim=n) for n in range(1, 10)]
+    + [fws.Complete(3, dim=n) for n in range(1, 10)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 10)]
+    + [fws.Complete(n, dim=n) for n in range(1, 10)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 10)],
 )
 def test_inf_rigid(framework):
     assert framework.is_inf_rigid()
@@ -61,24 +61,24 @@ def test_check_vertex_and_edge_order():
     "framework",
     [
         Framework.from_points([[i] for i in range(4)]),
-        Framework.Collinear(graphs.Complete(3), d=2),
+        Framework.Collinear(graphs.Complete(3), dim=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=3),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=3),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
         fws.Frustum(3),
     ]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 10)]
-    + [fws.Cycle(n, d=n) for n in range(4, 10)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 10)],
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 10)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 10)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 10)],
 )
 def test_not_inf_rigid(framework):
     assert not framework.is_inf_rigid()
@@ -87,22 +87,22 @@ def test_not_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Path(3, d=1),
-        fws.Path(4, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
+        fws.Complete(2, dim=1),
+        fws.Path(3, dim=1),
+        fws.Path(4, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
         fws.CompleteBipartite(3, 3),
         fws.Diamond(),
         fws.ThreePrism(),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 7)]
-    + [fws.Complete(3, d=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
-    + [fws.Complete(n, d=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 7)],
+    + [fws.Complete(2, dim=n) for n in range(1, 7)]
+    + [fws.Complete(3, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n, dim=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)],
 )
 def test_inf_min_rigid(framework):
     assert framework.is_min_inf_rigid()
@@ -114,30 +114,30 @@ def test_inf_min_rigid(framework):
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
-        Framework.Collinear(graphs.Complete(3), d=2),
-        fws.Complete(4, d=2),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
+        Framework.Collinear(graphs.Complete(3), dim=2),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=3),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=3),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
     ]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
-    + [fws.Cycle(n, d=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_not_min_inf_rigid(framework):
     assert not framework.is_min_inf_rigid()
@@ -146,34 +146,34 @@ def test_not_min_inf_rigid(framework):
 @pytest.mark.parametrize(
     "framework",
     [
-        fws.Complete(2, d=1),
-        fws.Complete(2, d=2),
-        fws.Complete(3, d=2),
-        fws.Complete(3, d=3),
-        fws.Complete(4, d=3),
+        fws.Complete(2, dim=1),
+        fws.Complete(2, dim=2),
+        fws.Complete(3, dim=2),
+        fws.Complete(3, dim=3),
+        fws.Complete(4, dim=3),
         fws.CompleteBipartite(3, 3),
         fws.CompleteBipartite(1, 3),
         fws.CompleteBipartite(2, 3),
         fws.Diamond(),
         fws.ThreePrism(),
         Framework.from_points([[i] for i in range(4)]),
-        fws.Cycle(4, d=2),
-        fws.Cycle(5, d=2),
-        fws.Cycle(4, d=2),
-        fws.Path(3, d=1),
-        fws.Path(3, d=2),
-        fws.Path(4, d=2),
-        fws.Path(3, d=3),
-        fws.Path(4, d=3),
+        fws.Cycle(4, dim=2),
+        fws.Cycle(5, dim=2),
+        fws.Cycle(4, dim=2),
+        fws.Path(3, dim=1),
+        fws.Path(3, dim=2),
+        fws.Path(4, dim=2),
+        fws.Path(3, dim=3),
+        fws.Path(4, dim=3),
     ]
-    + [fws.Complete(2, d=n) for n in range(1, 7)]
-    + [fws.Complete(3, d=n) for n in range(2, 7)]
-    + [fws.Complete(n - 1, d=n) for n in range(2, 7)]
-    + [fws.Complete(n, d=n) for n in range(1, 7)]
-    + [fws.Complete(n + 1, d=n) for n in range(1, 7)]
-    + [fws.Cycle(n - 1, d=n) for n in range(5, 7)]
-    + [fws.Cycle(n, d=n) for n in range(4, 7)]
-    + [fws.Cycle(n + 1, d=n) for n in range(3, 7)],
+    + [fws.Complete(2, dim=n) for n in range(1, 7)]
+    + [fws.Complete(3, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n - 1, dim=n) for n in range(2, 7)]
+    + [fws.Complete(n, dim=n) for n in range(1, 7)]
+    + [fws.Complete(n + 1, dim=n) for n in range(1, 7)]
+    + [fws.Cycle(n - 1, dim=n) for n in range(5, 7)]
+    + [fws.Cycle(n, dim=n) for n in range(4, 7)]
+    + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_independent(framework):
     assert framework.is_independent()
@@ -184,17 +184,17 @@ def test_is_independent(framework):
     [
         fws.K33plusEdge(),
         fws.ThreePrismPlusEdge(),
-        Framework.Collinear(graphs.Complete(3), d=2),
-        fws.Complete(3, d=1),
-        fws.Complete(4, d=1),
-        fws.Complete(4, d=2),
+        Framework.Collinear(graphs.Complete(3), dim=2),
+        fws.Complete(3, dim=1),
+        fws.Complete(4, dim=1),
+        fws.Complete(4, dim=2),
         fws.CompleteBipartite(3, 3, "dixonI"),
         fws.CompleteBipartite(3, 4),
         fws.CompleteBipartite(4, 4),
         fws.ThreePrism("flexible"),
         fws.ThreePrism("parallel"),
-        fws.Cycle(4, d=1),
-        fws.Cycle(5, d=1),
+        fws.Cycle(4, dim=1),
+        fws.Cycle(5, dim=1),
     ]
     + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
@@ -634,10 +634,10 @@ def test_rigidity_matrix():
     F = fws.Path(3)
     assert F.rigidity_matrix() == Matrix([[-1, 0, 1, 0, 0, 0], [0, 0, 1, -1, -1, 1]])
 
-    F = fws.Complete(3, d=1)
+    F = fws.Complete(3, dim=1)
     assert F.rigidity_matrix() == Matrix([[-1, 1, 0], [-2, 0, 2], [0, -1, 1]])
 
-    F = fws.Complete(4, d=3)
+    F = fws.Complete(4, dim=3)
     assert F.rigidity_matrix().shape == (6, 12)
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -57,8 +57,8 @@ def test_KL_values_are_not_correct():
     ],
 )
 def test_rigid_in_d2(graph):
-    assert graph.is_rigid(dim=2, combinatorial=True)
-    assert graph.is_rigid(dim=2, combinatorial=False)
+    assert graph.is_rigid(d=2, combinatorial=True)
+    assert graph.is_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -73,8 +73,8 @@ def test_rigid_in_d2(graph):
     ],
 )
 def test_not_rigid_in_d2(graph):
-    assert not graph.is_rigid(dim=2, combinatorial=True)
-    assert not graph.is_rigid(dim=2, combinatorial=False)
+    assert not graph.is_rigid(d=2, combinatorial=True)
+    assert not graph.is_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -92,8 +92,8 @@ def test_not_rigid_in_d2(graph):
     ],
 )
 def test_rigid_in_d1(graph):
-    assert graph.is_rigid(dim=1, combinatorial=True)
-    assert graph.is_rigid(dim=1, combinatorial=False)
+    assert graph.is_rigid(d=1, combinatorial=True)
+    assert graph.is_rigid(d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -101,8 +101,8 @@ def test_rigid_in_d1(graph):
     [Graph.from_vertices(range(3)), Graph([[0, 1], [2, 3]])],
 )
 def test_not_rigid_in_d1(graph):
-    assert not graph.is_rigid(dim=1, combinatorial=True)
-    assert not graph.is_rigid(dim=1, combinatorial=False)
+    assert not graph.is_rigid(d=1, combinatorial=True)
+    assert not graph.is_rigid(d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -195,8 +195,8 @@ def test_not_2_3_tight(graph):
     ],
 )
 def test_min_rigid_in_d1(graph):
-    assert graph.is_min_rigid(dim=1, combinatorial=True)
-    assert graph.is_min_rigid(dim=1, combinatorial=False)
+    assert graph.is_min_rigid(d=1, combinatorial=True)
+    assert graph.is_min_rigid(d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -214,8 +214,8 @@ def test_min_rigid_in_d1(graph):
     ],
 )
 def test_not_min_rigid_in_d1(graph):
-    assert not graph.is_min_rigid(dim=1, combinatorial=True)
-    assert not graph.is_min_rigid(dim=1, combinatorial=False)
+    assert not graph.is_min_rigid(d=1, combinatorial=True)
+    assert not graph.is_min_rigid(d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -229,8 +229,8 @@ def test_not_min_rigid_in_d1(graph):
     ],
 )
 def test_min_rigid_in_d2(graph):
-    assert graph.is_min_rigid(dim=2, combinatorial=True)
-    assert graph.is_min_rigid(dim=2, combinatorial=False)
+    assert graph.is_min_rigid(d=2, combinatorial=True)
+    assert graph.is_min_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -250,8 +250,8 @@ def test_min_rigid_in_d2(graph):
     ],
 )
 def test_not_min_rigid_in_d2(graph):
-    assert not graph.is_min_rigid(dim=2, combinatorial=True)
-    assert not graph.is_min_rigid(dim=2, combinatorial=False)
+    assert not graph.is_min_rigid(d=2, combinatorial=True)
+    assert not graph.is_min_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -267,7 +267,7 @@ def test_not_min_rigid_in_d2(graph):
     ],
 )
 def test_globally_rigid_in_d2(graph):
-    assert graph.is_globally_rigid(dim=2)
+    assert graph.is_globally_rigid(d=2)
 
 
 def read_random_from_graph6(filename):
@@ -315,7 +315,7 @@ def read_globally(d_v_):
     ],
 )
 def test_globally_rigid_in_d(graph, gdim):
-    assert graph.is_globally_rigid(dim=gdim)
+    assert graph.is_globally_rigid(d=gdim)
 
 
 @pytest.mark.parametrize(
@@ -364,7 +364,7 @@ def test_globally_rigid_in_d(graph, gdim):
     ],
 )
 def test_not_globally_rigid_in_d(graph, gdim):
-    assert not graph.is_globally_rigid(dim=gdim)
+    assert not graph.is_globally_rigid(d=gdim)
 
 
 @pytest.mark.parametrize(
@@ -382,7 +382,7 @@ def test_not_globally_rigid_in_d(graph, gdim):
     ],
 )
 def test_not_globally_in_d2(graph):
-    assert not graph.is_globally_rigid(dim=2)
+    assert not graph.is_globally_rigid(d=2)
 
 
 @pytest.mark.parametrize(
@@ -395,8 +395,8 @@ def test_not_globally_in_d2(graph):
     ],
 )
 def test_vertex_redundantly_rigid_in_d2(graph):
-    assert graph.is_vertex_redundantly_rigid(dim=2)
-    assert graph.is_vertex_redundantly_rigid(dim=2, combinatorial=False)
+    assert graph.is_vertex_redundantly_rigid(d=2)
+    assert graph.is_vertex_redundantly_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -415,8 +415,8 @@ def test_vertex_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=1)
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, d=1)
+    assert graph.is_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -436,8 +436,8 @@ def test_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=2)
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, d=2)
+    assert graph.is_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -464,7 +464,7 @@ def test_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -477,8 +477,8 @@ def test_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_vertex_redundantly_rigid_in_d2(graph):
-    assert not graph.is_vertex_redundantly_rigid(dim=2)
-    assert not graph.is_vertex_redundantly_rigid(dim=2, combinatorial=False)
+    assert not graph.is_vertex_redundantly_rigid(d=2)
+    assert not graph.is_vertex_redundantly_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -491,8 +491,8 @@ def test_not_vertex_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1)
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, d=1)
+    assert not graph.is_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -505,8 +505,8 @@ def test_not_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2)
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, d=2)
+    assert not graph.is_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -532,7 +532,7 @@ def test_not_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -551,8 +551,8 @@ def test_not_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1)
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, d=1)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -571,8 +571,8 @@ def test_min_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2)
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, d=2)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -583,7 +583,7 @@ def test_min_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -596,8 +596,8 @@ def test_min_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1)
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=1)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -610,8 +610,8 @@ def test_not_min_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2)
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=2)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -639,7 +639,7 @@ def test_not_min_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -655,8 +655,8 @@ def test_not_min_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_redundantly_rigid_in_d2(graph):
-    assert graph.is_redundantly_rigid(dim=2)
-    assert graph.is_redundantly_rigid(dim=2, combinatorial=False)
+    assert graph.is_redundantly_rigid(d=2)
+    assert graph.is_redundantly_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -677,8 +677,8 @@ def test_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_k_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_k_redundantly_rigid(k, dim=1)
-    assert graph.is_k_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, d=1)
+    assert graph.is_k_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -700,8 +700,8 @@ def test_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_k_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_k_redundantly_rigid(k, dim=2)
-    assert graph.is_k_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, d=2)
+    assert graph.is_k_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -729,7 +729,7 @@ def test_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_k_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_k_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -750,8 +750,8 @@ def test_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_redundantly_rigid_in_d2(graph):
-    assert not graph.is_redundantly_rigid(dim=2)
-    assert not graph.is_redundantly_rigid(dim=2, combinatorial=False)
+    assert not graph.is_redundantly_rigid(d=2)
+    assert not graph.is_redundantly_rigid(d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -763,8 +763,8 @@ def test_not_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_not_k_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, dim=1)
-    assert not graph.is_k_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, d=1)
+    assert not graph.is_k_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -782,8 +782,8 @@ def test_not_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_k_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, dim=2)
-    assert not graph.is_k_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, d=2)
+    assert not graph.is_k_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -801,7 +801,7 @@ def test_not_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_k_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -820,8 +820,8 @@ def test_not_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, dim=1)
-    assert graph.is_min_k_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, d=1)
+    assert graph.is_min_k_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -840,8 +840,8 @@ def test_min_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, dim=2)
-    assert graph.is_min_k_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, d=2)
+    assert graph.is_min_k_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -853,7 +853,7 @@ def test_min_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -868,8 +868,8 @@ def test_min_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=1)
-    assert not graph.is_min_k_redundantly_rigid(k, dim=1, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, d=1)
+    assert not graph.is_min_k_redundantly_rigid(k, d=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -882,8 +882,8 @@ def test_not_min_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=2)
-    assert not graph.is_min_k_redundantly_rigid(k, dim=2, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, d=2)
+    assert not graph.is_min_k_redundantly_rigid(k, d=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -898,15 +898,15 @@ def test_not_min_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=3, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, d=3, combinatorial=False)
 
 
 def test_rigid_components():
     G = graphs.Path(6)
-    rigid_components = G.rigid_components(dim=1)
+    rigid_components = G.rigid_components(d=1)
     assert rigid_components[0] == [0, 1, 2, 3, 4, 5]
     G.remove_edge(2, 3)
-    rigid_components = G.rigid_components(dim=1)
+    rigid_components = G.rigid_components(d=1)
     assert [set(H) for H in rigid_components] == [
         set([0, 1, 2]),
         set([3, 4, 5]),
@@ -981,7 +981,7 @@ def test_rigid_components():
     ]
 
     G = graphs.DoubleBanana()
-    rigid_components = G.rigid_components(dim=3)
+    rigid_components = G.rigid_components(d=3)
     assert [set(H) for H in rigid_components] == [
         set([0, 1, 2, 3, 4]),
         set([0, 1, 5, 6, 7]),
@@ -1099,12 +1099,12 @@ def test_loops(method, params):
 
 def test_k_extension():
     assert str(graphs.Complete(2).zero_extension([0, 1])) == str(graphs.Complete(3))
-    assert str(graphs.Complete(2).zero_extension([1], dim=1)) == str(graphs.Path(3))
+    assert str(graphs.Complete(2).zero_extension([1], d=1)) == str(graphs.Path(3))
     assert str(graphs.Complete(4).one_extension([0, 1, 2], (0, 1))) == str(
         Graph([(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
     )
     assert str(
-        graphs.CompleteBipartite(3, 2).one_extension([0, 1, 2, 3, 4], (0, 3), dim=4)
+        graphs.CompleteBipartite(3, 2).one_extension([0, 1, 2, 3, 4], (0, 3), d=4)
     ) == str(
         Graph(
             [
@@ -1123,7 +1123,7 @@ def test_k_extension():
     )
     assert str(
         graphs.CompleteBipartite(3, 2).k_extension(
-            2, [0, 1, 3], [(0, 3), (1, 3)], dim=1
+            2, [0, 1, 3], [(0, 3), (1, 3)], d=1
         )
     ) == str(Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]))
     assert str(
@@ -1131,7 +1131,7 @@ def test_k_extension():
     ) == str(Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]))
     assert str(
         graphs.Cycle(6).k_extension(
-            4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], dim=1
+            4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], d=1
         )
     ) == str(Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]))
 
@@ -1179,14 +1179,14 @@ def test_all_k_extensions():
 
 def test_k_extension_fail():
     with pytest.raises(TypeError):
-        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1], [0, 2]], dim=-1)
+        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1], [0, 2]], d=-1)
     with pytest.raises(ValueError):
-        graphs.Complete(6).k_extension(2, [0, 1, 6], [[0, 1], [0, 6]], dim=1)
+        graphs.Complete(6).k_extension(2, [0, 1, 6], [[0, 1], [0, 6]], d=1)
     with pytest.raises(ValueError):
-        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1]], dim=1)
+        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1]], d=1)
     with pytest.raises(ValueError):
         graphs.CompleteBipartite(2, 3).k_extension(
-            2, [0, 1, 2], [[0, 1], [0, 2]], dim=1
+            2, [0, 1, 2], [[0, 1], [0, 2]], d=1
         )
     with pytest.raises(ValueError):
         list(Graph.from_vertices([0, 1, 2]).all_k_extensions(1, 1))
@@ -1269,7 +1269,7 @@ def test_extension_sequence_solution():
     for i in range(len(result)):
         assert str(result[i]) == str(G)
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
+            G.k_extension(*solution_ext[i], d=2, inplace=True)
 
     result = graphs.Diamond().extension_sequence(return_solution=True)
     solution = [
@@ -1302,7 +1302,7 @@ def test_extension_sequence_solution():
     for i in range(len(result)):
         assert str(result[i]) == str(G)
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
+            G.k_extension(*solution_ext[i], d=2, inplace=True)
 
 
 def test_CompleteOnVertices():
@@ -1479,7 +1479,7 @@ def test_number_of_realizations_error(graph):
     [graphs.Cycle(n) for n in range(3, 7)],
 )
 def test_Rd_circuit_d1(graph):
-    assert graph.is_Rd_circuit(dim=1)
+    assert graph.is_Rd_circuit(d=1)
 
 
 @pytest.mark.parametrize(
@@ -1496,7 +1496,7 @@ def test_Rd_circuit_d1(graph):
     ],
 )
 def test_not_Rd_circuit_d1(graph):
-    assert not graph.is_Rd_circuit(dim=1)
+    assert not graph.is_Rd_circuit(d=1)
 
 
 @pytest.mark.parametrize(
@@ -1508,7 +1508,7 @@ def test_not_Rd_circuit_d1(graph):
     ],
 )
 def test_Rd_circuit_d2(graph):
-    assert graph.is_Rd_circuit(dim=2)
+    assert graph.is_Rd_circuit(d=2)
 
 
 @pytest.mark.parametrize(
@@ -1525,7 +1525,7 @@ def test_Rd_circuit_d2(graph):
     ],
 )
 def test_not_Rd_circuit_d2(graph):
-    assert not graph.is_Rd_circuit(dim=2)
+    assert not graph.is_Rd_circuit(d=2)
 
 
 @pytest.mark.parametrize(

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -57,8 +57,8 @@ def test_KL_values_are_not_correct():
     ],
 )
 def test_rigid_in_d2(graph):
-    assert graph.is_rigid(d=2, combinatorial=True)
-    assert graph.is_rigid(d=2, combinatorial=False)
+    assert graph.is_rigid(dim=2, combinatorial=True)
+    assert graph.is_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -73,8 +73,8 @@ def test_rigid_in_d2(graph):
     ],
 )
 def test_not_rigid_in_d2(graph):
-    assert not graph.is_rigid(d=2, combinatorial=True)
-    assert not graph.is_rigid(d=2, combinatorial=False)
+    assert not graph.is_rigid(dim=2, combinatorial=True)
+    assert not graph.is_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -92,8 +92,8 @@ def test_not_rigid_in_d2(graph):
     ],
 )
 def test_rigid_in_d1(graph):
-    assert graph.is_rigid(d=1, combinatorial=True)
-    assert graph.is_rigid(d=1, combinatorial=False)
+    assert graph.is_rigid(dim=1, combinatorial=True)
+    assert graph.is_rigid(dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -101,8 +101,8 @@ def test_rigid_in_d1(graph):
     [Graph.from_vertices(range(3)), Graph([[0, 1], [2, 3]])],
 )
 def test_not_rigid_in_d1(graph):
-    assert not graph.is_rigid(d=1, combinatorial=True)
-    assert not graph.is_rigid(d=1, combinatorial=False)
+    assert not graph.is_rigid(dim=1, combinatorial=True)
+    assert not graph.is_rigid(dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -195,8 +195,8 @@ def test_not_2_3_tight(graph):
     ],
 )
 def test_min_rigid_in_d1(graph):
-    assert graph.is_min_rigid(d=1, combinatorial=True)
-    assert graph.is_min_rigid(d=1, combinatorial=False)
+    assert graph.is_min_rigid(dim=1, combinatorial=True)
+    assert graph.is_min_rigid(dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -214,8 +214,8 @@ def test_min_rigid_in_d1(graph):
     ],
 )
 def test_not_min_rigid_in_d1(graph):
-    assert not graph.is_min_rigid(d=1, combinatorial=True)
-    assert not graph.is_min_rigid(d=1, combinatorial=False)
+    assert not graph.is_min_rigid(dim=1, combinatorial=True)
+    assert not graph.is_min_rigid(dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -229,8 +229,8 @@ def test_not_min_rigid_in_d1(graph):
     ],
 )
 def test_min_rigid_in_d2(graph):
-    assert graph.is_min_rigid(d=2, combinatorial=True)
-    assert graph.is_min_rigid(d=2, combinatorial=False)
+    assert graph.is_min_rigid(dim=2, combinatorial=True)
+    assert graph.is_min_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -250,8 +250,8 @@ def test_min_rigid_in_d2(graph):
     ],
 )
 def test_not_min_rigid_in_d2(graph):
-    assert not graph.is_min_rigid(d=2, combinatorial=True)
-    assert not graph.is_min_rigid(d=2, combinatorial=False)
+    assert not graph.is_min_rigid(dim=2, combinatorial=True)
+    assert not graph.is_min_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -267,7 +267,7 @@ def test_not_min_rigid_in_d2(graph):
     ],
 )
 def test_globally_rigid_in_d2(graph):
-    assert graph.is_globally_rigid(d=2)
+    assert graph.is_globally_rigid(dim=2)
 
 
 def read_random_from_graph6(filename):
@@ -315,7 +315,7 @@ def read_globally(d_v_):
     ],
 )
 def test_globally_rigid_in_d(graph, gdim):
-    assert graph.is_globally_rigid(d=gdim)
+    assert graph.is_globally_rigid(dim=gdim)
 
 
 @pytest.mark.parametrize(
@@ -364,7 +364,7 @@ def test_globally_rigid_in_d(graph, gdim):
     ],
 )
 def test_not_globally_rigid_in_d(graph, gdim):
-    assert not graph.is_globally_rigid(d=gdim)
+    assert not graph.is_globally_rigid(dim=gdim)
 
 
 @pytest.mark.parametrize(
@@ -382,7 +382,7 @@ def test_not_globally_rigid_in_d(graph, gdim):
     ],
 )
 def test_not_globally_in_d2(graph):
-    assert not graph.is_globally_rigid(d=2)
+    assert not graph.is_globally_rigid(dim=2)
 
 
 @pytest.mark.parametrize(
@@ -395,8 +395,8 @@ def test_not_globally_in_d2(graph):
     ],
 )
 def test_vertex_redundantly_rigid_in_d2(graph):
-    assert graph.is_vertex_redundantly_rigid(d=2)
-    assert graph.is_vertex_redundantly_rigid(d=2, combinatorial=False)
+    assert graph.is_vertex_redundantly_rigid(dim=2)
+    assert graph.is_vertex_redundantly_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -415,8 +415,8 @@ def test_vertex_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, d=1)
-    assert graph.is_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, dim=1)
+    assert graph.is_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -436,8 +436,8 @@ def test_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, d=2)
-    assert graph.is_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, dim=2)
+    assert graph.is_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -464,7 +464,7 @@ def test_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
+    assert graph.is_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -477,8 +477,8 @@ def test_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_vertex_redundantly_rigid_in_d2(graph):
-    assert not graph.is_vertex_redundantly_rigid(d=2)
-    assert not graph.is_vertex_redundantly_rigid(d=2, combinatorial=False)
+    assert not graph.is_vertex_redundantly_rigid(dim=2)
+    assert not graph.is_vertex_redundantly_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -491,8 +491,8 @@ def test_not_vertex_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, d=1)
-    assert not graph.is_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1)
+    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -505,8 +505,8 @@ def test_not_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, d=2)
-    assert not graph.is_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2)
+    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -532,7 +532,7 @@ def test_not_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
+    assert not graph.is_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -551,8 +551,8 @@ def test_not_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, d=1)
-    assert graph.is_min_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -571,8 +571,8 @@ def test_min_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, d=2)
-    assert graph.is_min_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -583,7 +583,7 @@ def test_min_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_min_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
+    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -596,8 +596,8 @@ def test_min_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=1)
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=1, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -610,8 +610,8 @@ def test_not_min_k_vertex_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=2)
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=2, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -639,7 +639,7 @@ def test_not_min_k_vertex_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_min_k_vertex_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, d=3, combinatorial=False)
+    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -655,8 +655,8 @@ def test_not_min_k_vertex_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_redundantly_rigid_in_d2(graph):
-    assert graph.is_redundantly_rigid(d=2)
-    assert graph.is_redundantly_rigid(d=2, combinatorial=False)
+    assert graph.is_redundantly_rigid(dim=2)
+    assert graph.is_redundantly_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -677,8 +677,8 @@ def test_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_k_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_k_redundantly_rigid(k, d=1)
-    assert graph.is_k_redundantly_rigid(k, d=1, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, dim=1)
+    assert graph.is_k_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -700,8 +700,8 @@ def test_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_k_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_k_redundantly_rigid(k, d=2)
-    assert graph.is_k_redundantly_rigid(k, d=2, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, dim=2)
+    assert graph.is_k_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -729,7 +729,7 @@ def test_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_k_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_k_redundantly_rigid(k, d=3, combinatorial=False)
+    assert graph.is_k_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -750,8 +750,8 @@ def test_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_redundantly_rigid_in_d2(graph):
-    assert not graph.is_redundantly_rigid(d=2)
-    assert not graph.is_redundantly_rigid(d=2, combinatorial=False)
+    assert not graph.is_redundantly_rigid(dim=2)
+    assert not graph.is_redundantly_rigid(dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -763,8 +763,8 @@ def test_not_redundantly_rigid_in_d2(graph):
     ],
 )
 def test_not_k_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, d=1)
-    assert not graph.is_k_redundantly_rigid(k, d=1, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, dim=1)
+    assert not graph.is_k_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -782,8 +782,8 @@ def test_not_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_k_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, d=2)
-    assert not graph.is_k_redundantly_rigid(k, d=2, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, dim=2)
+    assert not graph.is_k_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -801,7 +801,7 @@ def test_not_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_k_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_k_redundantly_rigid(k, d=3, combinatorial=False)
+    assert not graph.is_k_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -820,8 +820,8 @@ def test_not_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d1(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, d=1)
-    assert graph.is_min_k_redundantly_rigid(k, d=1, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, dim=1)
+    assert graph.is_min_k_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -840,8 +840,8 @@ def test_min_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d2(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, d=2)
-    assert graph.is_min_k_redundantly_rigid(k, d=2, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, dim=2)
+    assert graph.is_min_k_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -853,7 +853,7 @@ def test_min_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_min_k_redundantly_rigid_in_d3(graph, k):
-    assert graph.is_min_k_redundantly_rigid(k, d=3, combinatorial=False)
+    assert graph.is_min_k_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -868,8 +868,8 @@ def test_min_k_redundantly_rigid_in_d3(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d1(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, d=1)
-    assert not graph.is_min_k_redundantly_rigid(k, d=1, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, dim=1)
+    assert not graph.is_min_k_redundantly_rigid(k, dim=1, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -882,8 +882,8 @@ def test_not_min_k_redundantly_rigid_in_d1(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d2(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, d=2)
-    assert not graph.is_min_k_redundantly_rigid(k, d=2, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, dim=2)
+    assert not graph.is_min_k_redundantly_rigid(k, dim=2, combinatorial=False)
 
 
 @pytest.mark.parametrize(
@@ -898,15 +898,15 @@ def test_not_min_k_redundantly_rigid_in_d2(graph, k):
     ],
 )
 def test_not_min_k_redundantly_rigid_in_d3(graph, k):
-    assert not graph.is_min_k_redundantly_rigid(k, d=3, combinatorial=False)
+    assert not graph.is_min_k_redundantly_rigid(k, dim=3, combinatorial=False)
 
 
 def test_rigid_components():
     G = graphs.Path(6)
-    rigid_components = G.rigid_components(d=1)
+    rigid_components = G.rigid_components(dim=1)
     assert rigid_components[0] == [0, 1, 2, 3, 4, 5]
     G.remove_edge(2, 3)
-    rigid_components = G.rigid_components(d=1)
+    rigid_components = G.rigid_components(dim=1)
     assert [set(H) for H in rigid_components] == [
         set([0, 1, 2]),
         set([3, 4, 5]),
@@ -981,7 +981,7 @@ def test_rigid_components():
     ]
 
     G = graphs.DoubleBanana()
-    rigid_components = G.rigid_components(d=3)
+    rigid_components = G.rigid_components(dim=3)
     assert [set(H) for H in rigid_components] == [
         set([0, 1, 2, 3, 4]),
         set([0, 1, 5, 6, 7]),
@@ -1099,12 +1099,12 @@ def test_loops(method, params):
 
 def test_k_extension():
     assert str(graphs.Complete(2).zero_extension([0, 1])) == str(graphs.Complete(3))
-    assert str(graphs.Complete(2).zero_extension([1], d=1)) == str(graphs.Path(3))
+    assert str(graphs.Complete(2).zero_extension([1], dim=1)) == str(graphs.Path(3))
     assert str(graphs.Complete(4).one_extension([0, 1, 2], (0, 1))) == str(
         Graph([(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
     )
     assert str(
-        graphs.CompleteBipartite(3, 2).one_extension([0, 1, 2, 3, 4], (0, 3), d=4)
+        graphs.CompleteBipartite(3, 2).one_extension([0, 1, 2, 3, 4], (0, 3), dim=4)
     ) == str(
         Graph(
             [
@@ -1123,7 +1123,7 @@ def test_k_extension():
     )
     assert str(
         graphs.CompleteBipartite(3, 2).k_extension(
-            2, [0, 1, 3], [(0, 3), (1, 3)], d=1
+            2, [0, 1, 3], [(0, 3), (1, 3)], dim=1
         )
     ) == str(Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]))
     assert str(
@@ -1131,7 +1131,7 @@ def test_k_extension():
     ) == str(Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]))
     assert str(
         graphs.Cycle(6).k_extension(
-            4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], d=1
+            4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], dim=1
         )
     ) == str(Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]))
 
@@ -1179,14 +1179,14 @@ def test_all_k_extensions():
 
 def test_k_extension_fail():
     with pytest.raises(TypeError):
-        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1], [0, 2]], d=-1)
+        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1], [0, 2]], dim=-1)
     with pytest.raises(ValueError):
-        graphs.Complete(6).k_extension(2, [0, 1, 6], [[0, 1], [0, 6]], d=1)
+        graphs.Complete(6).k_extension(2, [0, 1, 6], [[0, 1], [0, 6]], dim=1)
     with pytest.raises(ValueError):
-        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1]], d=1)
+        graphs.Complete(6).k_extension(2, [0, 1, 2], [[0, 1]], dim=1)
     with pytest.raises(ValueError):
         graphs.CompleteBipartite(2, 3).k_extension(
-            2, [0, 1, 2], [[0, 1], [0, 2]], d=1
+            2, [0, 1, 2], [[0, 1], [0, 2]], dim=1
         )
     with pytest.raises(ValueError):
         list(Graph.from_vertices([0, 1, 2]).all_k_extensions(1, 1))
@@ -1269,7 +1269,7 @@ def test_extension_sequence_solution():
     for i in range(len(result)):
         assert str(result[i]) == str(G)
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], d=2, inplace=True)
+            G.k_extension(*solution_ext[i], dim=2, inplace=True)
 
     result = graphs.Diamond().extension_sequence(return_solution=True)
     solution = [
@@ -1302,7 +1302,7 @@ def test_extension_sequence_solution():
     for i in range(len(result)):
         assert str(result[i]) == str(G)
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], d=2, inplace=True)
+            G.k_extension(*solution_ext[i], dim=2, inplace=True)
 
 
 def test_CompleteOnVertices():
@@ -1479,7 +1479,7 @@ def test_number_of_realizations_error(graph):
     [graphs.Cycle(n) for n in range(3, 7)],
 )
 def test_Rd_circuit_d1(graph):
-    assert graph.is_Rd_circuit(d=1)
+    assert graph.is_Rd_circuit(dim=1)
 
 
 @pytest.mark.parametrize(
@@ -1496,7 +1496,7 @@ def test_Rd_circuit_d1(graph):
     ],
 )
 def test_not_Rd_circuit_d1(graph):
-    assert not graph.is_Rd_circuit(d=1)
+    assert not graph.is_Rd_circuit(dim=1)
 
 
 @pytest.mark.parametrize(
@@ -1508,7 +1508,7 @@ def test_not_Rd_circuit_d1(graph):
     ],
 )
 def test_Rd_circuit_d2(graph):
-    assert graph.is_Rd_circuit(d=2)
+    assert graph.is_Rd_circuit(dim=2)
 
 
 @pytest.mark.parametrize(
@@ -1525,7 +1525,7 @@ def test_Rd_circuit_d2(graph):
     ],
 )
 def test_not_Rd_circuit_d2(graph):
-    assert not graph.is_Rd_circuit(d=2)
+    assert not graph.is_Rd_circuit(dim=2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
+ Added missing 1-line comments
+ `d` -> `dim` for consistency
+ PEP 545: `Dict`, `List`, `Union` are deprecated. Now `dict`, `list`, `|` are generic types. For the input type, we should be able to deal with a `Sequence` instead of specifying `list | tuple`, while for the output type, we should specify exactly what the output is, e.g. `list`.