### PR TITLE
Non-public methods removed from lists

### DIFF
--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -2738,7 +2738,6 @@ class Framework(object):
             f"STL files for the bars have been generated in the folder `{output_dir}`."
         )
 
-    @doc_category("Other")
     def _transform_inf_flex_to_pointwise(
         self, inf_flex: Matrix, vertex_order: Sequence[Vertex] = None
     ) -> dict[Vertex, list[Coordinate]]:
@@ -2775,7 +2774,6 @@ class Framework(object):
             for i in range(len(vertex_order))
         }
 
-    @doc_category("Other")
     def _transform_stress_to_edgewise(
         self, stress: Matrix, edge_order: Sequence[Edge] = None
     ) -> dict[Edge, Coordinate]:
@@ -3162,7 +3160,6 @@ class Framework(object):
                 "The `inf_flex` must be specified either by a vector or a dictionary!"
             )
 
-    @doc_category("Other")
     def _check_vertex_order(self, vertex_order=Sequence[Vertex]) -> list[Vertex]:
         """
         Checks whether the provided `vertex_order` contains the same elements
@@ -3190,7 +3187,6 @@ class Framework(object):
                 )
             return list(vertex_order)
 
-    @doc_category("Other")
     def _check_edge_order(self, edge_order=Sequence[Edge]) -> list[Edge]:
         """
         Checks whether the provided `edge_order` contains the same elements

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -464,7 +464,6 @@ class Graph(nx.Graph):
         return max([self.degree(v) for v in self.nodes])
 
     @staticmethod
-    @doc_category("Sparseness")
     def _pebble_values_are_correct(K: int, L: int) -> bool:
         r"""
         Check if K and L satisfy pebble game conditions.
@@ -478,7 +477,6 @@ class Graph(nx.Graph):
             return False
         return True
 
-    @doc_category("Sparseness")
     def _build_pebble_digraph(self, K: int, L: int) -> None:
         r"""
         Build and save the pebble digraph from scratch.
@@ -531,7 +529,6 @@ class Graph(nx.Graph):
 
         return self._pebble_digraph.to_undirected()
 
-    @doc_category("Sparseness")
     def _is_pebble_digraph_sparse(
         self, K: int, L: int, use_precomputed_pebble_digraph: bool = False
     ) -> bool:


### PR DESCRIPTION
The removal of non-public methods related to plotting shall be done when refactoring plotting to avoid conflicts.