### PR TITLE
Setup: Added testing timeouts

### DIFF
--- a/.github/workflows/python-test-dev.yml
+++ b/.github/workflows/python-test-dev.yml
@@ -16,7 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-test-dev.yml
+++ b/.github/workflows/python-test-dev.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-test-main.yml
+++ b/.github/workflows/python-test-main.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v4

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -45,11 +45,11 @@ See the file `pyproject.toml` for the markers that specify groups of tests relyi
 
 We mark tests that take longer time according to the following table:
 
-| marker               | per test | total time | execution
-| -------------------- | -------- | ---------- | -------------------
-| standard (no marker) | < 0.5s   | < 2 min    | on merge/PR to `dev`
-| `slow_main`          | < 10s    | < 15 min   | on merge/PR to `main`
-| `long_local`         | > 10s    | hours      | locally when needed
+| marker               | per test | total time | execution             | GitHub action timeout |
+| -------------------- | -------- | ---------- | ----------------------| ----------------------|
+| standard (no marker) | < 0.5s   | < 2 min    | on merge/PR to `dev`  | 5 min                 |
+| `slow_main`          | < 10s    | < 15 min   | on merge/PR to `main` | 30 min                |
+| `long_local`         | > 10s    | hours      | locally when needed   | -                     |
 
 The column `total time` indicates how much time is needed to run all tests with the given marker.
 The time limits per tests are approximate: it is better to have a longer standard tests than none.


### PR DESCRIPTION
It happened that the tests on #309 were running for more than 4 hours without finishing, see https://github.com/PyRigi/PyRigi/actions/runs/14254585226/attempts/1. After cancellation and re-running, they passed. Besides investigating what the problem was, I suggest setting a timeout for the tests to avoid such long runs, where something is obviously going wrong.