### PR TITLE
Missing items displayed in the documentation

### DIFF
--- a/doc/development/howto/input_checks.md
+++ b/doc/development/howto/input_checks.md
@@ -57,6 +57,5 @@ def method(algorithm: str = test):
 ```{eval-rst}
 .. automodule:: pyrigi._input_check
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/doc/userguide/api.md
+++ b/doc/userguide/api.md
@@ -8,7 +8,8 @@ api/motion
 api/graphDB
 api/frameworkDB
 api/graphdrawer
+api/plot_style
+api/exception
 api/datatype
 api/misc
-api/plot_style
 :::

--- a/doc/userguide/api/datatype.md
+++ b/doc/userguide/api/datatype.md
@@ -1,24 +1,6 @@
 # Data types
 
-The following datatypes are used for type hinting.
-
 ```{eval-rst}
-.. autodata:: pyrigi.data_type.Vertex
-   
-.. autodata:: pyrigi.data_type.Edge
-
-.. autodata:: pyrigi.data_type.DirectedEdge
-
-.. autodata:: pyrigi.data_type.Number
-
-.. autodata:: pyrigi.data_type.Point
-
-.. autodata:: pyrigi.data_type.InfFlex
-
-.. autodata:: pyrigi.data_type.Stress
-
-.. autodata:: pyrigi.data_type.Inf
-
-.. autofunction:: pyrigi.data_type.point_to_vector
-
+.. automodule:: pyrigi.data_type
+   :members:
 ```

--- a/doc/userguide/api/exception.md
+++ b/doc/userguide/api/exception.md
@@ -1,0 +1,17 @@
+# Exceptions and warnings
+
+## Exceptions
+
+```{eval-rst}
+.. automodule:: pyrigi.exception
+   :members:
+   :show-inheritance:
+```
+
+## Warnings
+
+```{eval-rst}
+.. automodule:: pyrigi.warning
+   :members:
+   :show-inheritance:
+```

--- a/doc/userguide/api/framework.md
+++ b/doc/userguide/api/framework.md
@@ -4,6 +4,5 @@
 ```{eval-rst}
 .. automodule:: pyrigi.framework
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/doc/userguide/api/frameworkDB.md
+++ b/doc/userguide/api/frameworkDB.md
@@ -3,5 +3,4 @@
 ```{eval-rst}
 .. automodule:: pyrigi.frameworkDB
    :members:
-   :undoc-members:
 ```

--- a/doc/userguide/api/graph.md
+++ b/doc/userguide/api/graph.md
@@ -3,6 +3,5 @@
 ```{eval-rst}
 .. automodule:: pyrigi.graph
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/doc/userguide/api/graphDB.md
+++ b/doc/userguide/api/graphDB.md
@@ -3,5 +3,4 @@
 ```{eval-rst}
 .. automodule:: pyrigi.graphDB
    :members:
-   :undoc-members:
 ```

--- a/doc/userguide/api/graphdrawer.md
+++ b/doc/userguide/api/graphdrawer.md
@@ -3,6 +3,5 @@
 ```{eval-rst}
 .. automodule:: pyrigi.graph_drawer
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/doc/userguide/api/misc.md
+++ b/doc/userguide/api/misc.md
@@ -3,8 +3,7 @@
 The following functions are used in the code.
 
 ```{eval-rst}
-.. autofunction:: pyrigi.misc.is_zero_vector
-
-.. autofunction:: pyrigi.misc.eval_sympy_vector
+.. automodule:: pyrigi.misc
+   :members:
 
 ```

--- a/doc/userguide/api/motion.md
+++ b/doc/userguide/api/motion.md
@@ -4,6 +4,5 @@
 ```{eval-rst}
 .. automodule:: pyrigi.motion
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/doc/userguide/api/plot_style.md
+++ b/doc/userguide/api/plot_style.md
@@ -5,6 +5,5 @@ The following class can be used for setting style of plots.
 ```{eval-rst}
 .. automodule:: pyrigi.plot_style
    :members:
