### PR TITLE
Code: Used public attributes of `FrameworkBase`

### DIFF
--- a/pyrigi/framework/_general.py
+++ b/pyrigi/framework/_general.py
@@ -100,7 +100,7 @@ def is_congruent_realization(
     )
 
     for u, v in combinations(framework._graph.nodes, 2):
-        edge_vec = (framework._realization[u]) - framework._realization[v]
+        edge_vec = framework[u] - framework[v]
         dist_squared = (edge_vec.T * edge_vec)[0, 0]
 
         other_edge_vec = point_to_vector(other_realization[u]) - point_to_vector(
@@ -171,7 +171,7 @@ def is_equivalent_realization(
     )
 
     for u, v in framework._graph.edges:
-        edge_vec = framework._realization[u] - framework._realization[v]
+        edge_vec = framework[u] - framework[v]
         dist_squared = (edge_vec.T * edge_vec)[0, 0]
 
         other_edge_vec = point_to_vector(other_realization[u]) - point_to_vector(

--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -882,7 +882,7 @@ def plot2D(
     fig.set_figheight(plot_style.canvas_height)
     ax.set_aspect(plot_style.aspect_ratio)
 
-    if framework._dim == 1:
+    if framework.dim == 1:
         placement = {
             vertex: [position[0], 0]
             for vertex, position in framework.realization(
@@ -894,7 +894,7 @@ def plot2D(
         else:
             plot_style.update(edges_as_arcs=True)
 
-    elif framework._dim == 2:
+    elif framework.dim == 2:
         placement = framework.realization(as_points=True, numerical=True)
 
     else:
@@ -982,7 +982,7 @@ def animate3D_rotation(
     >>> F = frameworkDB.Complete(4, dim=3)
     >>> F.animate3D_rotation()
     """
-    _input_check.dimension_for_algorithm(framework._dim, [3], "animate3D")
+    _input_check.dimension_for_algorithm(framework.dim, [3], "animate3D")
     if plot_style is None:
         # change some PlotStyle default values to fit 3D plotting better
         plot_style = PlotStyle3D(vertex_size=13.5, edge_width=1.5, dpi=150)
@@ -1210,13 +1210,13 @@ def plot3D(
     ax.set_axis_off()
 
     placement = framework.realization(as_points=True, numerical=True)
-    if framework._dim in [1, 2]:
+    if framework.dim in [1, 2]:
         placement = {
-            v: list(p) + [0 for _ in range(3 - framework._dim)]
+            v: list(p) + [0 for _ in range(3 - framework.dim)]
             for v, p in placement.items()
         }
 
-    elif framework._dim == 3:
+    elif framework.dim == 3:
         placement = framework.realization(as_points=True, numerical=True)
 
     else:
@@ -1284,9 +1284,9 @@ def plot(
     use :meth:`.plot2D` or :meth:`.plot3D` instead.
     For various formatting options, see :class:`.PlotStyle`.
     """
-    if framework._dim == 3:
+    if framework.dim == 3:
         plot3D(framework, plot_style=plot_style, **kwargs)
-    elif framework._dim > 3:
+    elif framework.dim > 3:
         raise ValueError(
             "This framework is in higher dimension than 3!"
             + " For projection into 2D use F.plot2D(),"

--- a/pyrigi/framework/_rigidity/infinitesimal.py
+++ b/pyrigi/framework/_rigidity/infinitesimal.py
@@ -167,7 +167,7 @@ def trivial_inf_flexes(
     [ 0]])]
     """
     vertex_order = _graph_input_check.is_vertex_order(framework._graph, vertex_order)
-    dim = framework._dim
+    dim = framework.dim
     translations = [
         Matrix.vstack(*[A for _ in vertex_order]) for A in Matrix.eye(dim).columnspace()
     ]
@@ -374,7 +374,7 @@ def is_inf_rigid(
     False
     """
 
-    if framework._graph.number_of_nodes() <= framework._dim + 1:
+    if framework._graph.number_of_nodes() <= framework.dim + 1:
         return rigidity_matrix_rank(
             framework, numerical=numerical, tolerance=tolerance
         ) == binomial(framework._graph.number_of_nodes(), 2)

--- a/pyrigi/framework/_rigidity/infinitesimal.py
+++ b/pyrigi/framework/_rigidity/infinitesimal.py
@@ -72,8 +72,7 @@ def rigidity_matrix(
         [
             flatten(
                 [
-                    delta(e, w)
-                    * (framework._realization[e[0]] - framework._realization[e[1]])
+                    delta(e, w) * (framework[e[0]] - framework[e[1]])
                     for w in vertex_order
                 ]
             )
@@ -179,7 +178,7 @@ def trivial_inf_flexes(
             A[j, i] = -1
             basis_skew_symmetric += [A]
     inf_rot = [
-        Matrix.vstack(*[A * framework._realization[v] for v in vertex_order])
+        Matrix.vstack(*[A * framework[v] for v in vertex_order])
         for A in basis_skew_symmetric
     ]
     matrix_inf_flexes = Matrix.hstack(*(translations + inf_rot))

--- a/pyrigi/framework/_rigidity/second_order.py
+++ b/pyrigi/framework/_rigidity/second_order.py
@@ -115,7 +115,7 @@ def is_prestress_stable(
                             )
                             ** 2
                         )
-                        for j in range(framework._dim)
+                        for j in range(framework.dim)
                     ]
                 )
                 for u, v in edges

--- a/pyrigi/framework/_transformations/transformations.py
+++ b/pyrigi/framework/_transformations/transformations.py
@@ -254,17 +254,17 @@ def projected_realization(
     if coordinates is not None:
         if not isinstance(coordinates, tuple) and not isinstance(coordinates, list):
             raise TypeError("The parameter ``coordinates`` must be a tuple or a list.")
-        if max(coordinates) >= framework._dim:
+        if max(coordinates) >= framework.dim:
             raise ValueError(
                 f"Index {np.max(coordinates)} out of range"
-                + f" with placement in dim: {framework._dim}."
+                + f" with placement in dim: {framework.dim}."
             )
         if isinstance(proj_dim, int) and len(coordinates) != proj_dim:
             raise ValueError(
                 f"The number of coordinates ({len(coordinates)}) does not match"
                 + f" proj_dim ({proj_dim})."
             )
-        matrix = np.zeros((len(coordinates), framework._dim))
+        matrix = np.zeros((len(coordinates), framework.dim))
         for i, coord in enumerate(coordinates):
             matrix[i, coord] = 1
 
@@ -278,25 +278,25 @@ def projected_realization(
 
     if projection_matrix is not None:
         projection_matrix = np.array(projection_matrix)
-        if projection_matrix.shape[1] != framework._dim:
+        if projection_matrix.shape[1] != framework.dim:
             raise ValueError(
                 "The projection matrix has wrong number of columns."
-                + f"{projection_matrix.shape[1]} instead of {framework._dim}."
+                + f"{projection_matrix.shape[1]} instead of {framework.dim}."
             )
         if isinstance(proj_dim, int) and projection_matrix.shape[0] != proj_dim:
             raise ValueError(
                 "The projection matrix has wrong number of rows."
-                + f"{projection_matrix.shape[0]} instead of {framework._dim}."
+                + f"{projection_matrix.shape[0]} instead of {framework.dim}."
             )
 
     if projection_matrix is None:
         if proj_dim == 2:
             projection_matrix = _generate_two_orthonormal_vectors(
-                framework._dim, random_seed=random_seed
+                framework.dim, random_seed=random_seed
             )
         elif proj_dim == 3:
             projection_matrix = _generate_three_orthonormal_vectors(
-                framework._dim, random_seed=random_seed
+                framework.dim, random_seed=random_seed
             )
         else:
             raise ValueError(

--- a/test/motion/test_approximate_motion.py
+++ b/test/motion/test_approximate_motion.py
@@ -71,7 +71,7 @@ def test_from_framework(framework):
                 sample, numerical=True, tolerance=1e-3
             ) and not framework.is_congruent_realization(sample, numerical=True)
     except ValueError:
-        assert framework._dim == 1
+        assert framework.dim == 1
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ def test_from_graph(framework):
                 sample, numerical=True, tolerance=1e-3
             )
     except ValueError:
-        assert framework._dim == 1
+        assert framework.dim == 1
 
 
 def test_normalize_realizations():


### PR DESCRIPTION
Whenever possible, `framework.dim` and `framework[v]` is used instead of `framework._dim` and `framework._realization[v]` respectively in functions accepting `framework: FrameworkBase`. 