### PR TITLE
Doc: Fixed missing documentation of `Approximate` and `ParametricMotion`

### DIFF
--- a/doc/userguide/api/motion.md
+++ b/doc/userguide/api/motion.md
@@ -1,15 +1,24 @@
 # Motions
 
+## Motion
 
 ```{eval-rst}
 .. automodule:: pyrigi.motion.motion
    :members:
    :show-inheritance:
+```
 
+## Approximate Motion
+
+```{eval-rst}
 .. automodule:: pyrigi.motion.approximate_motion
    :members:
    :show-inheritance:
+```
 
+## Parametric Motion
+
+```{eval-rst}
 .. automodule:: pyrigi.motion.parametric_motion
    :members:
    :show-inheritance:

--- a/doc/userguide/api/motion.md
+++ b/doc/userguide/api/motion.md
@@ -1,7 +1,5 @@
 # Motions
 
-## Motion
-
 ```{eval-rst}
 .. automodule:: pyrigi.motion.motion
    :members:

--- a/doc/userguide/api/motion.md
+++ b/doc/userguide/api/motion.md
@@ -5,4 +5,12 @@
 .. automodule:: pyrigi.motion.motion
    :members:
    :show-inheritance:
+
+.. automodule:: pyrigi.motion.approximate_motion
+   :members:
+   :show-inheritance:
+
+.. automodule:: pyrigi.motion.parametric_motion
+   :members:
+   :show-inheritance:
 ```

--- a/doc/userguide/tutorials/motion.md
+++ b/doc/userguide/tutorials/motion.md
@@ -13,6 +13,8 @@ kernelspec:
 
 # Continuous Motions
 
+This notebook can be downloaded {download}`here <../../notebooks/motion.ipynb>`.
+
 It is possible to create {prf:ref}`continuous motions <def-motion>` of {prf:ref}`frameworks <def-realization>` in PyRigi.
 
 ## Parametric Motion


### PR DESCRIPTION
By splitting `motion.py` into separate files, the documentation of `ApproximateMotion` and `ParametricMotion` stopped being rendered in API Reference/Motions. This is fixed now.
Also, a missing download link is added. 