### PR TITLE
Animation closed immediately in pytest

### DIFF
--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -39,9 +39,9 @@ pytest -p no:doctestplus
 Functionalities requiring optional packages are tested by default;
 if you want to skip some specific optional feature(s), run
 ```
-pytest -m "not optional_feature1_name and not optional_feature2_name"
+pytest -m "not slow_main and not long_local and not opt_feature1 and not opt_feature2"
 ```
-See the file `pyproject.toml` for the markers that specify groups of tests relying on optional packages.
+See the file `pyproject.toml` for the markers that specify groups of tests relying on [optional packages](optional-packages).
 
 We mark tests that take longer time according to the following table:
 

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -575,6 +575,7 @@ class Framework(object):
             plot_style=plot_style,
             edge_colors_custom=edge_colors_custom,
             duration=duration,
+            **kwargs,
         )
 
     @doc_category("Plotting")

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 from warnings import warn
 from matplotlib.animation import FuncAnimation
 import matplotlib.pyplot as plt
+import os
 
 
 class Motion(object):
@@ -267,7 +268,10 @@ class Motion(object):
             plt.close()
             return HTML(ani.to_jshtml())
         else:
-            plt.show()
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                plt.show(block=False)
+            else:
+                plt.show()
             return
 
     def animate2D_plt(
@@ -421,7 +425,10 @@ class Motion(object):
             plt.close()
             return HTML(ani.to_jshtml())
         else:
-            plt.show()
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                plt.show(block=False)
+            else:
+                plt.show()
             return
 
     def animate2D_svg(

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -756,8 +756,6 @@ def test_animate3D_rotation():
     with pytest.raises(ValueError):
         F.animate3D_rotation()
 
-    plt.close("all")
-
 
 def test_rigidity_matrix():
     F = fws.Complete(2)


### PR DESCRIPTION
On some machines, one had to close animations manually when running `pytest`. They close automatically now.
Also the command for excluding optional packages for pytest was fixed: now also the test marked as `slow_main` or `long_local` are skipped.