### PR TITLE
GitHub tests require no sphinx warnings

### DIFF
--- a/.github/workflows/python-test-dev.yml
+++ b/.github/workflows/python-test-dev.yml
@@ -39,11 +39,11 @@ jobs:
     - name: Convert notebooks from md to ipynb
       run: |
         cd doc/userguide/tutorials/
-        jupytext --to notebook  *.md
+        poetry run jupytext --to notebook  *.md
         mkdir  --verbose ../../notebooks
         cp --verbose *.ipynb ../../notebooks
         cd ..
-        jupytext --to notebook  getting_started.md
+        poetry run jupytext --to notebook  getting_started.md
         cp --verbose getting_started.ipynb ../notebooks
         cd ..
     - name: Test doc compilation

--- a/.github/workflows/python-test-dev.yml
+++ b/.github/workflows/python-test-dev.yml
@@ -45,7 +45,7 @@ jobs:
         cd ..
         poetry run jupytext --to notebook  getting_started.md
         cp --verbose getting_started.ipynb ../notebooks
-        cd ..
     - name: Test doc compilation
       run: |
+        cd doc
         poetry run make SPHINXOPTS=--fail-on-warning html

--- a/.github/workflows/python-test-dev.yml
+++ b/.github/workflows/python-test-dev.yml
@@ -36,7 +36,16 @@ jobs:
       run: |
         poetry run pytest --doctest-modules
         # --doctest-modules overrides the default --doctest-plus
+    - name: Convert notebooks from md to ipynb
+      run: |
+        cd doc/userguide/tutorials/
+        jupytext --to notebook  *.md
+        mkdir  --verbose ../../notebooks
+        cp --verbose *.ipynb ../../notebooks
+        cd ..
+        jupytext --to notebook  getting_started.md
+        cp --verbose getting_started.ipynb ../notebooks
+        cd ..
     - name: Test doc compilation
       run: |
-        cd doc
-        poetry run make html
+        poetry run make SPHINXOPTS=--fail-on-warning html

--- a/.github/workflows/python-test-main.yml
+++ b/.github/workflows/python-test-main.yml
@@ -35,8 +35,17 @@ jobs:
       run: |
         poetry run pytest --doctest-modules -m 'not slow_main or slow_main'
         # --doctest-modules overrides the default --doctest-plus
+    - name: Remove skip-execution cell magic and convert notebooks from md to ipynb
+      run: |
+        python3 doc/remove_skip_execution_magic.py
+        cd doc/userguide/tutorials/
+        poetry run jupytext --to notebook  *.md
+        mkdir  --verbose ../../notebooks
+        cp --verbose *.ipynb ../../notebooks
+        cd ..
+        poetry run jupytext --to notebook  getting_started.md
+        cp --verbose getting_started.ipynb ../notebooks
     - name: Test doc compilation
       run: |
         cd doc
-        python3 doc/remove_skip_execution_magic.py
-        poetry run make html
+        poetry run make SPHINXOPTS=--fail-on-warning html

--- a/doc/development/howto/dependencies.md
+++ b/doc/development/howto/dependencies.md
@@ -1,5 +1,4 @@
-
-(dependencies)=
+(dependencies-poetry)=
 # Dependencies
 
 We maintain the dependencies of the package using [Poetry](https://python-poetry.org/).

--- a/doc/development/howto/documentation.md
+++ b/doc/development/howto/documentation.md
@@ -112,7 +112,7 @@ You can contact a maintainer if you have a `.ipynb` tutorial
 you want to contribute but struggle to get its `.md` version.
 
 
-In case the Poetry environment is [activated](dependencies), Jupyterlab and Jupytext
+In case the Poetry environment is [activated](#dependencies-poetry), Jupyterlab and Jupytext
 can be installed using
 ```
 pip install jupyterlab jupytext

--- a/doc/development/howto/style_guide.md
+++ b/doc/development/howto/style_guide.md
@@ -9,7 +9,7 @@ To check your code, simply run
 ```
 flake8
 ```
-in PyRigi's home folder (with Poetry environment [activated](dependencies)).
+in PyRigi's home folder (with Poetry environment [activated](#dependencies-poetry)).
 The `.flake8` file in PyRigi's home folder, which specifies `flake8` configuration,
 is the same that is used in the automatic tests once a pull request is filed in GitHub.
 Therefore, please check your code with `flake8` before performing a pull request.
@@ -20,7 +20,7 @@ To format your code, run
 ```
 black .
 ```
-in the root folder (with Poetry environment [activated](dependencies)) to modify the files in place.
+in the root folder (with Poetry environment [activated](#dependencies-poetry)) to modify the files in place.
 We suggest to integrate the use of `black` at every commit
 as explained at [this page](https://black.readthedocs.io/en/stable/integrations/source_version_control.html) of `black`'s guide.
 

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -26,7 +26,7 @@ Therefore, before opening a pull request we **strongly advise** to run
 ```
 pytest
 ```
-in the root folder of PyRigi (with Poetry environment [activated](dependencies)).
+in the root folder of PyRigi (with Poetry environment [activated](#dependencies-poetry)).
 The reason why the examples in the docstrings are tested is to make sure their outputs are valid,
 they do **not** replace the tests in the `test` folder.
 If you do not want to run doctests, run
@@ -41,7 +41,7 @@ if you want to skip some specific optional feature(s), run
 ```
 pytest -m "not slow_main and not long_local and not opt_feature1 and not opt_feature2"
 ```
-See the file `pyproject.toml` for the markers that specify groups of tests relying on [optional packages](optional-packages).
+See the file `pyproject.toml` for the markers that specify groups of tests relying on [optional packages](#optional-packages).
 
 We mark tests that take longer time according to the following table:
 

--- a/doc/userguide/installation.md
+++ b/doc/userguide/installation.md
@@ -1,5 +1,4 @@
 (installation-guide)=
-
 # Installation
 
 If you are familiar with `pip`, you can install the latest version of PyRigi including the necessary dependencies
@@ -12,7 +11,7 @@ Otherwise, see how to start using Python and `PyRigi` depending on your [operati
 Alternatively, one can clone/download the package
 from [this GitHub repository](https://github.com/pyRigi/PyRigi),
 see the branch `dev` for the development version.
-Installation for development is done via [Poetry](dependencies).
+Installation for development is done via [Poetry](#dependencies-poetry).
 
 (optional-packages)=
 ## Optional packages


### PR DESCRIPTION
Enforcing Sphinx warnings to fail the testing of doc compilation should help to avoid problems with links or badly formatted docstrings that we have been getting time to time unnoticed.