### PR TITLE
Guide: Added guide on PR prefixes and release notes

### DIFF
--- a/doc/development/howto/git.md
+++ b/doc/development/howto/git.md
@@ -9,7 +9,7 @@ In a nutshell, this means that there are two prominent branches in PyRigi's Git 
 - `dev`, which is used for the development.
 
 Collaborators are not allowed to push their Git commits directly to these two branches.
-Rather, they should employ _pull requests_.
+Rather, they should employ _pull requests_ (PR).
 Say Alice and Bob want to implement feature X in PyRigi.
 These are the tasks to be performed:
 
@@ -24,17 +24,60 @@ addressed a comment, Alica and Bob can use a tick in the GitHub GUI (`:white_che
 4. Once the pull request is approved, a maintainer merges `feature-X` into `dev` and during the next version release
 cycle, it will be merged into `main`, making the code available through the `pip` installation of PyRigi.
 
+The branch prefixes should be named according the following convention:
 
-We propose a few categories for contributing branches:
-* _features_: branches to implement new features/improvements to the current status; their name should start by `feature-`
-* _documentation_: branches to modify the documentation; their name should start by `doc-`, or `docfix-` when solving an error
-* _bugs_: branches to solve known bugs; their name should start by `bugfix-`
-* _hotfix_: branches to solve an urgent error; their name should start by `hotfix-`
-* _testing_: branches to add tests; their name should start by `test-`
-* _refactoring_: branches to refactor the code; their name should start by `refactor-`
+| Branch prefix | Usage                                                    | Usual PR prefix                |
+|---------------|----------------------------------------------------------|--------------------------------|
+| `feature-`    | adding new features, parameters or algorithms\*          | `Feature:`                     |
+| `bugfix-`     | fixing bugs on `dev` introduced since the latest release | `Feature:`                     |
+| `doc-`        | changing the documentation (including fixes)             | `Doc:`, `Guide:` or `Minor`    |
+| `hotfix-`     | fixing bugs on `main`                                    | `Fix:`                         |
+| `test-`       | adding and refactoring tests                             | `Test:` or `Minor:`            |
+| `refactor-`   | refactoring the package source code\*                    | `Code:`, `Minor:` or `Update:` |
+| `release-`    | creating new release                                     | `Setup:`                       |
+| `setup-`      | changing technical setting (e.g. GitHub workflows)       | `Setup:`                       |
+| `major-`      | introducing backward incompatible changes                | `Update:`                      |
 
-When a bug is discovered on `main`, the corresponding `bugfix-`/`hotfix-` branch should be created on `main`.
+\* Only in backward compatible manner.
 
+:::{warning}
+The changes that are not backward compatible can be introduced only on `major-` branch.
+When such a branch is merged to `dev`, only major release can follow.
+:::
+
+## Pull request titles
+
+The pull request titles are used for [Release Notes](https://github.com/PyRigi/PyRigi/releases).
+Hence, each PR title has to start with one of the prefixes from the table above
+followed by a capitalized verb in past tense.
+The maintainer who approves and merges a PR is responsible for checking (and possible adjusting)
+the prefix to match the section in which it should be listed in Release Notes according to the following tables.   
+The first part of Release Notes is aimed at users:
+
+| PR prefix  | Release notes section | Information about                           |
+|------------|-----------------------|---------------------------------------------|
+| `Feature:` | New features          | new functionality                           |
+| `Update:`  | Updates               | improvements, interface changes             |
+| `Fix:`     | Bug fixes             | fixed bugs since the last release           |
+| `Doc:`     | Documentation         | changes to User guide or Math documentation |
+
+The second part is meant for developers:
+
+| PR prefix | Release notes section | Information about                      |
+|-----------|-----------------------|----------------------------------------|
+| `Test:`   | Testing               | new or changed tests                   |
+| `Setup:`  | Technical setup       | changes to technical setting           |
+| `Code:`   | Code changes          | refactoring and restructuring the code |
+| `Guide:`  | Development guide     | changes to Development guide           |
+| `Minor:`  | Minor changes         | fixed typos, minor refactoring etc.    |
+
+After automatic grouping according to the prefixes, manual adjustments should be made.
+For instance:
+
+* If a feature was developed (and bug fixed) on several PRs,
+  they should be listed under the same item in New features.
+* If a bug is discovered on `main`, only hot fixed on `main` by disabling the functionality
+  and properly fixed on `dev` via a `feature-` branch, all corresponding PRs should be in the same item in Bug fixes. 
 
 ## Version Release
 
@@ -54,7 +97,7 @@ To create a new MAJOR/MINOR version, the following steps should be taken by the 
 5. Continue on the release branch and remove the files that are not supposed to be in the release (e.g. `poetry.lock`).
 6. Merge the branch into `main`.
 7. Check that the online documentation has been deployed correctly.
-8. Add a new release tag in GitHub and generate the corresponding release notes.
+8. Add a new release tag in GitHub and generate the corresponding release notes according to the instructions above.
 9. Review the upload to PyPi.
 10. Run `poetry update` and commit `poetry.lock` to update the dependencies on `dev` .
 

--- a/doc/development/howto/git.md
+++ b/doc/development/howto/git.md
@@ -15,12 +15,12 @@ These are the tasks to be performed:
 
 1. they branch from `dev`, creating a branch called `feature-X`, and there they develop the intended functionality;
 2. once they are done, they push `feature-X` to GitHub and solicit a pull request of `feature-X` into `dev`;
-3. After creating a pull request, but before your code is merged into the `dev` branch, the code is checked
+3. After creating a pull request, but before the branch is merged into `dev`, the code is checked
 by the maintainers, who may ask some other collaborator to serve as reviewer to ensure that the coding
 standards and other requirements are satisfied. In a review, Alice and Bob will get comments about specific
 pieces of code or other further suggestions. Once they think that they have adequately
-addressed a comment, Alica and Bob can use a tick in the GitHub GUI (`:white_check_mark:`✅ or
-`:heavy_check_mark:`✔️ ) to indicate that. If the reviewer agrees, they will resolve the comment. 
+addressed a comment, Alice and Bob can use a tick in the GitHub GUI (`:white_check_mark:`✅ or
+`:heavy_check_mark:`✔️ ) to indicate that. If the reviewer agrees, they will resolve the comment.
 4. Once the pull request is approved, a maintainer merges `feature-X` into `dev` and during the next version release
 cycle, it will be merged into `main`, making the code available through the `pip` installation of PyRigi.
 
@@ -41,17 +41,17 @@ The branch prefixes should be named according the following convention:
 \* Only in backward compatible manner.
 
 :::{warning}
-The changes that are not backward compatible can be introduced only on `major-` branch.
-When such a branch is merged to `dev`, only major release can follow.
+Changes that are not backward compatible can only be introduced on a `major-` branch.
+When such a branch is merged to `dev`, only a major release can follow.
 :::
 
 ## Pull request titles
 
 The pull request titles are used for [Release Notes](https://github.com/PyRigi/PyRigi/releases).
 Hence, each PR title has to start with one of the prefixes from the table above
-followed by a capitalized verb in past tense.
+followed by a capitalized verb as a past participle.
 The maintainer who approves and merges a PR is responsible for checking (and possible adjusting)
-the prefix to match the section in which it should be listed in Release Notes according to the following tables.   
+the prefix to match the section in which it should be listed in the Release Notes according to the following tables.
 The first part of Release Notes is aimed at users:
 
 | PR prefix  | Release notes section | Information about                           |
@@ -75,9 +75,9 @@ After automatic grouping according to the prefixes, manual adjustments should be
 For instance:
 
 * If a feature was developed (and bug fixed) on several PRs,
-  they should be listed under the same item in New features.
+  the latter should be listed under the same item under New features.
 * If a bug is discovered on `main`, only hot fixed on `main` by disabling the functionality
-  and properly fixed on `dev` via a `feature-` branch, all corresponding PRs should be in the same item in Bug fixes. 
+  and properly fixed on `dev` via a `feature-` branch, all corresponding PRs should be in the same item under Bug fixes.
 
 ## Version Release
 
@@ -107,4 +107,4 @@ To release a new PATCH version, the following should be taken using some steps f
 * Steps 6.-10.
 * Create branch `release-x.y.z-main-to-dev` on `dev`.
 * Merge `main` into `release-x.y.z-main-to-dev` while keeping the `poetry.lock` file from `release-x.y.z-main-to-dev`.
-* Merge the branch `release-x.y.z-main-to-dev` via a PR to `dev`. 
+* Merge the branch `release-x.y.z-main-to-dev` via a PR to `dev`.


### PR DESCRIPTION
I propose to introduce predefined prefixes of PRs in order to have better Release notes [(see 1.0.0 and 1.0.1)](https://github.com/PyRigi/PyRigi/releases) with reasonable amount of work.
The (usage of) branch prefixes is also adjusted.

A script for automatic grouping the PRs according to prefixes will be provided once there are enough prefixed PRs to create and test it.