### PR TITLE
Renaming, minor todos and refactoring to has_node

### DIFF
--- a/pyrigi/_pebble_digraph.py
+++ b/pyrigi/_pebble_digraph.py
@@ -2,7 +2,6 @@
 Auxiliary class for directed graph used in pebble game style algorithms.
 """
 
-from collections.abc import Sequence
 from typing import Iterable
 
 from pyrigi.data_type import Vertex, DirectedEdge

--- a/pyrigi/_pebble_digraph.py
+++ b/pyrigi/_pebble_digraph.py
@@ -106,8 +106,9 @@ class PebbleDiGraph(nx.MultiDiGraph):
         Parameters
         ----------
         vertex: Vertex, whose indegree we want to know.
-        TODO check if vertex exists
         """
+        if not self.has_node(vertex):
+            raise ValueError(f"Vertex {vertex} is not present in the graph.")
         return int(super().in_degree(vertex))
 
     def out_degree(self, vertex: Vertex) -> int:
@@ -117,8 +118,9 @@ class PebbleDiGraph(nx.MultiDiGraph):
         Parameters
         ----------
         vertex: Vertex, whose outdegree we want to know.
-        TODO check if vertex exists
         """
+        if not self.has_node(vertex):
+            raise ValueError(f"Vertex {vertex} is not present in the graph.")
         return int(super().out_degree(vertex))
 
     def redirect_edge_to_head(self, edge: DirectedEdge, vertex_to: Vertex) -> None:

--- a/pyrigi/_pebble_digraph.py
+++ b/pyrigi/_pebble_digraph.py
@@ -2,6 +2,9 @@
 Auxiliary class for directed graph used in pebble game style algorithms.
 """
 
+from collections.abc import Sequence
+from typing import Iterable
+
 from pyrigi.data_type import Vertex, DirectedEdge
 import pyrigi._input_check as _input_check
 
@@ -107,8 +110,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
         ----------
         vertex: Vertex, whose indegree we want to know.
         """
-        if not self.has_node(vertex):
-            raise ValueError(f"Vertex {vertex} is not present in the graph.")
+        self._input_check_vertex_members(vertex, "vertex")
         return int(super().in_degree(vertex))
 
     def out_degree(self, vertex: Vertex) -> int:
@@ -119,8 +121,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
         ----------
         vertex: Vertex, whose outdegree we want to know.
         """
-        if not self.has_node(vertex):
-            raise ValueError(f"Vertex {vertex} is not present in the graph.")
+        self._input_check_vertex_members(vertex, "vertex")
         return int(super().out_degree(vertex))
 
     def redirect_edge_to_head(self, edge: DirectedEdge, vertex_to: Vertex) -> None:
@@ -273,3 +274,24 @@ class PebbleDiGraph(nx.MultiDiGraph):
         """
         for edge in edges:
             self.add_edge_maintaining_digraph(edge[0], edge[1])
+
+    def _input_check_vertex_members(
+        self, to_check: Iterable[Vertex] | Vertex, name: str = ""
+    ) -> None:
+        """
+        Check whether the elements of a list are indeed vertices and
+        raise error otherwise.
+        """
+        if not isinstance(to_check, Iterable):
+            if not self.has_node(to_check):
+                raise ValueError(
+                    f"The element {to_check} is not a vertex of the graph!"
+                )
+        else:
+            for vertex in to_check:
+                if not self.has_node(vertex):
+                    raise ValueError(
+                        f"The element {vertex} from "
+                        + name
+                        + f" {to_check} is not a vertex of the graph!"
+                    )

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -192,11 +192,11 @@ class Framework(object):
         """
         if vertex is None:
             candidate = self._graph.number_of_nodes()
-            while candidate in self._graph.nodes:
+            while self._graph.has_node(candidate):
                 candidate += 1
             vertex = candidate
 
-        if vertex in self._graph.nodes:
+        if self._graph.has_node(vertex):
             raise KeyError(f"Vertex {vertex} is already a vertex of the graph!")
 
         self._realization[vertex] = Matrix(point)

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -295,8 +295,8 @@ def CompleteBipartite(m: int, n: int, realization: str = None) -> Framework:
         the other on the y-axis is returned.
         Otherwise (default), a "general" realization is returned.
 
-    Todo
-    ----
+    Suggested Improvements
+    ----------------------
     Implement realization in higher dimensions.
     """
     _input_check.integrality_and_range(m, "size m", 1)

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -565,7 +565,7 @@ class Graph(nx.Graph):
         self._pebble_digraph = dir_graph
 
     @doc_category("Sparseness")
-    def spanning_sparse_subgraph(
+    def spanning_kl_sparse_subgraph(
         self, K: int, L: int, use_precomputed_pebble_digraph: bool = False
     ) -> Graph:
         r"""
@@ -2284,7 +2284,7 @@ class Graph(nx.Graph):
             # the one last edge
             if self.number_of_edges() != 2 * self.number_of_nodes() - 2:
                 return False
-            max_sparse_subgraph = self.spanning_sparse_subgraph(
+            max_sparse_subgraph = self.spanning_kl_sparse_subgraph(
                 K=2, L=3, use_precomputed_pebble_digraph=use_precomputed_pebble_digraph
             )
             if max_sparse_subgraph.number_of_edges() != 2 * self.number_of_nodes() - 3:

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -133,7 +133,7 @@ class Graph(nx.Graph):
         ):
             return False
         for v in self.nodes:
-            if v not in other.nodes:
+            if not other.has_node(v):
                 return False
         for e in self.edges:
             if not other.has_edge(*e):