-   :undoc-members:
    :show-inheritance:
 ```

--- a/pyrigi/_input_check.py
+++ b/pyrigi/_input_check.py
@@ -45,7 +45,7 @@ def integrality_and_range(
     value: int, name: str, min_val: int = 0, max_val: int = math.inf
 ) -> None:
     """
-    Check whether an input parameter `value` is an integer in a certain range and
+    Check whether an input parameter ``value`` is an integer in a certain range and
     raise an error otherwise.
 
     Parameters
@@ -72,7 +72,7 @@ def greater_equal(
     val1: int | float, val2: int | float, name1: str, name2: str = ""
 ) -> None:
     """
-    Check whether an input parameter val1 is greater than or equal to val2 and
+    Check whether an input parameter ``val1`` is greater than or equal to ``val2`` and
     raise an error otherwise.
 
     Parameters
@@ -82,9 +82,9 @@ def greater_equal(
     val2:
         Value that shall be smaller
     name1:
-        Name of the parameter val1
+        Name of the parameter ``val1``
     name2:
-        Name of the parameter val2
+        Name of the parameter ``val2``
     """
     if name2 == "":
         str2 = ""
@@ -100,7 +100,7 @@ def greater_equal(
 
 def greater(val1: int | float, val2: int | float, name1: str, name2: str = "") -> None:
     """
-    Check whether an input parameter val1 is greater than or equal to val2 and
+    Check whether an input parameter ``val1`` is greater than or equal to ``val2`` and
     raise an error otherwise.
 
     Parameters
@@ -110,9 +110,9 @@ def greater(val1: int | float, val2: int | float, name1: str, name2: str = "") -
     val2:
         Value that shall be smaller/equal
     name1:
-        Name of the parameter val1
+        Name of the parameter ``val1``
     name2:
-        Name of the parameter val2
+        Name of the parameter ``val2``
     """
     if name2 == "":
         str2 = ""
@@ -130,7 +130,7 @@ def smaller_equal(
     val1: int | float, val2: int | float, name1: str, name2: str = ""
 ) -> None:
     """
-    Check whether an input parameter val1 is smaller than or equal to val2 and
+    Check whether an input parameter ``val1`` is smaller than or equal to ``val2`` and
     raise an error otherwise.
 
     Parameters
@@ -140,9 +140,9 @@ def smaller_equal(
     val2:
         Value that shall be greater
     name1:
-        Name of the parameter val1
+        Name of the parameter ``val1``
     name2:
-        Name of the parameter val2
+        Name of the parameter ``val2``
     """
     if name2 == "":
         str2 = ""
@@ -158,8 +158,8 @@ def smaller_equal(
 
 def pebble_values(K: int, L: int) -> None:
     """
-    Check if K and L satisfy the pebble conditions K > 0 and 0 <= L < 2K and
-    raise an error otherwise.
+    Check if ``K`` and ``L`` satisfy the pebble conditions ``K > 0`` and ``0 <= L < 2K``
+    and raise an error otherwise.
     """
     # Check that K and L are integers and range
     integrality_and_range(K, "K", min_val=1)

--- a/pyrigi/exception.py
+++ b/pyrigi/exception.py
@@ -9,8 +9,7 @@ from collections.abc import Callable
 
 class LoopError(ValueError):
     """
-    Error class responsible for throwing an error, when the
-    graph is not loop-free.
+    Error raised when the graph is not loop-free.
     """
 
     def __init__(self, msg: str = "The graph needs to be loop-free.", *args, **kwargs):
@@ -19,8 +18,7 @@ class LoopError(ValueError):
 
 class NotSupportedValueError(ValueError):
     """
-    Error class responsible for throwing an error, when an
-    input value is not supported.
+    Error raised when an input value is not supported.
     """
 
     def __init__(

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -359,8 +359,8 @@ def CnSymmetricFourRegular(n: int = 8) -> Framework:
     """
     if not n % 2 == 0 or n < 8:
         raise ValueError(
-            "To generate this framework, the cyclical group "
-            + "needs to have an even order of at least 8!"
+            "To generate this framework, the cyclic group "
+            + "must have an even order of at least 8!"
         )
     return Framework(
         graphs.CnSymmetricFourRegular(n),
@@ -378,7 +378,7 @@ def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Framework:
     """
     Return a $C_n$-symmetric framework with a fixed vertex.
 
-    The cyclical group $C_n$ needs to have even order of at least 8.
+    The value ``n`` must be even and at least 8.
 
     The returned graph satisfies the expected symmetry-adapted Laman
     count for rotation but is infinitesimally flexible.
@@ -389,8 +389,8 @@ def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Framework:
     """
     if not n % 2 == 0 or n < 8:
         raise ValueError(
-            "To generate this framework, the cyclical group "
-            + "needs to have an even order of at least 8!"
+            "To generate this framework, the cyclic group "
+            + "must have an even order of at least 8!"
         )
     return Framework(
         graphs.CnSymmetricFourRegularWithFixedVertex(n),

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -328,7 +328,7 @@ def CompleteBipartite(m: int, n: int, realization: str = None) -> Framework:
 
 def Frustum(n: int) -> Framework:
     """
-    Return the n-Frustum with `n` vertices in dimension 2.
+    Return the n-Frustum with ``n`` vertices in dimension 2.
 
     Definitions
     -----------
@@ -351,7 +351,7 @@ def Frustum(n: int) -> Framework:
 
 def CnSymmetricFourRegular(n: int = 8) -> Framework:
     """
-    Return a C_n-symmetric framework.
+    Return a $C_n$-symmetric framework.
 
     Definitions
     -----------
@@ -376,8 +376,9 @@ def CnSymmetricFourRegular(n: int = 8) -> Framework:
 
 def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Framework:
     """
-    Return a C_n-symmetric framework with a fixed vertex.
-    The cyclical group C_n needs to have even order of at least 8.
+    Return a $C_n$-symmetric framework with a fixed vertex.
+
+    The cyclical group $C_n$ needs to have even order of at least 8.
 
     The returned graph satisfies the expected symmetry-adapted Laman
     count for rotation but is infinitesimally flexible.

--- a/pyrigi/graphDB.py
+++ b/pyrigi/graphDB.py
@@ -8,22 +8,22 @@ import pyrigi._input_check as _input_check
 
 
 def Cycle(n: int) -> Graph:
-    """Return the cycle graph on n vertices."""
+    """Return the cycle graph on ``n`` vertices."""
     return Graph(nx.cycle_graph(n))
 
 
 def Complete(n: int) -> Graph:
-    """Return the complete graph on n vertices."""
+    """Return the complete graph on ``n`` vertices."""
     return Graph(nx.complete_graph(n))
 
 
 def Path(n: int) -> Graph:
-    """Return the path graph with n vertices."""
+    """Return the path graph with ``n`` vertices."""
     return Graph(nx.path_graph(n))
 
 
 def CompleteBipartite(m: int, n: int) -> Graph:
-    """Return the complete bipartite graph on m+n vertices."""
+    """Return the complete bipartite graph on ``m+n`` vertices."""
     return Graph(nx.complete_multipartite_graph(m, n))
 
 
@@ -65,12 +65,14 @@ def CubeWithDiagonal() -> Graph:
 
 def DoubleBanana(dim: int = 3, t: int = 2) -> Graph:
     r"""
-    Return the d-dimensional double banana graph.
+    Return the `dim`-dimensional double banana graph.
 
     Parameters
     ----------
-    dim: integer, must be at least 3
-    t: integer, must be 2 <= t <= dim-1
+    dim:
+        An integer greater or equal 3.
+    t:
+        An integer such that ``2 <= t <= dim-1``.
 
     Definitions
     -----
@@ -99,7 +101,7 @@ def DoubleBanana(dim: int = 3, t: int = 2) -> Graph:
 
 
 def CompleteMinusOne(n: int) -> Graph:
-    """Return the complete graph on n vertices minus one edge."""
+    """Return the complete graph on ``n`` vertices minus one edge."""
     G = Complete(n)
     G.delete_edge((0, 1))
     return G
@@ -190,7 +192,7 @@ def K66MinusPerfectMatching():
 
 def CnSymmetricFourRegular(n: int = 8) -> Graph:
     """
-    Return a C_n-symmetric graph.
+    Return a $C_n$-symmetric graph.
 
     Definitions
     -----------
@@ -212,8 +214,9 @@ def CnSymmetricFourRegular(n: int = 8) -> Graph:
 
 def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Graph:
     """
-    Return a C_n-symmetric graph with a fixed vertex.
-    The cyclical group C_n needs to have even order of at least 8.
+    Return a $C_n$-symmetric graph with a fixed vertex.
+
+    The cyclical group $C_n$ needs to have even order of at least 8.
 
     The returned graph satisfies the expected symmetry-adapted Laman
     count for rotation but is infinitesimally flexible.
@@ -236,9 +239,9 @@ def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Graph:
 
 def ThreeConnectedR3Circuit():
     """
-    Return a 3-connected R_3-circuit.
+    Return a 3-connected $R_3$-circuit.
 
-    The returned graph is hypothesized to be the smallest 3-connected R_3-circuit.
+    The returned graph is hypothesized to be the smallest 3-connected $R_3$-circuit.
     """
     return Graph(
         [

--- a/pyrigi/graphDB.py
+++ b/pyrigi/graphDB.py
@@ -200,8 +200,8 @@ def CnSymmetricFourRegular(n: int = 8) -> Graph:
     """
     if not n % 2 == 0 or n < 8:
         raise ValueError(
-            "To generate this graph, the cyclical group "
-            + "needs to have an even order of at least 8!"
+            "To generate this graph, the cyclic group "
+            + "must have an even order of at least 8!"
         )
     G = Graph()
     G.add_edges([(0, n - 1), (n - 3, 0), (n - 2, 1), (n - 1, 2)])
@@ -216,7 +216,7 @@ def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Graph:
     """
     Return a $C_n$-symmetric graph with a fixed vertex.
 
-    The cyclical group $C_n$ needs to have even order of at least 8.
+    The value ``n`` must be even and at least 8.
 
     The returned graph satisfies the expected symmetry-adapted Laman
     count for rotation but is infinitesimally flexible.
@@ -227,8 +227,8 @@ def CnSymmetricFourRegularWithFixedVertex(n: int = 8) -> Graph:
     """
     if not n % 2 == 0 or n < 8:
         raise ValueError(
-            "To generate this graph, the cyclical group "
-            + "needs to have an even order of at least 8!"
+            "To generate this graph, the cyclic group "
+            + "must have an even order of at least 8!"
         )
     G = CnSymmetricFourRegular(n)
     G.add_edges([(0, n), (n, 2 * n), (n + 1, 2 * n - 1), (n, 2 * n - 2)])

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -15,7 +15,7 @@ try:
     @register_cell_magic
     def skip_execution(line, cell):
         print(
-            "This cell was marked to be skipped (probably due to its long execution time."
+            "This cell was marked to be skipped (probably due to long execution time)."
         )
         print("Remove the cell magic `%%skip_execution` to run it.")
         return
@@ -25,6 +25,10 @@ except NameError:
 
 
 def doc_category(category):
+    """
+    Decorator for doc categories.
+    """
+
     def decorator_doc_category(func):
         setattr(func, "_doc_category", category)
         return func
@@ -44,7 +48,7 @@ def generate_category_tables(cls, tabs, cat_order=None, include_all=False) -> st
         Specifies the number of indentation levels that are applied to
         the output.
     cat_order:
-        Optional list specifying the the order in which categories appear
+        Optional list specifying the order in which categories appear
         in the output.
     include_all:
         Optional boolean determining whether methods without a specific category
@@ -210,7 +214,7 @@ def normalize_flex(
     inf_flex: InfFlex, numerical: bool = False, tolerance: float = 1e-12
 ) -> InfFlex:
     """
-    Divides a vector by its Euclidean norm.
+    Divide a vector by its Euclidean norm.
 
     Parameters
     ----------
@@ -258,10 +262,10 @@ def vector_distance_pointwise(
     numerical: bool = False,
 ) -> float:
     """
-    Computes the Euclidean distance between two realizations or pointwise vectors.
+    Compute the Euclidean distance between two realizations or pointwise vectors.
 
-    This method computes the Euclidean distance from the realization `dict_1`
-    to `dict2`. These dicts need to be based on the same vertex set.
+    This method computes the Euclidean distance from the realization ``dict_1``
+    to ``dict2``. These dicts need to be based on the same vertex set.
 
     Parameters
     ----------

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -265,7 +265,7 @@ def vector_distance_pointwise(
     Compute the Euclidean distance between two realizations or pointwise vectors.
 
     This method computes the Euclidean distance from the realization ``dict_1``
-    to ``dict2``. These dicts need to be based on the same vertex set.
+    to ``dict2``. The keys of ``dict1`` and ``dict2`` must be the same.
 
     Parameters
     ----------

--- a/pyrigi/warning.py
+++ b/pyrigi/warning.py
@@ -9,9 +9,7 @@ from collections.abc import Callable
 
 class RandomizedAlgorithmWarning(UserWarning):
     """
-    Class representing the warning that is raised for randomized algorithm.
-
-    This class inherits the class :class:`warnings.UserWarning`.
+    Warning raised when randomized algorithm is used without explicit call.
     """
 
     def __init__(


### PR DESCRIPTION
In some cases, we listed items to be displayed in the documentation explicitly, now they are added automatically using `automodule`. Moreover, a page with exceptions and warnings has been added and some docstrings have been improved.
The `:undoc-members:` setting has been removed to display only methods etc. that have a docstring. Hence, `make html coverage` discovers the missing ones now.