### PR TITLE
Make some misc functions non-public

### DIFF
--- a/doc/math/rigidity/second-order.md
+++ b/doc/math/rigidity/second-order.md
@@ -83,7 +83,7 @@ It is {prf:ref}`second-order rigid <def-second-order-rigid>`,
 but not {prf:ref}`prestress stable <def-prestress-stability>`.
 {{references}} {cite:p}`ConnellyWhiteley1996{Exm 5.3.1}`
 
-{{pyrigi_crossref}} {func}`~.frameworkDB.ConnellyExampleSecondOrderRigidity`
+{{pyrigi_crossref}} {func}`~.frameworkDB.SecondOrderRigid`
 :::
 
 Checking prestress stability and second-order rigidity is generally computationally hard. In the case where

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -28,7 +28,6 @@ from pyrigi.data_type import (
 from pyrigi.graph import Graph
 from pyrigi.graphDB import Complete as CompleteGraph
 from pyrigi.misc import (
-    doc_category,
     generate_category_tables,
     is_zero,
     is_zero_vector,
@@ -38,6 +37,7 @@ from pyrigi.misc import (
     point_to_vector,
     _null_space,
 )
+from pyrigi.misc import _doc_category as doc_category
 import pyrigi._input_check as _input_check
 
 

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -31,8 +31,8 @@ from pyrigi.misc import (
     _generate_category_tables,
     is_zero,
     is_zero_vector,
-    generate_two_orthonormal_vectors,
-    generate_three_orthonormal_vectors,
+    _generate_two_orthonormal_vectors,
+    _generate_three_orthonormal_vectors,
     sympy_expr_to_float,
     point_to_vector,
     _null_space,
@@ -2697,11 +2697,11 @@ class Framework(object):
 
         if projection_matrix is None:
             if proj_dim == 2:
-                projection_matrix = generate_two_orthonormal_vectors(
+                projection_matrix = _generate_two_orthonormal_vectors(
                     self._dim, random_seed=random_seed
                 )
             elif proj_dim == 3:
-                projection_matrix = generate_three_orthonormal_vectors(
+                projection_matrix = _generate_three_orthonormal_vectors(
                     self._dim, random_seed=random_seed
                 )
             else:

--- a/pyrigi/framework.py
+++ b/pyrigi/framework.py
@@ -28,7 +28,7 @@ from pyrigi.data_type import (
 from pyrigi.graph import Graph
 from pyrigi.graphDB import Complete as CompleteGraph
 from pyrigi.misc import (
-    generate_category_tables,
+    _generate_category_tables,
     is_zero,
     is_zero_vector,
     generate_two_orthonormal_vectors,
@@ -3355,7 +3355,7 @@ class Framework(object):
 
 Framework.__doc__ = Framework.__doc__.replace(
     "METHODS",
-    generate_category_tables(
+    _generate_category_tables(
         Framework,
         1,
         [

--- a/pyrigi/frameworkDB.py
+++ b/pyrigi/frameworkDB.py
@@ -424,7 +424,7 @@ def CnSymmetricWithFixedVertex(n: int = 8) -> Framework:
     )
 
 
-def ConnellyExampleSecondOrderRigidity() -> Framework:
+def SecondOrderRigid() -> Framework:
     """
     Return an example by Connelly.
 

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -19,7 +19,7 @@ import pyrigi._input_check as _input_check
 import pyrigi._pebble_digraph
 from pyrigi.data_type import Vertex, Edge, Point, Inf, Sequence
 from pyrigi.exception import LoopError, NotSupportedValueError
-from pyrigi.misc import generate_category_tables
+from pyrigi.misc import _generate_category_tables
 from pyrigi.misc import _doc_category as doc_category
 from pyrigi.plot_style import PlotStyle
 from pyrigi.warning import RandomizedAlgorithmWarning
@@ -3929,7 +3929,7 @@ class Graph(nx.Graph):
 
 Graph.__doc__ = Graph.__doc__.replace(
     "METHODS",
-    generate_category_tables(
+    _generate_category_tables(
         Graph,
         1,
         [

--- a/pyrigi/graph.py
+++ b/pyrigi/graph.py
@@ -19,7 +19,8 @@ import pyrigi._input_check as _input_check
 import pyrigi._pebble_digraph
 from pyrigi.data_type import Vertex, Edge, Point, Inf, Sequence
 from pyrigi.exception import LoopError, NotSupportedValueError
-from pyrigi.misc import doc_category, generate_category_tables
+from pyrigi.misc import generate_category_tables
+from pyrigi.misc import _doc_category as doc_category
 from pyrigi.plot_style import PlotStyle
 from pyrigi.warning import RandomizedAlgorithmWarning
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -250,7 +250,7 @@ def sympy_expr_to_float(
         raise ValueError(f"The expression `{expression}` could not be parsed by sympy.")
 
 
-def normalize_flex(
+def _normalize_flex(
     inf_flex: InfFlex, numerical: bool = False, tolerance: float = 1e-9
 ) -> InfFlex:
     """

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -89,7 +89,7 @@ def _generate_category_tables(cls, tabs, cat_order=None, include_all=False) -> s
     return ("\n" + indent).join(res.splitlines())
 
 
-def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
+def _generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
     """
     Generate two random numeric orthonormal vectors in the given dimension.
 
@@ -126,7 +126,7 @@ def generate_two_orthonormal_vectors(dim: int, random_seed: int = None) -> Matri
     return matrix
 
 
-def generate_three_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
+def _generate_three_orthonormal_vectors(dim: int, random_seed: int = None) -> Matrix:
     """
     Generate three random numeric orthonormal vectors in the given dimension.
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -38,7 +38,7 @@ def _doc_category(category):
     return decorator_doc_category
 
 
-def generate_category_tables(cls, tabs, cat_order=None, include_all=False) -> str:
+def _generate_category_tables(cls, tabs, cat_order=None, include_all=False) -> str:
     """
     Generate a formatted string that categorizes methods of a given class.
 

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -298,7 +298,7 @@ def _normalize_flex(
         raise TypeError("`inf_flex` does not have the correct type.")
 
 
-def vector_distance_pointwise(
+def _vector_distance_pointwise(
     dict1: dict[Vertex, Sequence[Number]],
     dict2: dict[Vertex, Sequence[Number]],
     numerical: bool = False,

--- a/pyrigi/misc.py
+++ b/pyrigi/misc.py
@@ -26,7 +26,7 @@ except NameError:
     pass
 
 
-def doc_category(category):
+def _doc_category(category):
     """
     Decorator for doc categories.
     """

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -31,7 +31,7 @@ from pyrigi.plot_style import PlotStyle, PlotStyle2D, PlotStyle3D
 from pyrigi.misc import (
     point_to_vector,
     _normalize_flex,
-    vector_distance_pointwise,
+    _vector_distance_pointwise,
     sympy_expr_to_float,
     is_zero,
 )
@@ -1069,7 +1069,7 @@ class ApproximateMotion(Motion):
             self.motion_samples += [cur_sol]
             # Reject the step if the step size is not close to what we expect
             if (
-                vector_distance_pointwise(
+                _vector_distance_pointwise(
                     self.motion_samples[-1], self.motion_samples[-2], numerical=True
                 )
                 > self.step_size * 2
@@ -1082,7 +1082,7 @@ class ApproximateMotion(Motion):
                     jump_indicator = [False, False]
                 continue
             elif (
-                vector_distance_pointwise(
+                _vector_distance_pointwise(
                     self.motion_samples[-1], self.motion_samples[-2], numerical=True
                 )
                 < self.step_size / 2

--- a/pyrigi/motion.py
+++ b/pyrigi/motion.py
@@ -30,7 +30,7 @@ from pyrigi.framework import Framework
 from pyrigi.plot_style import PlotStyle, PlotStyle2D, PlotStyle3D
 from pyrigi.misc import (
     point_to_vector,
-    normalize_flex,
+    _normalize_flex,
     vector_distance_pointwise,
     sympy_expr_to_float,
     is_zero,
@@ -1041,7 +1041,7 @@ class ApproximateMotion(Motion):
         _input_check.integrality_and_range(
             chosen_flex, "chosen_flex", max_val=len(inf_flexes)
         )
-        cur_inf_flex = normalize_flex(
+        cur_inf_flex = _normalize_flex(
             F._transform_inf_flex_to_pointwise(inf_flexes[chosen_flex]),
             numerical=True,
         )
@@ -1267,7 +1267,7 @@ class ApproximateMotion(Motion):
         predicted_inf_flex = sum(
             np.dot(inf_flex_space.transpose(), flex_coefficients).tolist(), []
         )
-        predicted_inf_flex = normalize_flex(
+        predicted_inf_flex = _normalize_flex(
             F._transform_inf_flex_to_pointwise(predicted_inf_flex), numerical=True
         )
         realization = self.motion_samples[-1]

--- a/test/test_framework.py
+++ b/test/test_framework.py
@@ -248,7 +248,7 @@ def test_is_not_prestress_stable(framework):
     "framework",
     [
         fws.CompleteBipartite(3, 3, realization="collinear"),
-        fws.ConnellyExampleSecondOrderRigidity(),
+        fws.SecondOrderRigid(),
     ],
 )
 def test_is_prestress_stable_error(framework):
@@ -300,7 +300,7 @@ def test_is_not_second_order_rigid(framework):
     "framework",
     [
         fws.CompleteBipartite(3, 3, realization="collinear"),
-        fws.ConnellyExampleSecondOrderRigidity(),
+        fws.SecondOrderRigid(),
     ],
 )
 def test_is_second_order_rigid_error(framework):
@@ -1118,7 +1118,7 @@ def test_stress_matrix():
         pytest.param(fws.Frustum(5), 1, marks=pytest.mark.long_local),
         [fws.ThreePrism(realization="flexible"), 1],
         [fws.ThreePrism(realization="parallel"), 1],
-        [fws.ConnellyExampleSecondOrderRigidity(), 2],
+        [fws.SecondOrderRigid(), 2],
         [fws.CompleteBipartite(3, 3, realization="collinear"), 4],
     ],
 )
@@ -1142,7 +1142,7 @@ def test_stresses(framework, num_stresses):
         [fws.Complete(6), 6],
         [fws.ThreePrism(realization="flexible"), 1],
         [fws.ThreePrism(realization="parallel"), 1],
-        [fws.ConnellyExampleSecondOrderRigidity(), 2],
+        [fws.SecondOrderRigid(), 2],
         [fws.CompleteBipartite(3, 3, realization="collinear"), 4],
     ]
     + [[fws.Frustum(i), 1] for i in range(3, 8)],

--- a/test/test_frameworkDB.py
+++ b/test/test_frameworkDB.py
@@ -308,6 +308,17 @@ def test_Dodecahedron():
         assert sp.simplify(length - edge_lengths[0]) == 0
 
 
+def test_SecondOrderRigid():
+    F = fws.SecondOrderRigid()
+    assert (
+        F._dim == 3
+        and F._graph.number_of_nodes() == 7
+        and F._graph.number_of_edges() == 15
+        and len(F.inf_flexes()) == 2
+        and len(F.stresses()) == 2
+    )
+
+
 def test_Wheel():
     with pytest.raises(ValueError):
         fws.Wheel(1)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -9,7 +9,7 @@ import sympy as sp
 from pyrigi.graph import Graph
 from pyrigi.misc import (
     is_zero_vector,
-    generate_two_orthonormal_vectors,
+    _generate_two_orthonormal_vectors,
     sympy_expr_to_float,
     is_isomorphic_graph_list,
     _normalize_flex,
@@ -47,9 +47,9 @@ def test_is_zero_vector():
     assert not is_zero_vector(V6, numerical=True, tolerance=1e-9)
 
 
-def test_generate_two_orthonormal_vectors():
+def test__generate_two_orthonormal_vectors():
     for _ in range(15):
-        m = generate_two_orthonormal_vectors(randint(2, 10))
+        m = _generate_two_orthonormal_vectors(randint(2, 10))
         assert abs(np.dot(m[:, 0], m[:, 1])) < 1e-9
         assert abs(np.linalg.norm(m[:, 0])) - 1 < 1e-9
         assert abs(np.linalg.norm(m[:, 1])) - 1 < 1e-9

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -12,7 +12,7 @@ from pyrigi.misc import (
     generate_two_orthonormal_vectors,
     sympy_expr_to_float,
     is_isomorphic_graph_list,
-    normalize_flex,
+    _normalize_flex,
     vector_distance_pointwise,
     point_to_vector,
     is_zero,
@@ -71,23 +71,23 @@ def test_sympy_expr_to_float():
     assert sympy_expr_to_float("1/4") == 0.25
 
 
-def test_normalize_flex():
-    flex = normalize_flex([1, 0, 1])
+def test__normalize_flex():
+    flex = _normalize_flex([1, 0, 1])
     assert sum(p**2 for p in flex) == 1
-    flex = normalize_flex([1, 0, 1, -2, 3], numerical=True)
+    flex = _normalize_flex([1, 0, 1, -2, 3], numerical=True)
     assert isclose(np.linalg.norm(flex), 1.0)
-    flex = normalize_flex(
+    flex = _normalize_flex(
         {0: [1.0, 0.0], 1: [1.0, -2.5], 2: [pi, np.sqrt(15)]}, numerical=True
     )
     assert isclose(np.linalg.norm(sum([list(val) for val in flex.values()], [])), 1.0)
-    flex = normalize_flex(
+    flex = _normalize_flex(
         {0: (1, 0), 1: (sp.cos(1), sp.sin(2)), 2: (sp.sqrt(5), sp.Rational(1 / 2))}
     )
     assert sp.simplify(sum(sum(p**2 for p in pt) for pt in flex.values())) == 1
 
     with pytest.raises(ValueError):
-        normalize_flex([0])
-        normalize_flex([0], numerical=True)
+        _normalize_flex([0])
+        _normalize_flex([0], numerical=True)
 
 
 def test_vector_distance_pointwise():

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -13,7 +13,7 @@ from pyrigi.misc import (
     sympy_expr_to_float,
     is_isomorphic_graph_list,
     _normalize_flex,
-    vector_distance_pointwise,
+    _vector_distance_pointwise,
     point_to_vector,
     is_zero,
 )
@@ -91,22 +91,23 @@ def test__normalize_flex():
 
 
 def test_vector_distance_pointwise():
-    assert is_zero(vector_distance_pointwise({0: [1, 1]}, {0: [1, 1]}))
+    assert is_zero(_vector_distance_pointwise({0: [1, 1]}, {0: [1, 1]}))
     assert is_zero(
-        vector_distance_pointwise({0: [1, 1], 1: [1, -1]}, {0: [1, -1], 1: [1, -1]}) - 2
+        _vector_distance_pointwise({0: [1, 1], 1: [1, -1]}, {0: [1, -1], 1: [1, -1]})
+        - 2
     )
     assert isclose(
-        vector_distance_pointwise({0: [1, 1]}, {0: [1, -1]}, numerical=True), 2
+        _vector_distance_pointwise({0: [1, 1]}, {0: [1, -1]}, numerical=True), 2
     )
     assert isclose(
-        vector_distance_pointwise(
+        _vector_distance_pointwise(
             {0: [1, 1], 1: [1, -1]}, {0: [1, -1], 1: [1, 1]}, numerical=True
         ),
         math.sqrt(8),
     )
 
     with pytest.raises(ValueError):
-        vector_distance_pointwise({0: [1, 1]}, {1: [1, 1]})
+        _vector_distance_pointwise({0: [1, 1]}, {1: [1, 1]})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I suggest to make some misc functions non-public as their usage is just within the package itself.
Also, I propose to avoid names in function names.