@@ -955,10 +955,10 @@ class Graph(nx.Graph):
                 )
         if new_vertex is None:
             candidate = self.number_of_nodes()
-            while candidate in self.nodes:
+            while self.has_node(candidate):
                 candidate += 1
             new_vertex = candidate
-        if new_vertex in self.nodes:
+        if self.has_node(new_vertex):
             raise ValueError(f"Vertex {new_vertex} is already a vertex of the graph!")
         G = self
         if not inplace:
@@ -2274,7 +2274,7 @@ class Graph(nx.Graph):
                 return False
 
             # Check if every vertex has degree 2
-            for vertex in self.nodes():
+            for vertex in self.nodes:
                 if self.degree(vertex) != 2:
                     return False
             return True

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -224,20 +224,20 @@ class Graph(nx.Graph):
             raise LoopError()
 
     def _input_check_vertex_members(
-        self, to_check: Sequence[Vertex] | Vertex, name: str = ""
+        self, to_check: Iterable[Vertex] | Vertex, name: str = ""
     ) -> None:
         """
         Check whether the elements of a list are indeed vertices and
         raise error otherwise.
         """
         if not isinstance(to_check, Iterable):
-            if to_check not in self.nodes:
+            if not self.has_node(to_check):
                 raise ValueError(
                     f"The element {to_check} is not a vertex of the graph!"
                 )
         else:
             for vertex in to_check:
-                if vertex not in self.nodes:
+                if not self.has_node(vertex):
                     raise ValueError(
                         f"The element {vertex} from "
                         + name

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -2245,6 +2245,26 @@ def test_is_kl_tight():
     assert G.is_kl_tight(3, 6)
 
 
+@pytest.mark.parametrize(
+    "graph",
+    [
+        graphs.Complete(4),
+        graphs.CompleteBipartite(3, 4),
+        graphs.CompleteBipartite(2, 4),
+        graphs.ThreePrism(),
+        graphs.ThreePrismPlusEdge(),
+        graphs.Cycle(5),
+        graphs.Path(4),
+    ],
+)
+def test_spanning_kl_sparse_subgraph(graph):
+    for K in range(1, 3):
+        for L in range(0, 2 * K):
+            spanning_subgraph = graph.spanning_kl_sparse_subgraph(K, L)
+            assert spanning_subgraph.is_kl_sparse(K, L, algorithm="subgraph")
+            assert set(graph.vertex_list()) == set(spanning_subgraph.vertex_list())
+
+
 def test_plot():
     G = graphs.DoubleBanana()
     G.plot(layout="random")

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -2007,6 +2007,8 @@ def test__input_check_edge_format_loopfree_loop_error(graph, edge):
         [Graph([[-1, -2], [-2, 3]]), [-2, -1], [-3, -2, 0, 1, 2, 3]],
         [Graph([[-1, -2], [-2, 3]]), [-1, -2], [-2, 3]],
         [Graph([[-1, -2], [-2, 3]]), [-2, 3], [3]],
+        [graphs.Diamond(), [[1, 2], [2, 3]], None],
+        [graphs.Diamond(), [[1, 2], [2, 3]], [1, 2, 3]],
     ],
 )
 def test__input_check_edge_on_vertices_value_error(graph, edge, vertices):
@@ -2024,7 +2026,6 @@ def test__input_check_edge_on_vertices_value_error(graph, edge, vertices):
         [Graph.from_vertices_and_edges([1, 2, 3], [(1, 2), (2, 3)]), "[3, 2]"],
         [Graph([[1, 2], [2, 3]]), "12"],
         [graphs.Complete(3), [[0, 1]]],
-        [graphs.Diamond(), [[1, 2], [2, 3]]],
     ],
 )
 def test__input_check_edge_type_error(graph, edge):
@@ -2048,7 +2049,6 @@ def test__input_check_edge_type_error(graph, edge):
         ],
         [Graph([[1, 2], [2, 3]]), "12", [1, 2, 3]],
         [graphs.Complete(3), [[0, 1]], [1, 2, 3]],
-        [graphs.Diamond(), [[1, 2], [2, 3]], [1, 2, 3]],
         [Graph([[1, 2], [2, 3]]), [1, 2], "1"],
         [Graph([[1, 2], [2, 3]]), [1, 2], 1],
     ],
@@ -2116,6 +2116,7 @@ def test__input_check_edge_list(graph, edge):
         [Graph([[-1, -2], [-2, 3]]), [[-2, -1], [1, 3]]],
         [Graph([[-1, -2], [-2, 3]]), [[-1, 5], (-2, 3)]],
         [Graph([[-1, -2], [-2, 3]]), [[-2, -3], [-1, -2]]],
+        [graphs.Diamond(), [[[1, 2], [2, 3]]]],
     ],
 )
 def test__input_check_edge_list_value_error(graph, edge):
@@ -2134,7 +2135,6 @@ def test__input_check_edge_list_value_error(graph, edge):
         [Graph([[1, 2], [2, 3]]), "12"],
         [graphs.Complete(3), [0, 1]],
         [graphs.Diamond(), (1, 2)],
-        [graphs.Diamond(), [[[1, 2], [2, 3]]]],
     ],
 )
 def test__input_check_edge_list_type_error(graph, edge):


### PR DESCRIPTION
- `spanning_sparse_subgraph`  renamed to `spanning_kl_sparse_subgraph`, a test of the method added
- minors todos fixed
- construction `if v in Graph.nodes` replaced by `if Graph.has_node(v)` since the former raises `TypeError` when called on non-hashable