### PR TITLE
Made numerical and symbolic flexes consistent by adding the option `fixed_vertices`

### DIFF
--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -38,6 +38,7 @@ def _resolve_inf_flex(
     inf_flex: int | Matrix | InfFlex,
     realization: dict[Vertex, Point] = None,
     projection_matrix: Matrix = None,
+    fixed_vertices: Sequence[Vertex] = [],
 ) -> dict[Vertex, Point]:
     """
     Resolve an infinitesimal flex from various datatypes.
@@ -52,12 +53,14 @@ def _resolve_inf_flex(
         If ``None``, the framework realization is used.
     projection_matrix:
         A matrix used for projection to a lower dimension.
+    fixed_vertices:
+        Vertices that are assigned a zero flex in the plot.
     """
     if isinstance(inf_flex, int) and inf_flex >= 0:
         inf_flex_basis = infinitesimal_rigidity.nontrivial_inf_flexes(
-            framework, numerical=True
+            framework, numerical=True, fixed_vertices=fixed_vertices
         )
-        if inf_flex >= len(inf_flex_basis):
+        if inf_flex > len(inf_flex_basis):
             raise IndexError(
                 "The value of inf_flex exceeds "
                 + "the dimension of the space "
@@ -146,6 +149,7 @@ def _plot_inf_flex2D(
     realization: dict[Vertex, Point] = None,
     projection_matrix: Matrix = None,
     plot_style: PlotStyle2D = None,
+    fixed_vertices: Sequence[Vertex] = [],
 ) -> None:
     """
     Plot a 2D infinitesimal flex on the canvas.
@@ -160,9 +164,11 @@ def _plot_inf_flex2D(
     projection_matrix:
         A matrix used to project the infinitesimal flex to 2D.
     plot_style:
+    fixed_vertices:
+        Vertices that are assigned a zero flex in the plot.
     """
     inf_flex_pointwise = _resolve_inf_flex(
-        framework, inf_flex, realization, projection_matrix
+        framework, inf_flex, realization, projection_matrix, fixed_vertices
     )
 
     x_canvas_width = ax.get_xlim()[1] - ax.get_xlim()[0]
@@ -208,6 +214,7 @@ def _plot_inf_flex3D(
     realization: dict[Vertex, Point] = None,
     projection_matrix: Matrix = None,
     plot_style: PlotStyle3D = None,
+    fixed_vertices: Sequence[Vertex] = [],
 ) -> None:
     """
     Plot a 3D infinitesimal flex on the canvas.
@@ -222,9 +229,11 @@ def _plot_inf_flex3D(
     projection_matrix:
         A matrix used to project the infinitesimal flex to 3D.
     plot_style:
+    fixed_vertices:
+        Vertices that are assigned a zero flex in the plot.
     """
     inf_flex_pointwise = _resolve_inf_flex(
-        framework, inf_flex, realization, projection_matrix
+        framework, inf_flex, realization, projection_matrix, fixed_vertices
     )
     x_canvas_width = ax.get_xlim()[1] - ax.get_xlim()[0]
     y_canvas_width = ax.get_ylim()[1] - ax.get_ylim()[0]
@@ -778,7 +787,8 @@ def plot2D(
     stress_label_positions: dict[DirectedEdge, float] = None,
     arc_angles_dict: Sequence[float] | dict[DirectedEdge, float] = None,
     filename: str = None,
-    dpi=300,
+    dpi: int = 300,
+    fixed_vertices: Sequence[Vertex] = [],
     **kwargs,
 ) -> None:
     """
@@ -848,6 +858,8 @@ def plot2D(
         ``matplotlib``.
     dpi: Dots per inched in case the figure is saved. Default is 300 for producing
         a print-quality image.
+    fixed_vertices:
+        Vertices that are assigned a zero flex in the plot.
 
     Examples
     --------
@@ -940,6 +952,7 @@ def plot2D(
             realization=placement,
             plot_style=plot_style,
             projection_matrix=projection_matrix,
+            fixed_vertices=fixed_vertices,
         )
     if stress is not None:
         _plot_stress2D(
@@ -1107,7 +1120,8 @@ def plot3D(
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     stress_label_positions: dict[DirectedEdge, float] = None,
     filename: str = None,
-    dpi=300,
+    dpi: int = 300,
+    fixed_vertices: Sequence[Vertex] = [],
     **kwargs,
 ) -> None:
     """
@@ -1174,6 +1188,8 @@ def plot3D(
         ``matplotlib``.
     dpi: Dots per inched in case the figure is saved. Default is 300 for producing
         a print-quality image.
+    fixed_vertices:
+        Vertices that are assigned a zero flex in the plot.
 
     Examples
     --------
@@ -1270,6 +1286,7 @@ def plot3D(
             realization=_placement,
             plot_style=plot_style,
             projection_matrix=projection_matrix,
+            fixed_vertices=fixed_vertices,
         )
 
     if stress is not None:

--- a/pyrigi/framework/_rigidity/infinitesimal.py
+++ b/pyrigi/framework/_rigidity/infinitesimal.py
@@ -3,6 +3,7 @@ This module provides algorithms related to infinitesimal rigidity of frameworks.
 """
 
 from copy import deepcopy
+import warnings
 
 import numpy as np
 import sympy as sp
@@ -11,7 +12,7 @@ from sympy import Matrix, binomial, flatten
 import pyrigi.graph._utils._input_check as _graph_input_check
 from pyrigi._utils._conversion import sympy_expr_to_float
 from pyrigi._utils._zero_check import is_zero_vector
-from pyrigi._utils.linear_algebra import _null_space
+from pyrigi._utils.linear_algebra import _reduced_null_space
 from pyrigi.data_type import (
     Edge,
     InfFlex,
@@ -224,6 +225,7 @@ def inf_flexes(
     vertex_order: Sequence[Vertex] = None,
     numerical: bool = False,
     tolerance: float = 1e-9,
+    fixed_vertices: Sequence[Vertex] = [],
 ) -> list[Matrix] | list[list[float]]:
     r"""
     Return a basis of the space of infinitesimal flexes.
@@ -249,8 +251,11 @@ def inf_flexes(
         If none is provided, the list from :meth:`.Graph.vertex_list` is taken.
     numerical:
         Determines whether the output is symbolic (default) or numerical.
-    tolerance
+    tolerance:
         Used tolerance when computing the infinitesimal flex numerically.
+    fixed_vertices:
+        Fixed vertices are assigned a flex of length 0. The default value is
+        an empty list. They can be provided as a sequence of vertices.
 
     Examples
     --------
@@ -284,23 +289,49 @@ def inf_flexes(
     [0]])]
     """
     vertex_order = _graph_input_check.is_vertex_order(framework._graph, vertex_order)
+    if not isinstance(fixed_vertices, Sequence) or (
+        fixed_vertices is not None
+        and not all(v in framework._graph.nodes for v in fixed_vertices)
+    ):
+        raise ValueError(
+            "All `fixed_vertices` need to be contained in the underlying graph."
+        )
+    if (
+        len(fixed_vertices) > 2
+        or len(fixed_vertices) == 2
+        and not framework._graph.has_edge(*fixed_vertices)
+    ):
+        warnings.warn(
+            "The `fixed_vertices` are not an edge of the graph, so the resulting "
+            + "nontrivial infinitesimal flexes may be affected."
+        )
+    # Define the columns of the rigidity matrix that are not fixed by `fixed_vertices`
+    free_columns = [
+        framework.dim * i + j
+        for (i, v) in enumerate(vertex_order)
+        for j in range(framework.dim)
+        if v not in fixed_vertices
+    ]
+
     if include_trivial:
         if not numerical:
-            return rigidity_matrix(framework, vertex_order=vertex_order).nullspace()
+            rig_matrix = rigidity_matrix(framework, vertex_order=vertex_order)
         else:
             F = FrameworkBase(
                 framework._graph, framework.realization(as_points=True, numerical=True)
             )
-            return _null_space(
-                np.array(rigidity_matrix(F, vertex_order=vertex_order)).astype(
-                    np.float64
-                )
+            rig_matrix = np.array(rigidity_matrix(F, vertex_order=vertex_order)).astype(
+                np.float64
             )
+        inf_flexes = _reduced_null_space(
+            rig_matrix, free_columns, numerical=numerical, tolerance=tolerance
+        )
+        return [inf_flexes[:, i] for i in range(inf_flexes.shape[1])]
 
     if not numerical:
         rig_matrix = rigidity_matrix(framework, vertex_order=vertex_order)
-
-        all_inf_flexes = rig_matrix.nullspace()
+        all_inf_flexes = _reduced_null_space(rig_matrix, free_columns, numerical=False)
+        all_inf_flexes = [all_inf_flexes[:, i] for i in range(all_inf_flexes.shape[1])]
         triv_inf_flexes = trivial_inf_flexes(framework, vertex_order=vertex_order)
         s = len(triv_inf_flexes)
         extend_basis_matrix = Matrix.hstack(*triv_inf_flexes)
@@ -314,27 +345,32 @@ def inf_flexes(
         F = FrameworkBase(
             framework._graph, framework.realization(as_points=True, numerical=True)
         )
-        flexes = _null_space(
-            np.array(rigidity_matrix(F, vertex_order=vertex_order)).astype(np.float64),
-            tolerance=tolerance,
+        rig_matrix = np.array(rigidity_matrix(F, vertex_order=vertex_order)).astype(
+            np.float64
         )
-        flexes = [flexes[:, i] for i in range(flexes.shape[1])]
+        all_inf_flexes = _reduced_null_space(
+            rig_matrix, free_columns, numerical=True, tolerance=tolerance
+        )
+        all_inf_flexes = [all_inf_flexes[:, i] for i in range(all_inf_flexes.shape[1])]
+
         Kn = FrameworkBase(
             CompleteGraph(len(framework._graph)),
             framework.realization(as_points=True, numerical=True),
         )
-        inf_flexes_trivial = _null_space(
-            np.array(rigidity_matrix(Kn, vertex_order=vertex_order)).astype(np.float64),
-            tolerance=tolerance,
+        rig_matrix_complete = np.array(
+            rigidity_matrix(Kn, vertex_order=vertex_order)
+        ).astype(np.float64)
+        triv_inf_flexes = _reduced_null_space(
+            rig_matrix_complete, free_columns, numerical=True, tolerance=tolerance
         )
-        s = inf_flexes_trivial.shape[1]
-        extend_basis_matrix = inf_flexes_trivial
-        for inf_flex in flexes:
+        s = triv_inf_flexes.shape[1]
+        extend_basis_matrix = triv_inf_flexes
+        for inf_flex in all_inf_flexes:
             inf_flex = np.reshape(inf_flex, (-1, 1))
-            tmp_matrix = np.hstack((inf_flexes_trivial, inf_flex))
+            tmp_matrix = np.hstack((extend_basis_matrix, inf_flex))
             if not np.linalg.matrix_rank(
                 tmp_matrix, tol=tolerance
-            ) == np.linalg.matrix_rank(inf_flexes_trivial, tol=tolerance):
+            ) == np.linalg.matrix_rank(extend_basis_matrix, tol=tolerance):
                 extend_basis_matrix = np.hstack((extend_basis_matrix, inf_flex))
         Q, R = np.linalg.qr(extend_basis_matrix)
         Q = Q[:, s : np.linalg.matrix_rank(R, tol=tolerance)]

--- a/pyrigi/framework/framework.py
+++ b/pyrigi/framework/framework.py
@@ -102,7 +102,8 @@ class Framework(FrameworkBase):
         stress_label_positions: dict[DirectedEdge, float] = None,
         arc_angles_dict: Sequence[float] | dict[DirectedEdge, float] = None,
         filename: str = None,
-        dpi=300,
+        dpi: int = 300,
+        fixed_vertices: Sequence[Vertex] = [],
         **kwargs,
     ) -> None:
         return plot.plot2D(
@@ -118,6 +119,7 @@ class Framework(FrameworkBase):
             arc_angles_dict=arc_angles_dict,
             filename=filename,
             dpi=dpi,
+            fixed_vertices=fixed_vertices,
             **kwargs,
         )
 
@@ -155,7 +157,8 @@ class Framework(FrameworkBase):
         edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
         stress_label_positions: dict[DirectedEdge, float] = None,
         filename: str = None,
-        dpi=300,
+        dpi: int = 300,
+        fixed_vertices: Sequence[Vertex] = [],
         **kwargs,
     ) -> None:
         return plot.plot3D(
@@ -170,6 +173,7 @@ class Framework(FrameworkBase):
             stress_label_positions=stress_label_positions,
             filename=filename,
             dpi=dpi,
+            fixed_vertices=fixed_vertices,
             **kwargs,
         )
 
@@ -517,6 +521,7 @@ class Framework(FrameworkBase):
         vertex_order: Sequence[Vertex] = None,
         numerical: bool = False,
         tolerance: float = 1e-9,
+        fixed_vertices: Sequence[Vertex] = [],
     ) -> list[Matrix] | list[list[float]]:
         return infinitesimal_rigidity.inf_flexes(
             self,
@@ -524,6 +529,7 @@ class Framework(FrameworkBase):
             vertex_order=vertex_order,
             numerical=numerical,
             tolerance=tolerance,
+            fixed_vertices=fixed_vertices,
         )
 
     @doc_category("Infinitesimal rigidity")

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -68,6 +68,8 @@ def test_plot2D():
     with pytest.raises(ValueError):
         F.plot2D(inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
     F.plot2D(inf_flex=0)
+    F.plot2D(inf_flex=0, fixed_vertices=[0])
+    F.plot2D(inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Complete(4)
     F.plot2D(stress=0, dpi=200, filename="K4_Test_output")
@@ -97,6 +99,8 @@ def test_plot2D():
                 F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]}
             )
         framework_plot.plot2D(F, inf_flex=0)
+        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
+        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
 
         F = fws.Complete(4)
         F = _to_FrameworkBase(F)
@@ -123,9 +127,11 @@ def test_plot3D():
 
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
     F.plot3D(inf_flex=0)
+    F.plot3D(inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Octahedron(realization="Bricard_plane")
     F.plot3D(inf_flex=0, stress=0)
+    F.plot3D(inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0])
 
     F = fws.Complete(4)
     F.plot3D(stress=0, dpi=200, filename="K4_Test_output")
@@ -155,10 +161,14 @@ def test_plot3D():
         F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
         F = _to_FrameworkBase(F)
         framework_plot.plot3D(F, inf_flex=0)
+        framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
 
         F = fws.Octahedron(realization="Bricard_plane")
         F = _to_FrameworkBase(F)
         framework_plot.plot3D(F, inf_flex=0, stress=0)
+        framework_plot.plot3D(
+            F, inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0]
+        )
 
         F = fws.Complete(4)
         F = _to_FrameworkBase(F)


### PR DESCRIPTION
+ This option allows to specify any number of vertices that are assigned a zero flex.
+ If the vertices do not form an edge, the user is warned that it might affect the computation
+ Helper method `_reduced_null_space` implemented
+ `plot.py` touched