### PR TITLE
Doc: Renamed Internal Reference

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -363,39 +363,6 @@ def setup(app: Sphinx):
     app.add_lexer("myst", MystLexer)
 
 
-# -----create the documentation of input checks
-
-input_check_str = ""
-for cls in [Framework]:
-    methods = [
-        method
-        for method in dir(cls)
-        if method.startswith("_input_check_") and callable(getattr(cls, method))
-    ]
-    input_check_str += (
-        f"""
-Input check methods of {cls.__name__}
-======================={''.join(["=" for _ in range(len(cls.__name__))])}
-
-.. automethod:: {cls.__module__}.{cls.__name__}."""
-        + f"""
-
-.. automethod:: {cls.__module__}.{cls.__name__}.""".join(
-            methods
-        )
-        + "\n\n"
-    )
-
-input_check_str += """
-
-General input check functions
-=============================
-
-
-"""
-
-_input_check.__doc__ = input_check_str
-
 
 # ----------generate module structure with comments------------------------
 

--- a/doc/development/howto/input_checks.md
+++ b/doc/development/howto/input_checks.md
@@ -60,7 +60,11 @@ def method(self, algorithm: str = "default"):
    :show-inheritance:
 ```
 
-## Input check functions
+## Input check functions of Framework
+
+See the methods of {class}`~.framework.base.FrameworkBase` starting with `_input_check`.
+
+## General input check functions
 
 ```{eval-rst}
 .. automodule:: pyrigi._utils._input_check

--- a/doc/development/internal_reference.md
+++ b/doc/development/internal_reference.md
@@ -1,8 +1,9 @@
-# Internal API Reference
+# Internal Reference
 
 Here we collect the documentation of classes that are internally used in PyRigi.
+The interface might change in future releases.
 
 :::{toctree}
 :maxdepth: 2
-internal_api/framework_base
+internal_reference/framework_base
 :::

--- a/doc/development/internal_reference/framework_base.md
+++ b/doc/development/internal_reference/framework_base.md
@@ -6,4 +6,5 @@
    :members:
    :inherited-members:
    :show-inheritance:
+   :private-members:
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -30,7 +30,7 @@ math/references
 :maxdepth: 2
 :caption: Development guide
 development/howto
-development/internal_api
+development/internal_reference
 development/cheatsheet
 development/contributors
 :::

--- a/doc/userguide/api.md
+++ b/doc/userguide/api.md
@@ -1,5 +1,7 @@
 # API Reference
 
+The interface of the classes listed below is considered stable.
+
 :::{toctree}
 :maxdepth: 2
 api/graph

--- a/pyrigi/framework/base.py
+++ b/pyrigi/framework/base.py
@@ -525,6 +525,13 @@ class FrameworkBase(object):
         """
         Check whether a vertex appears as key in a realization and
         raise an error otherwise.
+
+        Parameters
+        ----------
+        vertex:
+            The vertex to check.
+        realization:
+            The realization to check.
         """
         if realization is None:
             realization = self._realization
