### PR TITLE
Added `ApproximateMotion` class

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,6 +128,7 @@ myst_heading_anchors = 3
 nb_execution_mode = "cache"
 nb_execution_raise_on_error = True
 nb_execution_show_tb = True
+nb_execution_timeout = 60
 
 tippy_enable_mathjax = True
 tippy_props = {

--- a/doc/userguide/tutorial.md
+++ b/doc/userguide/tutorial.md
@@ -7,5 +7,6 @@
 tutorials/graph_basics
 tutorials/framework_database
 tutorials/plotting
+tutorials/motion
 tutorials/mesh_generation
 :::

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -78,7 +78,7 @@ A cyclic motion of $K_{4,2}$ can be approximated using the following code:
 from pyrigi.motion import ApproximateMotion
 from pyrigi import frameworkDB as frameworks
 F = frameworks.CompleteBipartite(2,4)
-motion = ApproximateMotion.from_framework(F, 393, chosen_flex=0, step_size=0.15)
+motion = ApproximateMotion(F, 393, chosen_flex=0, step_size=0.15)
 motion.animate(duration=10)
 ```
 
@@ -93,6 +93,6 @@ to the placement of the second vertex. Alternatively, this vector can be specifi
 
 ```{code-cell} ipython3
 F = frameworks.Path(5)
-motion = ApproximateMotion.from_framework(F, 147, chosen_flex=1)
+motion = ApproximateMotion(F, 147, chosen_flex=1)
 motion.animate(fixed_edge=[0,4], fixed_direction=[0,1])
 ```

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -53,7 +53,7 @@ motion = ParametricMotion(
         3: ("cos(8*pi/5 + t)", "sin(8*pi/5 + t)"),
         4: ("cos(t)", "sin(t)")
     },
-    [0, sp.sympify("pi")],
+    [0, sp.sympify("2*pi")],
 )
 motion.animate()
 ```

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -61,6 +61,7 @@ motion.animate()
 Internal checks on the edge lengths are in place to ensure that the specified parametric motion
 never violates the edge-length equations. 
 
+
 ## Approximate Motion
 
 However, a parametric motion is not always available. If you still want to get an
@@ -77,3 +78,15 @@ motion.animate(duration=10)
 ```
 
 Currently, only nontrivial motions can be computed in this way.
+
+Typically, only the origin is fixed during the animation sequence. If a (directed) edge is
+provided in the method {meth}`~.Motion.animate` via the keyword `fixed_edge`, then it is possible to
+pin the first vertex of `fixed_edge` to the origin and the second vertex to the vector from the origin
+to the placement of the second vertex. Alternatively, this vector can be specified using the keyword
+``fixed_direction``.
+
+```{code-cell} ipython3
+F = frameworks.Path(5)
+motion = ApproximateMotion.from_framework(F, 147, chosen_flex=1)
+motion.animate(fixed_edge=[0,4], fixed_direction=[0,1])
+```

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -59,7 +59,7 @@ motion = ParametricMotion(
 motion.animate(
     vertex_labels=False,
     edge_color='blue',
-    edge_width=20,
+    edge_width=4,
 )
 ```
 
@@ -82,7 +82,8 @@ motion = ApproximateMotion.from_framework(F, 393, chosen_flex=0, step_size=0.15)
 motion.animate(duration=10)
 ```
 
-Currently, only nontrivial motions can be computed in this way.
+Only nontrivial motions can be computed in this way, so you don't need to worry about approximating a
+trivial motion here.
 
 Typically, only the origin is fixed during the animation sequence. If a (directed) edge is
 provided in the method {meth}`~.Motion.animate` via the keyword `fixed_edge`, then it is possible to

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -1,0 +1,79 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.6
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Continuous Motions
+
+It is possible to create {prf:ref}`continuous motions <def-motion>` of {prf:ref}`frameworks <def-realization>` in PyRigi.
+
+## Parametric Motion
+
+The user can specify a parametric motion using the class {class}`~.ParametricMotion`. 
+As an example, consider the 4-cycle. A parametric motion can be specified
+using the following sequence of commands:
+
+```{code-cell} ipython3
+from pyrigi import graphDB as graphs
+from pyrigi.motion import ParametricMotion
+import sympy as sp
+motion = ParametricMotion(
+    graphs.Cycle(4),
+    {
+        0: ("0", "0"),
+        1: ("1", "0"),
+        2: ("4 * (t**2 - 2) / (t**2 + 4)", "12 * t / (t**2 + 4)"),
+        3: (
+            "(t**4 - 13 * t**2 + 4) / (t**4 + 5 * t**2 + 4)",
+            "6 * (t**3 - 2 * t) / (t**4 + 5 * t**2 + 4)",
+        ),
+    },
+    [-sp.oo, sp.oo],
+)
+motion.animate()
+```
+
+It is also possible to provide trivial motions in a similar manner.
+
+```{code-cell} ipython3
+motion = ParametricMotion(
+    graphs.Complete(5),
+    {
+        0: ("cos(2*pi/5 + t)", "sin(2*pi/5 + t)"),
+        1: ("cos(4*pi/5 + t)", "sin(4*pi/5 + t)"),
+        2: ("cos(6*pi/5 + t)", "sin(6*pi/5 + t)"),
+        3: ("cos(8*pi/5 + t)", "sin(8*pi/5 + t)"),
+        4: ("cos(t)", "sin(t)")
+    },
+    [0, sp.sympify("pi")],
+)
+motion.animate()
+```
+
+Internal checks on the edge lengths are in place to ensure that the specified parametric motion
+never violates the edge-length equations. 
+
+## Approximate Motion
+
+However, a parametric motion is not always available. If you still want to get an
+intuition for how a deformation path looks, it can be numerically approximated using
+the class {class}`~.ApproximateMotion`. As an example, consider the complete bipartite graph $K_{4,2}$.
+A cyclic motion of $K_{4,2}$ can be approximated using the following code:
+
+```{code-cell} ipython3
+from pyrigi.motion import ApproximateMotion
+from pyrigi import frameworkDB as frameworks
+F = frameworks.CompleteBipartite(2,4)
+motion = ApproximateMotion.from_framework(F, 393, chosen_flex=0, step_size=0.15)
+motion.animate(duration=10)
+```
+
+Currently, only nontrivial motions can be computed in this way.

--- a/doc/userguide/tutorials/plotting.md
+++ b/doc/userguide/tutorials/plotting.md
@@ -318,7 +318,7 @@ A cyclic motion of $K_{4,2}$ can be approximated using the following code:
 ```{code-cell} ipython3
 from pyrigi.motion import ApproximateMotion
 F = frameworks.CompleteBipartite(2,4)
-motion = ApproximateMotion.from_framework(F, 394, chosen_flex=0, step_length=0.15)
+motion = ApproximateMotion.from_framework(F, 395, chosen_flex=0, step_size=0.15)
 motion.animate(duration=10)
 ```
 

--- a/doc/userguide/tutorials/plotting.md
+++ b/doc/userguide/tutorials/plotting.md
@@ -310,44 +310,6 @@ collinear configurations from a previous section that displays edges as curved a
 ```{code-cell} ipython3
 F = Framework.Complete([[1],[3],[0],[2]])
 F.plot(stress=0, arc_angles_dict={(0,1):0.3, (0,2):0, (0,3):0, (1,2):0.5, (1,3):0, (2,3):-0.3})
-
-
-### Continuous Motions
-
-It is possible to create {prf:ref}`continuous motions <def-motion>` in two separate ways. First,
-the user can specify a parametric motion using the class ``ParametricMotion``. 
-As an example, consider the 4-cycle. A parametric motion can be specified
-using the following sequence of commands:
-
-```{code-cell} ipython3
-from pyrigi.motion import ParametricMotion
-import sympy as sp
-motion = ParametricMotion(
-    graphs.Cycle(4),
-    {
-        0: ("0", "0"),
-        1: ("1", "0"),
-        2: ("4 * (t**2 - 2) / (t**2 + 4)", "12 * t / (t**2 + 4)"),
-        3: (
-            "(t**4 - 13 * t**2 + 4) / (t**4 + 5 * t**2 + 4)",
-            "6 * (t**3 - 2 * t) / (t**4 + 5 * t**2 + 4)",
-        ),
-    },
-    [-sp.oo, sp.oo],
-)
-motion.animate()
-```
-
-However, a parametric motion is not always available. If you still want to get an
-intuition for how a deformation path looks, it can be numerically approximated using
-the class ``ApproximateMotion``. As an example, consider the complete bipartite graph $K_{4,2}$.
-A cyclic motion of $K_{4,2}$ can be approximated using the following code:
-
-```{code-cell} ipython3
-from pyrigi.motion import ApproximateMotion
-F = frameworks.CompleteBipartite(2,4)
-motion = ApproximateMotion.from_framework(F, 395, chosen_flex=0, step_size=0.15)
-motion.animate(duration=10)
 ```
 
 ## Plotting in 3 Dimensions

--- a/doc/userguide/tutorials/plotting.md
+++ b/doc/userguide/tutorials/plotting.md
@@ -284,6 +284,44 @@ F.plot(
 )
 ```
 
+### Continuous Motions
+
+It is possible to create {prf:ref}`continuous motions <def-motion>` in two separate ways. First,
+the user can specify a parametric motion using the class ``ParametricMotion``. 
+As an example, consider the 4-cycle. A parametric motion can be specified
+using the following sequence of commands:
+
+```{code-cell} ipython3
+from pyrigi.motion import ParametricMotion
+import sympy as sp
+motion = ParametricMotion(
+    graphs.Cycle(4),
+    {
+        0: ("0", "0"),
+        1: ("1", "0"),
+        2: ("4 * (t**2 - 2) / (t**2 + 4)", "12 * t / (t**2 + 4)"),
+        3: (
+            "(t**4 - 13 * t**2 + 4) / (t**4 + 5 * t**2 + 4)",
+            "6 * (t**3 - 2 * t) / (t**4 + 5 * t**2 + 4)",
+        ),
+    },
+    [-sp.oo, sp.oo],
+)
+motion.animate()
+```
+
+However, a parametric motion is not always available. If you still want to get an
+intuition for how a deformation path looks, it can be numerically approximated using
+the class ``ApproximateMotion``. As an example, consider the complete bipartite graph $K_{4,2}$.
+A cyclic motion of $K_{4,2}$ can be approximated using the following code:
+
+```{code-cell} ipython3
+from pyrigi.motion import ApproximateMotion
+F = frameworks.CompleteBipartite(2,4)
+motion = ApproximateMotion.from_framework(F, 394, chosen_flex=0, step_length=0.15)
+motion.animate(duration=10)
+```
+
 ## Plotting in 3 Dimensions
 
 Plotting in 3 dimensions is also possible. The plot can be made interactive by using cell magic:

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -3,7 +3,7 @@ Module for miscellaneous functions.
 """
 
 import math
-from pyrigi.data_type import Sequence, Number, point_to_vector, InfFlex, Vertex, Point
+from pyrigi.data_type import Sequence, Number, point_to_vector, InfFlex, Vertex
 from sympy import Matrix
 import sympy as sp
 import numpy as np

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -3,7 +3,7 @@ Module for miscellaneous functions.
 """
 
 import math
-from pyrigi.data_type import Sequence, Number, point_to_vector, InfFlex
+from pyrigi.data_type import Sequence, Number, point_to_vector, InfFlex, Vertex, Point
 from sympy import Matrix
 import sympy as sp
 import numpy as np
@@ -207,3 +207,41 @@ def normalize_flex(inf_flex: InfFlex, numerical: bool = False) -> InfFlex:
         return [q / flex_norm for q in inf_flex]
     else:
         raise TypeError("`inf_flex` does not have the correct type.")
+
+
+def vector_distance_pointwise(
+    dict1: dict[Vertex, Sequence[Number]],
+    dict2: dict[Vertex, Sequence[Number]],
+    numerical: bool = False,
+) -> float:
+    """
+    Computes the Euclidean distance between two realizations or pointwise vectors.
+
+    This method computes the Euclidean distance from the realization `dict_1`
+    to `dict2`. These dicts need to be based on the same vertex set.
+    """
+    if not set(dict1.keys()) == set(dict2.keys()) or not len(dict1) == len(dict2):
+        raise ValueError("`dict1` and `dict2` are not based on the same vertex set.")
+    if numerical:
+        return np.linalg.norm(
+            [
+                p1 - p2
+                for v in dict1.keys()
+                for p1, p2 in zip(
+                    dict1[v],
+                    dict2[v],
+                )
+            ]
+        )
+    return sp.sqrt(
+        sum(
+            [
+                (p1 - p2) ** 2
+                for v in dict1.keys()
+                for p1, p2 in zip(
+                    dict1[v],
+                    dict2[v],
+                )
+            ]
+        )
+    )

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -3,8 +3,9 @@ Module for miscellaneous functions.
 """
 
 import math
-from pyrigi.data_type import Sequence, Number, point_to_vector
+from pyrigi.data_type import Sequence, Number, point_to_vector, InfFlex
 from sympy import Matrix
+import sympy as sp
 import numpy as np
 from math import isclose, log10
 
@@ -179,3 +180,18 @@ def eval_sympy_vector(vector: Sequence[Number], tolerance: float = 1e-9) -> list
         float(coord.evalf(int(round(2.5 * log10(tolerance ** (-1) + 1)))))
         for coord in point_to_vector(vector)
     ]
+
+
+def normalize_flex(inf_flex: InfFlex, numerical:bool=False) -> InfFlex:
+    """
+    Divides a vector by its Euclidean norm.
+    """
+    if isinstance(inf_flex, dict):
+        complete_flex = sum(list(inf_flex.values()),[])
+        flex_norm = np.linalg.norm(complete_flex) if numerical else sp.sqrt(sum([q**2 for q in complete_flex]))
+        return {v: tuple([pt/flex_norm for pt in q]) for v, q in inf_flex.items()}
+    elif isinstance(inf_flex, Sequence):
+        flex_norm = np.linalg.norm(inf_flex) if numerical else sp.sqrt(sum([q**2 for q in inf_flex]))
+        return [q/flex_norm for q in inf_flex]
+    else:
+        raise TypeError("`inf_flex` does not have the correct type.")

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -182,16 +182,30 @@ def eval_sympy_vector(vector: Sequence[Number], tolerance: float = 1e-9) -> list
     ]
 
 
-def normalize_flex(inf_flex: InfFlex, numerical:bool=False) -> InfFlex:
+def normalize_flex(inf_flex: InfFlex, numerical: bool = False) -> InfFlex:
     """
     Divides a vector by its Euclidean norm.
     """
     if isinstance(inf_flex, dict):
-        complete_flex = sum(list(inf_flex.values()),[])
-        flex_norm = np.linalg.norm(complete_flex) if numerical else sp.sqrt(sum([q**2 for q in complete_flex]))
-        return {v: tuple([pt/flex_norm for pt in q]) for v, q in inf_flex.items()}
+        if numerical:
+            _inf_flex = {
+                v: [float(sp.sympify(q).evalf(15)) for q in flex]
+                for v, flex in inf_flex.items()
+            }
+            flex_norm = np.linalg.norm(sum(_inf_flex.values(), []))
+            return {
+                v: tuple([pt / flex_norm for pt in q]) for v, q in _inf_flex.items()
+            }
+        flex_norm = sp.sqrt(
+            sum([q**2 for q in sum([list(val) for val in inf_flex.values()], [])])
+        )
+        return {v: tuple([pt / flex_norm for pt in q]) for v, q in inf_flex.items()}
     elif isinstance(inf_flex, Sequence):
-        flex_norm = np.linalg.norm(inf_flex) if numerical else sp.sqrt(sum([q**2 for q in inf_flex]))
-        return [q/flex_norm for q in inf_flex]
+        if numerical:
+            _inf_flex = [float(sp.sympify(q).evalf(15)) for q in _inf_flex]
+            flex_norm = np.linalg.norm(_inf_flex)
+            return [q / flex_norm for q in _inf_flex]
+        flex_norm = sp.sqrt(sum([q**2 for q in inf_flex]))
+        return [q / flex_norm for q in inf_flex]
     else:
         raise TypeError("`inf_flex` does not have the correct type.")

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -196,9 +196,7 @@ def normalize_flex(inf_flex: InfFlex, numerical: bool = False) -> InfFlex:
             return {
                 v: tuple([pt / flex_norm for pt in q]) for v, q in _inf_flex.items()
             }
-        flex_norm = sp.sqrt(
-            sum([q**2 for q in sum([list(val) for val in inf_flex.values()], [])])
-        )
+        flex_norm = sp.sqrt(sum([q**2 for val in inf_flex.values() for q in val]))
         return {v: tuple([pt / flex_norm for pt in q]) for v, q in inf_flex.items()}
     elif isinstance(inf_flex, Sequence):
         if numerical:

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -4,13 +4,14 @@ This module contains functionality related to motions (continuous flexes).
 
 from pyrigi.graph import Graph
 from pyrigi.framework import Framework
-from pyrigi.data_type import Vertex, Point, Sequence, InfFlex
+from pyrigi.data_type import Vertex, Point, Sequence, InfFlex, Number
 from sympy import simplify
 from pyrigi.misc import point_to_vector, normalize_flex
 import numpy as np
 import sympy as sp
 from IPython.display import SVG
 from typing import Any
+from copy import deepcopy
 
 
 class Motion(object):
@@ -30,6 +31,12 @@ class Motion(object):
 
     def __repr__(self) -> str:
         return self.__str__()
+    
+    def graph(self) -> Graph:
+        """
+        Return a copy of the underlying graph.
+        """
+        return deepcopy(self._graph)
 
     @staticmethod
     def _normalize_realizations(
@@ -99,7 +106,6 @@ class Motion(object):
         duration:
             The duration of one period of the animation in seconds.
         """
-
         if self._dim != 2:
             raise ValueError("Animations are supported only for motions in 2D.")
         if not (
@@ -269,15 +275,22 @@ class ParametricMotion(Motion):
                 return False
         return True
 
-    def realization(self, value, numeric: bool = False) -> dict[Vertex:Point]:
+    def realization(self, value: Number, numerical: bool = False) -> dict[Vertex:Point]:
         """
-        Return specific realization for the given value of the parameter.
+        Return specific realization for the given ``value`` of the parameter.
 
+        Parameters
+        ----------
+        value:
+            The parameter of the deformation path is substituted by ``value``.
+        numerical:
+            Boolean determining whether the sympy expressions are supposed to be
+            evaluated (``True``) or not (``False``).
         """
 
         realization = {}
         for v in self._graph.nodes:
-            if numeric:
+            if numerical:
                 _value = sp.sympify(value).evalf()
                 placement = (
                     self._parametrization[v]
@@ -383,7 +396,7 @@ class ApproximateMotion(Motion):
     Attributes
     ----------
     edge_lengths:
-        The edge lengths that ought to be preserved. This parameter is set internally.
+        The edge lengths that ought to be preserved.
     motion_samples:
         A list of numerical configurations on the configuration space.
 

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -84,7 +84,7 @@ class Motion(object):
         if len(fixed_edge) != 2:
             raise TypeError("The length of `fixed_edge` is not 2.")
         (v1, v2) = (fixed_edge[0], fixed_edge[1])
-        if not v1 in realizations[0] and v in realizations[0]:
+        if not (v1 in realizations[0] and v2 in realizations[0]):
             raise ValueError(
                 "The vertices of the edge {realizations} are not part of the graph."
             )
@@ -100,7 +100,8 @@ class Motion(object):
             ]
             if np.isclose(np.linalg.norm(fixed_direction), 0, rtol=1e-6):
                 warn(
-                    f"The entries of the edge {fixed_edge} are too close to each other. Thus, `fixed_direction=(1,0)` is chosen instead."
+                    f"The entries of the edge {fixed_edge} are too close to each "
+                    + "other. Thus, `fixed_direction=(1,0)` is chosen instead."
                 )
                 fixed_direction = (1, 0)
             else:

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -31,7 +31,7 @@ class Motion(object):
 
     def __repr__(self) -> str:
         return self.__str__()
-    
+
     def graph(self) -> Graph:
         """
         Return a copy of the underlying graph.

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -235,9 +235,7 @@ class Motion(object):
             _realizations = self._fix_origin(realizations)
         else:
             _realizations = realizations
-        _realizations = self._normalize_realizations(
-            _realizations, width, height, 15
-        )
+        _realizations = self._normalize_realizations(_realizations, width, height, 15)
 
         svg = f'<svg width="{width}" height="{height}" version="1.1" '
         svg += 'baseProfile="full" xmlns="http://www.w3.org/2000/svg" '

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -3,9 +3,10 @@ This module contains functionality related to motions (continuous flexes).
 """
 
 from pyrigi.graph import Graph
-from pyrigi.data_type import Vertex, Point, Sequence
+from pyrigi.framework import Framework
+from pyrigi.data_type import Vertex, Point, Sequence, InfFlex
 from sympy import simplify
-from pyrigi.misc import point_to_vector
+from pyrigi.misc import point_to_vector, normalize_flex
 import numpy as np
 import sympy as sp
 from IPython.display import SVG
@@ -28,7 +29,147 @@ class Motion(object):
 
     def __repr__(self) -> str:
         return self.__str__()
+    
+    @staticmethod
+    def _normalize_realizations(
+        realizations: Sequence[dict[Vertex, Point]],
+        width: int,
+        height: int,
+        spacing: int,
+    ) -> list[dict[Vertex, Point]]:
+        """
+        Normalize a given list of realizations
+        so they fit exactly to the window with the given dimensions.
+        """
 
+        xmin = np.inf
+        xmax = -np.inf
+        ymin = np.inf
+        ymax = -np.inf
+        for r in realizations:
+            for v, placement in r.items():
+                xmin = min(xmin, placement[0])
+                xmax = max(xmax, placement[0])
+                ymin = min(ymin, placement[1])
+                ymax = max(ymax, placement[1])
+
+        xnorm = (width - spacing * 2) / (xmax - xmin)
+        ynorm = (height - spacing * 2) / (ymax - ymin)
+        norm_factor = min(xnorm, ynorm)
+
+        realizations_normalized = []
+        for r in realizations:
+            r_norm = {}
+            for v, placement in r.items():
+                r_norm[v] = [
+                    int((placement[0] - xmin) * norm_factor) + spacing,
+                    int((placement[1] - ymin) * norm_factor) + spacing,
+                ]
+            realizations_normalized.append(r_norm)
+        return realizations_normalized
+
+    def animate(
+        self,
+        width: int = 500,
+        height: int = 500,
+        filename: str = None,
+        sampling: int = 50,
+        show_labels: bool = True,
+        vertex_size: int = 5,
+        duration: int = 8,
+    ) -> None:
+        """
+        Animate the parametric motion.
+
+        Parameters
+        ----------
+        width:
+            The width of the window in the svg file.
+        height:
+            The height of the window in the svg file.
+        filename:
+            A name used to store the svg. If ``None```, the svg is not saved.
+        sampling:
+            The number of discrete points or frames used to approximate the motion in the
+            animation. A higher value results in a smoother and more accurate
+            representation of the motion, while a lower value can speed up rendering
+            but may lead to a less precise or jerky animation. This parameter controls
+            the resolution of the animation's movement by setting the density of
+            sampled data points between keyframes or time steps.
+        show_labels:
+            If ``True``, the vertices will have a number label.
+        vertex_size:
+            The size of vertices in the animation.
+        duration:
+            The duration of one period of the animation in seconds.
+        """
+
+        if self._dim != 2:
+            raise ValueError("This motion is not in dimension 2!")
+        if self.__class__.__name__=="ParametricMotion":
+            lower, upper = self._interval
+            if lower == -np.inf or upper == np.inf:
+                realizations = self._realization_sampling(sampling, use_tan=True)
+            else:
+                realizations = self._realization_sampling(sampling)
+        elif self.__class__.__name__=="ApproximateMotion":
+            realizations = self.motion_samples
+        else:
+            raise AttributeError("The method `animate` is not yet implemented for the class {self.__class__.__name__}")
+
+        realizations = self._normalize_realizations(realizations, width, height, 15)
+
+        svg = f'<svg width="{width}" height="{height}" version="1.1" '
+        svg += 'baseProfile="full" xmlns="http://www.w3.org/2000/svg" '
+        svg += 'xmlns:xlink="http://www.w3.org/1999/xlink">\n'
+        svg += '<rect width="100%" height="100%" fill="white"/>\n'
+
+        v_to_int = {}
+        for i, v in enumerate(self._graph.nodes):
+            v_to_int[v] = i
+            tmp = """<defs>\n"""
+
+            tmp += f'\t<marker id="vertex{i}" viewBox="0 0 30 30" '
+            tmp += f'refX="15" refY="15" markerWidth="{vertex_size}" '
+            tmp += f'markerHeight="{vertex_size}">\n'
+            tmp += '\t<circle cx="15" cy="15" r="13.5" fill="white" '
+            tmp += 'stroke="black" stroke-width="2"/>\n'
+            if show_labels:
+                tmp += '\t<text x="15" y="22" font-size="22.5" '
+                tmp += f'text-anchor="middle" fill="black">\n\t\t{i}\n\t</text>\n'
+            tmp += "\t</marker>\n</defs>\n"
+            svg = svg + "\n" + tmp
+
+        inital_realization = realizations[0]
+        for u, v in self._graph.edges:
+            ru = inital_realization[u]
+            rv = inital_realization[v]
+            path = '<path fill="transparent" stroke="grey" stroke-width="5px" '
+            path += f'id="edge{v_to_int[u]}-{v_to_int[v]}" d="M {ru[0]} {ru[1]} '
+            path += f'L {rv[0]} {ru[1]}" marker-start="url(#vertex{v_to_int[u]})" '
+            path += f'marker-end="url(#vertex{v_to_int[v]})" />'
+            svg = svg + "\n" + path
+        svg = svg + "\n"
+
+        for u, v in self._graph.edges:
+            positions_str = ""
+            for r in realizations:
+                ru = r[u]
+                rv = r[v]
+                positions_str += f" M {ru[0]} {ru[1]} L {rv[0]} {rv[1]};"
+            animation = f'<animate href="#edge{v_to_int[u]}-{v_to_int[v]}" '
+            animation += f'attributeName="d" dur="{duration}s" '
+            animation += 'repeatCount="indefinite" calcMode="linear" '
+            animation += f'values="{positions_str}"/>'
+            svg = svg + "\n" + animation
+        svg = svg + "\n</svg>"
+
+        if filename is not None:
+            if not filename.endswith(".svg"):
+                filename = filename + ".svg"
+            with open(filename, "wt") as file:
+                file.write(svg)
+        return SVG(data=svg)
 
 class ParametricMotion(Motion):
     """
@@ -47,10 +188,8 @@ class ParametricMotion(Motion):
     interval:
         The interval in which the parameter is considered.
 
-
     Examples
     --------
-
     >>> from pyrigi.motion import ParametricMotion
     >>> import sympy as sp
     >>> from pyrigi import graphDB as graphs
@@ -183,139 +322,125 @@ class ParametricMotion(Motion):
             realizations.append(self.realization(f"tan({i})", numeric=True))
         return realizations
 
-    @staticmethod
-    def _normalize_realizations(
-        realizations: Sequence[dict[Vertex, Point]],
-        width: int,
-        height: int,
-        spacing: int,
-    ) -> list[dict[Vertex, Point]]:
-        """
-        Normalize a given list of realizations
-        so they fit exactly to the window with the given dimensions.
-        """
 
-        xmin = np.inf
-        xmax = -np.inf
-        ymin = np.inf
-        ymax = -np.inf
-        for r in realizations:
-            for v, placement in r.items():
-                xmin = min(xmin, placement[0])
-                xmax = max(xmax, placement[0])
-                ymin = min(ymin, placement[1])
-                ymax = max(ymax, placement[1])
+class ApproximateMotion(Motion):
+    """
+    Class representing an approximated motion of a framework.
 
-        xnorm = (width - spacing * 2) / (xmax - xmin)
-        ynorm = (height - spacing * 2) / (ymax - ymin)
-        norm_factor = min(xnorm, ynorm)
+    Definitions
+    -----------
+    :prf:ref:`Continuous flex (motion)<def-motion>`
 
-        realizations_normalized = []
-        for r in realizations:
-            r_norm = {}
-            for v, placement in r.items():
-                r_norm[v] = [
-                    int((placement[0] - xmin) * norm_factor) + spacing,
-                    int((placement[1] - ymin) * norm_factor) + spacing,
-                ]
-            realizations_normalized.append(r_norm)
-        return realizations_normalized
+    Parameters
+    ----------
+    graph:
+    motion_samples:
+        A list of numerical configurations on the configuration space.
+    steps:
+        The amount of retraction steps.
+    initial_step_length:
+        The step size of each retraction step.
+    edge_lengths:
+        The edge lengths that ought to be preserved. 
 
-    def animate(
-        self,
-        width: int = 500,
-        height: int = 500,
-        filename: str = None,
-        sampling: int = 50,
-        show_labels: bool = True,
-        vertex_size: int = 5,
-        duration: int = 8,
+    Examples
+    --------
+    >>> from pyrigi.motion import ApproximateMotion
+    >>> from pyrigi import graphDB as graphs
+    >>> motion = ApproximateMotion(
+    ...     graphs.Cycle(4),
+    ...     {0:(0,0), 1:(1,0), 2:(1,1), 3:(0,1)},
+    ...     10
+    ... )
+    >>> motion
+    ApproximateMotion of a Graph with vertices [0, 1, 2, 3] and edges [[0, 1], [0, 3], [1, 2], [2, 3]] with starting configuration
+    {0: (0.0, 0.0), 1: (1.0, 0.0), 2: (1.0, 1.0), 3: (0.0, 1.0)},
+    10 retraction steps and initial step size 0.1.
+    """  # noqa: E501
+
+    def __init__(
+        self, graph: Graph, starting_configuration: dict[Vertex, Point], steps: int, step_length: float = 0.1
     ) -> None:
         """
-        Animate the parametric motion.
-
-        Parameters
-        ----------
-        width:
-            The width of the window in the svg file.
-        height:
-            The height of the window in the svg file.
-        filename:
-            A name used to store the svg. If ``None```, the svg is not saved.
-        sampling:
-            The number of discrete points or frames used to approximate the motion in the
-            animation. A higher value results in a smoother and more accurate
-            representation of the motion, while a lower value can speed up rendering
-            but may lead to a less precise or jerky animation. This parameter controls
-            the resolution of the animation's movement by setting the density of
-            sampled data points between keyframes or time steps.
-        show_labels:
-            If ``True``, the vertices will have a number label.
-        vertex_size:
-            The size of vertices in the animation.
-        duration:
-            The duration of one period of the animation in seconds.
+        Creates an instance.
         """
+        super().__init__(graph)
 
-        if self._dim != 2:
-            raise ValueError("This motion is not in dimension 2!")
+        if not len(starting_configuration) == self._graph.number_of_nodes():
+            raise IndexError(
+                "The realization does not contain the correct amount of vertices!"
+            )
 
-        lower, upper = self._interval
-        if lower == -np.inf or upper == np.inf:
-            realizations = self._realization_sampling(sampling, use_tan=True)
-        else:
-            realizations = self._realization_sampling(sampling)
+        self._starting_configuration = {v: tuple([float(sp.sympify(pt).evalf(15)) for pt in p]) for v, p in starting_configuration.items()}
+        p0 = list(self._starting_configuration.values())[0]
+        # Translate to the origin
+        self._starting_configuration = {v: tuple([pt[i]-p0[i] for i in range(len(pt))]) for v,pt in self._starting_configuration.items()}
+        self._dim = len(list(self._starting_configuration.values())[0])
+        for v in self._graph.nodes:
+            if v not in starting_configuration:
+                raise KeyError(f"Vertex {v} is not a key of the given realization!")
+            if len(self._starting_configuration[v]) != self._dim:
+                raise ValueError(
+                    f"The point {self._starting_configuration[v]} in the parametrization"
+                    f" corresponding to vertex {v} does not have the right dimension."
+                )
 
-        realizations = self._normalize_realizations(realizations, width, height, 15)
+        self.motion_samples = [self._starting_configuration]
+        self.steps = steps
+        self.initial_step_length = step_length
+        self._current_step_length = step_length
+        F = Framework(self._graph, self._starting_configuration)
+        self.edge_lengths = F.edge_lengths(numerical=True)
+        cur_inf_flex = normalize_flex(F._transform_inf_flex_to_pointwise(F.inf_flexes()[0]))
+        for i in range(steps):
+            euler_step, cur_inf_flex = self._euler_step(cur_inf_flex)
+            self.motion_samples.append(self._newton_steps(euler_step))
+            # Reject the step if the step size is not close to what we expect
+            if any([np.linalg.norm([p1-p2 for p1,p2 in zip(self.motion_samples[-1][v], self.motion_samples[-2][v])])>self.initial_step_length for v in self._graph.nodes]):
+                self._current_step_length=self._current_step_length/2
+                self.motion_samples.pop()
+                i = i-1
+            elif all([np.linalg.norm([p1-p2 for p1,p2 in zip(self.motion_samples[-1][v], self.motion_samples[-2][v])])<self.initial_step_length/1.5 for v in self._graph.nodes]):
+                self._current_step_length=self._current_step_length*2
+                self.motion_samples.pop()
+                i = i-1
+    
+    @classmethod
+    def from_framework(cls, F: Framework, steps: int, step_length: float = 0.001):
+        """
+        Instantiates an ``ApproximateMotion`` from a ``Framework``.
+        """
+        return ApproximateMotion(F.graph(), F.realization(as_points=True, numerical=True), steps, step_length)
 
-        svg = f'<svg width="{width}" height="{height}" version="1.1" '
-        svg += 'baseProfile="full" xmlns="http://www.w3.org/2000/svg" '
-        svg += 'xmlns:xlink="http://www.w3.org/1999/xlink">\n'
-        svg += '<rect width="100%" height="100%" fill="white"/>\n'
+    def _euler_step(self, old_inf_flex: InfFlex) -> tuple[dict[Vertex, Point], InfFlex]:
+        """
+        Computes a single Euler step.
 
-        v_to_int = {}
-        for i, v in enumerate(self._graph.nodes):
-            v_to_int[v] = i
-            tmp = """<defs>\n"""
+        This method returns the resulting configuration and the infinitesimal flex
+        that was used in the computation as a tuple.
+        """
+        F = Framework(self._graph, self.motion_samples[-1])
+        inf_flex = normalize_flex(F._transform_inf_flex_to_pointwise(F.inf_flexes()[0]))
+        if any([np.linalg.norm([float(sp.sympify(q-w).evalf(15)) for q,w in zip(inf_flex[v], old_inf_flex[v])])>1 for v in inf_flex.keys()]):
+            inf_flex = {v: [-pt for pt in p] for v,p in inf_flex.items()}
+        point = self.motion_samples[-1]
+        return {v: tuple([p[i]+self._current_step_length*inf_flex[v][i] for i in range(len(point[v]))]) for v, p in point.items()}, inf_flex
 
-            tmp += f'\t<marker id="vertex{i}" viewBox="0 0 30 30" '
-            tmp += f'refX="15" refY="15" markerWidth="{vertex_size}" '
-            tmp += f'markerHeight="{vertex_size}">\n'
-            tmp += '\t<circle cx="15" cy="15" r="13.5" fill="white" '
-            tmp += 'stroke="black" stroke-width="2"/>\n'
-            if show_labels:
-                tmp += '\t<text x="15" y="22" font-size="22.5" '
-                tmp += f'text-anchor="middle" fill="black">\n\t\t{i}\n\t</text>\n'
-            tmp += "\t</marker>\n</defs>\n"
-            svg = svg + "\n" + tmp
+    def _newton_steps(self, realization: dict[Vertex, Point]) -> dict[Vertex, Point]: 
+        F = Framework(self._graph, realization)
+        cur_sol = np.array(sum([list(p) for p in realization.values()], []))
+        while not all([np.isclose(L, self.edge_lengths[e], atol=1e-4) for e, L in F.edge_lengths(numerical=True).items()]):
+            mat = np.array(F.rigidity_matrix()).astype(np.float64)
+            equations = [np.linalg.norm([float(sp.sympify(v-w).evalf(15)) for v, w in zip(cur_sol[(self._dim*e[0]):(self._dim*(e[0]+1))], cur_sol[(self._dim*e[1]):(self._dim*(e[1]+1))])])-self.edge_lengths[e] for e in self.edge_lengths.keys()]
+            newton_step = np.dot(np.linalg.pinv(mat), equations)
+            new_sol = [float(sp.sympify(cur_sol[i] - 1e-2*newton_step[i]).evalf(15)) for i in range(len(cur_sol))]
+            cur_sol = sum([[new_sol[i+j] - new_sol[j] for j in range(self._dim)] for i in range(0,len(new_sol),self._dim)], [])
+            F = Framework(self._graph, {i: [cur_sol[(self._dim*i):(self._dim*(i+1))]] for i in range(len(realization.keys()))})
+        return({i: tuple(cur_sol[(self._dim*i):(self._dim*(i+1))]) for i in range(len(realization.keys()))})
 
-        inital_realization = realizations[0]
-        for u, v in self._graph.edges:
-            ru = inital_realization[u]
-            rv = inital_realization[v]
-            path = '<path fill="transparent" stroke="grey" stroke-width="5px" '
-            path += f'id="edge{v_to_int[u]}-{v_to_int[v]}" d="M {ru[0]} {ru[1]} '
-            path += f'L {rv[0]} {ru[1]}" marker-start="url(#vertex{v_to_int[u]})" '
-            path += f'marker-end="url(#vertex{v_to_int[v]})" />'
-            svg = svg + "\n" + path
-        svg = svg + "\n"
-
-        for u, v in self._graph.edges:
-            positions_str = ""
-            for r in realizations:
-                ru = r[u]
-                rv = r[v]
-                positions_str += f" M {ru[0]} {ru[1]} L {rv[0]} {rv[1]};"
-            animation = f'<animate href="#edge{v_to_int[u]}-{v_to_int[v]}" '
-            animation += f'attributeName="d" dur="{duration}s" '
-            animation += 'repeatCount="indefinite" calcMode="linear" '
-            animation += f'values="{positions_str}"/>'
-            svg = svg + "\n" + animation
-        svg = svg + "\n</svg>"
-
-        if filename is not None:
-            if not filename.endswith(".svg"):
-                filename = filename + ".svg"
-            with open(filename, "wt") as file:
-                file.write(svg)
-        return SVG(data=svg)
+    def __str__(self) -> str:
+        res = super().__str__() + " with starting configuration\n"
+        res += str(self.motion_samples[0]) + ",\n"
+        res += str(self.steps) + " retraction steps and initial step size "
+        res += str(self.initial_step_length) + "."
+        return res

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -180,6 +180,7 @@ class Motion(object):
         plot_style: PlotStyle,
         fixed_edge: DirectedEdge = None,
         fixed_direction: Sequence[Number] = [1, 0],
+        fix_origin: bool = True,
         filename: str = None,
         duration: int = 8,
         **kwargs,
@@ -187,7 +188,9 @@ class Motion(object):
         """
         Animate the continuous motion.
 
-        See :class:`~.PlotStyle` for a list of possible visualization keywords.
+        See :class:`~.PlotStyle2D` for a list of possible visualization keywords.
+        Not necessarily all of them apply (e.g. keywords related to infinitesimal
+        flexes are ignored).
 
         Parameters
         ----------
@@ -201,8 +204,11 @@ class Motion(object):
             the animation. The default is that only the origin is pinned and that
             the framework can rotate freely.
         fixed_direction:
-            Vector to which the first direction is fixed. By default, this is the
-            x-axis.
+            Vector to which the first direction is fixed. By default, it is the
+            vector from ``fixed_edge[0]`` to ``fixed_edge[1]``.
+        fix_origin:
+            A boolean deciding whether the origin is fixed. This only has an effect
+            if fixed_edge=None``.
         filename:
             A name used to store the svg. If ``None``, the svg is not saved.
         duration:
@@ -225,9 +231,13 @@ class Motion(object):
 
         if fixed_edge is not None:
             _realizations = self._fix_edge(realizations, fixed_edge, fixed_direction)
-        else:
+        elif fix_origin:
             _realizations = self._fix_origin(realizations)
-        _realizations = self._normalize_realizations(_realizations, width, height, 15)
+        else:
+            _realizations = realizations
+        _realizations = self._normalize_realizations(
+            _realizations, width, height, 15
+        )
 
         svg = f'<svg width="{width}" height="{height}" version="1.1" '
         svg += 'baseProfile="full" xmlns="http://www.w3.org/2000/svg" '
@@ -475,6 +485,7 @@ class ParametricMotion(Motion):
         return super().animate(
             realizations,
             None,
+            fix_origin=False,
             **kwargs,
         )
 
@@ -660,6 +671,7 @@ class ApproximateMotion(Motion):
         return super().animate(
             realizations,
             None,
+            fix_origin=True,
             **kwargs,
         )
 

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -159,9 +159,11 @@ def test_ParametricMotion_init():
 
 
 def test_ApproximateMotion_init():
-    ApproximateMotion.from_framework(fws.Cycle(4), 10)
+    ApproximateMotion(fws.Cycle(4), 10)
     F = fws.Cycle(5)
-    ApproximateMotion(F.graph(), F.realization(as_points=True, numerical=True), 1, 1)
+    ApproximateMotion.from_graph(
+        F.graph(), F.realization(as_points=True, numerical=True), 1, 1
+    )
 
 
 @pytest.mark.slow_main
@@ -170,7 +172,7 @@ def test_animate():
     Test that the motion actually moves.
     """
     F = fws.Square()
-    M = ApproximateMotion(
+    M = ApproximateMotion.from_graph(
         F.graph(), F.realization(as_points=True, numerical=True), 50, 0.075
     )
 
@@ -185,7 +187,7 @@ def test_animate():
 
 def test_ApproximateMotion_from_framework():
     F = fws.Square()
-    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    M = ApproximateMotion(F, 10, 0.075)
     for sample in M.motion_samples[1:]:
         assert F.is_equivalent_realization(
             sample, numerical=True, tolerance=1e-3
@@ -194,7 +196,7 @@ def test_ApproximateMotion_from_framework():
     # Square with a triangle on one of its sides
     F.add_vertex([2, 2])
     F.add_edges([[2, 4], [3, 4]])
-    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    M = ApproximateMotion(F, 10, 0.075)
     for sample in M.motion_samples[1:]:
         assert F.is_equivalent_realization(
             sample, numerical=True, tolerance=1e-3
@@ -204,7 +206,7 @@ def test_ApproximateMotion_from_framework():
     F = Framework.Complete([[0, 0], [1, 0], [1, 1], [0, 1]])
     F.add_vertex([2, 2])
     F.add_edge([2, 4])
-    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    M = ApproximateMotion(F, 10, 0.075)
     for sample in M.motion_samples[1:]:
         assert F.is_equivalent_realization(
             sample, numerical=True, tolerance=1e-3
@@ -215,4 +217,4 @@ def test_ApproximateMotion_from_framework():
 def test_newton_raises_runtimeerror():
     F = fws.ThreePrism(realization="flexible")
     with pytest.raises(RuntimeError):
-        ApproximateMotion.from_framework(F, 5, 0.1)
+        ApproximateMotion(F, 5, 0.1)

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -159,12 +159,27 @@ def test_ParametricMotion_init():
 
 
 def test_ApproximateMotion_init():
-    ApproximateMotion.from_framework(fws.Cycle(4), 100)
+    ApproximateMotion.from_framework(fws.Cycle(4), 10)
+    F = fws.Cycle(5)
+    ApproximateMotion(F.graph(), F.realization(as_points=True, numerical=True), 1, 1)
 
 
 @pytest.mark.slow_main
 def test_animate():
     F = fws.Square()
-    M = ApproximateMotion(F.graph(), F.realization(as_points=True, numerical=True), 118, 0.075)
-    assert np.linalg.norm([u-v for u,v in zip(sum([list(val) for val in M.motion_samples[0].values()],[]), sum([list(val) for val in M.motion_samples[-1].values()],[]))])<1e-2
+    M = ApproximateMotion(
+        F.graph(), F.realization(as_points=True, numerical=True), 167, 0.075
+    )
+    assert (
+        np.linalg.norm(
+            [
+                u - v
+                for u, v in zip(
+                    sum([list(val) for val in M.motion_samples[0].values()], []),
+                    sum([list(val) for val in M.motion_samples[-1].values()], []),
+                )
+            ]
+        )
+        < 1e-2
+    )
     M.animate()

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -167,8 +167,7 @@ def test_ApproximateMotion_init():
 @pytest.mark.slow_main
 def test_animate():
     """
-    Test that (1) the motion actually does something and
-    (2) that it returns to its original configuration.
+    Test that the motion actually moves.
     """
     F = fws.Square()
     M = ApproximateMotion(
@@ -210,3 +209,10 @@ def test_ApproximateMotion_from_framework():
         assert F.is_equivalent_realization(
             sample, numerical=True, tolerance=1e-3
         ) and not F.is_congruent_realization(sample, numerical=True)
+
+
+@pytest.mark.long_local
+def test_newton_raises_runtimeerror():
+    F = fws.ThreePrism(realization="flexible")
+    with pytest.raises(RuntimeError):
+        ApproximateMotion.from_framework(F, 5, 0.1)

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -167,13 +167,13 @@ def test_ApproximateMotion_init():
 def test_animate():
     F = fws.Square()
     M = ApproximateMotion(
-        F.graph(), F.realization(as_points=True, numerical=True), 167, 0.075
+        F.graph(), F.realization(as_points=True, numerical=True), 50, 0.075
     )
     # Test that (1) the motion actually does something and
     # (2) that it returns to its original configuration
-    assert F.is_equivalent_realization(
-        M.motion_samples[-1], numerical=True
-    ) and not F.is_equivalent_realization(
-        M.motion_samples[83], numerical=True, tolerance=1
-    )
+
+    for i in range(1, len(M.motion_samples)):
+        assert F.is_equivalent_realization(
+            M.motion_samples[i], numerical=True
+        ) and not F.is_congruent_realization(M.motion_samples[i], numerical=True)
     M.animate()

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -2,7 +2,6 @@ from pyrigi.motion import ParametricMotion, ApproximateMotion
 import pyrigi.graphDB as graphs
 import pyrigi.frameworkDB as fws
 import sympy as sp
-import numpy as np
 import pytest
 
 
@@ -170,16 +169,11 @@ def test_animate():
     M = ApproximateMotion(
         F.graph(), F.realization(as_points=True, numerical=True), 167, 0.075
     )
-    assert (
-        np.linalg.norm(
-            [
-                u - v
-                for u, v in zip(
-                    sum([list(val) for val in M.motion_samples[0].values()], []),
-                    sum([list(val) for val in M.motion_samples[-1].values()], []),
-                )
-            ]
-        )
-        < 1e-2
+    # Test that (1) the motion actually does something and
+    # (2) that it returns to its original configuration
+    assert F.is_equivalent_realization(
+        M.motion_samples[-1], numerical=True
+    ) and not F.is_equivalent_realization(
+        M.motion_samples[83], numerical=True, tolerance=1
     )
     M.animate()

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -1,6 +1,8 @@
-from pyrigi.motion import ParametricMotion
+from pyrigi.motion import ParametricMotion, ApproximateMotion
 import pyrigi.graphDB as graphs
+import pyrigi.frameworkDB as fws
 import sympy as sp
+import numpy as np
 import pytest
 
 
@@ -154,3 +156,15 @@ def test_ParametricMotion_init():
     }
     with pytest.raises(ValueError):
         ParametricMotion(graphs.Cycle(4), mot, [-sp.oo, sp.oo])
+
+
+def test_ApproximateMotion_init():
+    ApproximateMotion.from_framework(fws.Cycle(4), 100)
+
+
+@pytest.mark.slow_main
+def test_animate():
+    F = fws.Square()
+    M = ApproximateMotion(F.graph(), F.realization(as_points=True, numerical=True), 118, 0.075)
+    assert np.linalg.norm([u-v for u,v in zip(sum([list(val) for val in M.motion_samples[0].values()],[]), sum([list(val) for val in M.motion_samples[-1].values()],[]))])<1e-2
+    M.animate()

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -1,3 +1,4 @@
+from pyrigi import Framework
 from pyrigi.motion import ParametricMotion, ApproximateMotion
 import pyrigi.graphDB as graphs
 import pyrigi.frameworkDB as fws
@@ -177,3 +178,31 @@ def test_animate():
             M.motion_samples[i], numerical=True
         ) and not F.is_congruent_realization(M.motion_samples[i], numerical=True)
     M.animate()
+
+
+def test_ApproximateMotion_from_framework():
+    F = fws.Square()
+    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    for sample in M.motion_samples[1:]:
+        assert F.is_equivalent_realization(
+            sample, numerical=True, tolerance=1e-3
+        ) and not F.is_congruent_realization(sample, numerical=True)
+
+    # Square with a triangle on one of its sides
+    F.add_vertex([2, 2])
+    F.add_edges([[2, 4], [3, 4]])
+    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    for sample in M.motion_samples[1:]:
+        assert F.is_equivalent_realization(
+            sample, numerical=True, tolerance=1e-3
+        ) and not F.is_congruent_realization(sample, numerical=True)
+
+    # overconstrained flexible framework
+    F = Framework.Complete([[0, 0], [1, 0], [1, 1], [0, 1]])
+    F.add_vertex([2, 2])
+    F.add_edge([2, 4])
+    M = ApproximateMotion.from_framework(F, 10, 0.075)
+    for sample in M.motion_samples[1:]:
+        assert F.is_equivalent_realization(
+            sample, numerical=True, tolerance=1e-3
+        ) and not F.is_congruent_realization(sample, numerical=True)

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -166,17 +166,21 @@ def test_ApproximateMotion_init():
 
 @pytest.mark.slow_main
 def test_animate():
+    """
+    Test that (1) the motion actually does something and
+    (2) that it returns to its original configuration.
+    """
     F = fws.Square()
     M = ApproximateMotion(
         F.graph(), F.realization(as_points=True, numerical=True), 50, 0.075
     )
-    # Test that (1) the motion actually does something and
-    # (2) that it returns to its original configuration
 
     for i in range(1, len(M.motion_samples)):
         assert F.is_equivalent_realization(
-            M.motion_samples[i], numerical=True
-        ) and not F.is_congruent_realization(M.motion_samples[i], numerical=True)
+            M.motion_samples[i], numerical=True, tolerance=1e-4
+        ) and not F.is_congruent_realization(
+            M.motion_samples[i], numerical=True, tolerance=1e-4
+        )
     M.animate()
 
 

--- a/test/test_motion.py
+++ b/test/test_motion.py
@@ -83,7 +83,7 @@ def test_realization():
         },
         [-sp.oo, sp.oo],
     )
-    R = mot.realization(0, numeric=False)
+    R = mot.realization(0, numerical=False)
     tmp = R[0]
     assert tmp[0] == 0
     assert tmp[1] == 0
@@ -100,7 +100,7 @@ def test_realization():
     assert tmp[0] == 1
     assert tmp[1] == 0
 
-    R = mot.realization("2/3", numeric=False)
+    R = mot.realization("2/3", numerical=False)
     tmp = R[2]
     assert tmp[0] == sp.sympify("-7/5")
     assert tmp[1] == sp.sympify("9/5")
@@ -109,7 +109,7 @@ def test_realization():
     assert tmp[0] == sp.sympify("-16/65")
     assert tmp[1] == sp.sympify("-63/65")
 
-    R = mot.realization(2 / 3, numeric=True)
+    R = mot.realization(2 / 3, numerical=True)
     tmp = R[2]
     assert abs(tmp[0] - (-7 / 5)) < 1e-9
     assert abs(tmp[1] - 9 / 5) < 1e-9


### PR DESCRIPTION
+ Implemented the numerical `ApproximateMotion` class. It depends on a naive implementation of homotopy continuation. 
+ Moved the methods `_normalize_realizations` and `animate` to the parent `Motion` class, that both `ParametricMotion` and `ApproximateMotion` depend on