### PR TITLE
Setup: Release 1.0.2 (pulled `main` to `dev`)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ author = "The PyRigi Developers"
 # The short X.Y version
 version = "1.0"
 # The full version, including alpha/beta/rc tags
-release = "1.0.1"
+release = "1.0.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/development/howto/git.md
+++ b/doc/development/howto/git.md
@@ -106,7 +106,8 @@ To create a new MAJOR/MINOR version, the following steps should be taken by the 
 To release a new PATCH version, the following should be taken using some steps from above:
 * Create a release branch `release-x.y.z` on `main`.
 * Step 2. (and 3. if the patch involves a new contributor).
-* Steps 6.-10.
+* Steps 6.-9.
+* Pull `main`.
 * Create branch `release-x.y.z-main-to-dev` on `dev`.
 * Merge `main` into `release-x.y.z-main-to-dev` while keeping the `poetry.lock` file from `release-x.y.z-main-to-dev`.
 * Merge the branch `release-x.y.z-main-to-dev` via a PR to `dev`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrigi"
-version = "1.0.1"
+version = "1.0.2"
 dynamic = [ "readme", "classifiers", "dependencies", "optional-dependencies" ]
 description = "Python package concerning the rigidity and flexibility of bar-and-joint frameworks."
 requires-python = ">=3.11"


### PR DESCRIPTION
Since on #324, not the latest version of `main` was merged, `main` is merged to `dev` again.