@@ -535,6 +542,10 @@ class FrameworkBase(object):
         """
         Check whether a point has the right dimension and
         raise an error otherwise.
+
+        Parameters
+        ----------
+        point:
         """
         if not len(point) == self.dim:
             raise ValueError(

--- a/pyrigi/graph/_sparsity/_pebble_digraph.py
+++ b/pyrigi/graph/_sparsity/_pebble_digraph.py
@@ -12,6 +12,8 @@ class PebbleDiGraph(nx.MultiDiGraph):
     """
     Class representing a directed graph for pebble game algorithm.
 
+    It must hold that ``0 < K`` and ``L < 2K``.
+
     Notes
     -----
     All ``networkx`` methods in use need a wrapper - to
@@ -20,7 +22,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
     def __init__(self, K: int = None, L: int = None, *args, **kwargs) -> None:
         """
-        Set up the graph and the values of K and L for the pebble game algorithm.
+        Set up the graph and the values of ``K`` and ``L`` for the pebble game algorithm.
         """
         # We allow not defining them yet
         if K is not None and L is not None:
@@ -34,9 +36,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
     @property
     def K(self) -> int:
         """
-        Get the value of K.
-
-        K is integer and 0 < K. Also, L < 2K.
+        Get the value of ``K``.
         """
         return self._K
 
@@ -49,7 +49,8 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
         Parameters
         ----------
-        value: value K must be an integer and 0 < K. Also, L < 2K.
+        value:
+            value K must be an integer and 0 < K. Also, L < 2K.
         """
         _input_check.pebble_values(value, self._L)
         self._K = value
@@ -57,9 +58,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
     @property
     def L(self) -> int:
         """
-        Get the value of L.
-
-        L is integer and 0 <= L. Also, L < 2K.
+        Get the value of ``L``.
         """
         return self._L
 
@@ -72,22 +71,25 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
         Parameters
         ----------
-        value: value L must be integer and 0 <= L. Also, L < 2K.
+        value:
+            value L must be integer and 0 <= L. Also, L < 2K.
         """
         _input_check.pebble_values(self._K, value)
         self._L = value
 
     def set_K_and_L(self, K: int, L: int) -> None:
         """
-        Set K and L.
+        Set ``K`` and ``L``.
 
         After doing so, the directions of the edges may have to be recomputed.
 
         Parameters
         ----------
-        K: K is integer and 0 < K.
-        L: L is integer and 0 <= L.
-        Also, L < 2K.
+        K:
+            ``K`` is integer and ``0 < K``.
+        L:
+            ``L`` is integer and ``0 <= L``.
+            Also, ``L < 2K``.
         """
         _input_check.pebble_values(K, L)
 
@@ -102,22 +104,14 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
     def in_degree(self, vertex: Vertex) -> int:
         """
-        Return the number of edges leading to vertex.
-
-        Parameters
-        ----------
-        vertex: Vertex, whose indegree we want to know.
+        Return the number of edges leading to ``vertex``.
         """
         self._input_check_vertex_member(vertex)
         return int(super().in_degree(vertex))
 
     def out_degree(self, vertex: Vertex) -> int:
         """
-        Return the number of edges leading out from a vertex.
-
-        Parameters
-        ----------
-        vertex: Vertex, whose outdegree we want to know.
+        Return the number of edges leading out from ``vertex``.
         """
         self._input_check_vertex_member(vertex)
         return int(super().out_degree(vertex))
@@ -129,7 +123,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
         Parameters
         ----------
         edge:
-            DirectedEdge to redirect.
+            A directed edge to redirect.
         vertex_to:
             A vertex to which the edge should point to.
             The vertex must be part of the edge.
@@ -144,9 +138,9 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
     def fundamental_circuit(self, u: Vertex, v: Vertex) -> {set[Vertex]}:  # noqa: C901
         """
-        Return the fundamental (k, l)-matroid circuit of the edge uv.
+        Return the fundamental $(k, l)$-matroid circuit of the edge ``uv``.
 
-        If the edge uv is independent, ``None`` is returned.
+        If the edge ``uv`` is independent, ``None`` is returned.
         """
 
         def dfs(
@@ -256,7 +250,7 @@ class PebbleDiGraph(nx.MultiDiGraph):
 
     def can_add_edge_between_vertices(self, u: Vertex, v: Vertex) -> bool:
         """
-        Check whether the edge (u, v) can be added to the pebble digraph.
+        Check whether the edge ``(u, v)`` can be added to the pebble digraph.
         """
         return self.fundamental_circuit(u, v) is None
 


### PR DESCRIPTION
Also:
- fixed some issues with displaying data_types in `FrameworkBase`
- avoided rewriting module docstrings in `conf.py`
- improved docstrings of `PebbleDigraph` in case it should be displayed in the Internal Reference in future