### PR TITLE
Feature: Export `PlotStyle` and custom colors from `GraphDrawer`

### DIFF
--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -471,7 +471,9 @@ def _plot_with_2D_realization(
     ax: Axes,
     realization: dict[Vertex, Point],
     plot_style: PlotStyle2D,
-    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
+    vertex_colors_custom: (
+        Sequence[Sequence[Vertex]] | dict[str, Sequence[Vertex]]
+    ) = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     arc_angles_dict: Sequence[float] | dict[Edge, float] = None,
 ) -> None:
@@ -575,7 +577,9 @@ def _plot_with_3D_realization(
     ax: Axes,
     realization: dict[Vertex, Point],
     plot_style: PlotStyle3D,
-    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
+    vertex_colors_custom: (
+        Sequence[Sequence[Vertex]] | dict[str, Sequence[Vertex]]
+    ) = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
 ) -> None:
     """
@@ -788,7 +792,9 @@ def _resolve_edge_colors(
 def _resolve_vertex_colors(
     framework: FrameworkBase,
     vertex_color: str,
-    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
+    vertex_colors_custom: (
+        Sequence[Sequence[Vertex]] | dict[str, Sequence[Vertex]]
+    ) = None,
 ) -> tuple[list, list]:
     """
     Return the lists of colors and vertices in the format for plotting.
@@ -814,7 +820,7 @@ def _resolve_vertex_colors(
                 if not G.has_node(v):
                     raise ValueError("The input includes a pair that is not an edge.")
                 vertex_color_array.append(colors[i])
-                vertex_list_ref.append(tuple(e))
+                vertex_list_ref.append(v)
     elif isinstance(vertex_colors_custom, dict):
         color_vertex_dict = vertex_colors_custom
         for color, vertices in color_vertex_dict.items():
@@ -836,7 +842,7 @@ def _resolve_vertex_colors(
     if len(vertex_list_ref) > G.number_of_nodes():
         multiple_colored = [
             v
-            for v in edge_list_ref
+            for v in vertex_list_ref
             if (vertex_list_ref.count(v) > 1 or v in vertex_list_ref)
         ]
         duplicates = []
@@ -858,7 +864,9 @@ def plot2D(
     coordinates: Sequence[int] = None,
     inf_flex: int | InfFlex = None,
     stress: int | Stress = None,
-    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
+    vertex_colors_custom: (
+        Sequence[Sequence[Vertex]] | dict[str, Sequence[Vertex]]
+    ) = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     stress_label_positions: dict[DirectedEdge, float] = None,
     arc_angles_dict: Sequence[float] | dict[DirectedEdge, float] = None,
@@ -1051,6 +1059,9 @@ def plot2D(
 def animate3D_rotation(
     framework: FrameworkBase,
     plot_style: PlotStyle = None,
+    vertex_colors_custom: (
+        Sequence[Sequence[Vertex]] | dict[str, Sequence[Vertex]]
+    ) = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     total_frames: int = 100,
     delay: int = 75,
@@ -1068,6 +1079,12 @@ def animate3D_rotation(
     plot_style:
         An instance of the ``PlotStyle`` class that defines the visual style
         for plotting, see :class:`PlotStyle` for more details.
+    vertex_colors_custom:
+        Optional parameter to specify the colors of vertices. It can be
+        a ``Sequence[Sequence[Vertex]]`` to define groups of vertices with the same color
+        or a ``dict[str, Sequence[Vertex]]`` where the keys are color strings and the
+        values are lists of vertices.
+        The ommited vertices are given the value ``plot_style.vertex_color``.
     edge_colors_custom:
         Optional parameter to specify the colors of edges. It can be
         a ``Sequence[Sequence[Edge]]`` to define groups of edges with the same color
@@ -1180,6 +1197,7 @@ def animate3D_rotation(
     return motion.animate3D(
         _realizations,
         plot_style=plot_style,
+        vertex_colors_custom=vertex_colors_custom,
         edge_colors_custom=edge_colors_custom,
         duration=duration,
         **kwargs,

--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -624,7 +624,7 @@ def _plot_with_3D_realization(
             [z_coords[i]],
             s=plot_style.vertex_size,
             marker=plot_style.vertex_shape,
-            c=vertex_color_array[i]
+            c=vertex_color_array[i],
         )
 
     for i in range(len(edge_list_ref)):

--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -471,6 +471,7 @@ def _plot_with_2D_realization(
     ax: Axes,
     realization: dict[Vertex, Point],
     plot_style: PlotStyle2D,
+    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     arc_angles_dict: Sequence[float] | dict[Edge, float] = None,
 ) -> None:
@@ -485,6 +486,10 @@ def _plot_with_2D_realization(
     realization:
         A dictionary mapping vertices to their points in the realization.
     plot_style:
+    vertex_colors_custom:
+        It is possible to provide custom vertex colors through this parameter.
+        They can either be provided through a partition of vertices or a
+        dictionary with ``str`` color keywords that map to lists of vertices.
     edge_colors_custom:
         It is possible to provide custom edge colors through this parameter.
         They can either be provided through a partition of edges or a
@@ -492,6 +497,10 @@ def _plot_with_2D_realization(
     arc_angles_dict:
         A dictionary specifying arc angles for curved edges.
     """
+    vertex_color_array, vertex_list_ref = _resolve_vertex_colors(
+        framework, plot_style.vertex_color, vertex_colors_custom
+    )
+
     edge_color_array, edge_list_ref = _resolve_edge_colors(
         framework, plot_style.edge_color, edge_colors_custom
     )
@@ -506,6 +515,8 @@ def _plot_with_2D_realization(
             node_shape=plot_style.vertex_shape,
             with_labels=plot_style.vertex_labels,
             width=plot_style.edge_width,
+            node_color=vertex_color_array,
+            nodelist=vertex_list_ref,
             edge_color=edge_color_array,
             font_color=plot_style.font_color,
             font_size=plot_style.font_size,
@@ -565,6 +576,7 @@ def _plot_with_3D_realization(
     ax: Axes,
     realization: dict[Vertex, Point],
     plot_style: PlotStyle3D,
+    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
 ) -> None:
     """
@@ -578,12 +590,19 @@ def _plot_with_3D_realization(
     realization:
         A dictionary mapping vertices to their points in the realization.
     plot_style:
+    vertex_colors_custom:
+        It is possible to provide custom vertex colors through this parameter.
+        They can either be provided through a partition of vertices or a
+        dictionary with ``str`` color keywords that map to lists of vertices.
     edge_colors_custom:
         It is possible to provide custom edge colors through this parameter.
         They can either be provided through a partition of edges or a
         dictionary with ``str`` color keywords that map to lists of edges.
     """
     # Create a figure for the representation of the framework
+    vertex_color_array, vertex_list_ref = _resolve_vertex_colors(
+        framework, plot_style.vertex_color, vertex_colors_custom
+    )
 
     edge_color_array, edge_list_ref = _resolve_edge_colors(
         framework, plot_style.edge_color, edge_colors_custom
@@ -591,7 +610,7 @@ def _plot_with_3D_realization(
 
     # Center the realization
     x_coords, y_coords, z_coords = [
-        [realization[u][i] for u in framework._graph.nodes] for i in range(3)
+        [realization[u][i] for u in vertex_list_ref] for i in range(3)
     ]
     min_coord = min(x_coords + y_coords + z_coords) - plot_style.padding
     max_coord = max(x_coords + y_coords + z_coords) + plot_style.padding
@@ -599,14 +618,15 @@ def _plot_with_3D_realization(
     ax.set_zlim(min_coord * aspect_ratio[0], max_coord * aspect_ratio[0])
     ax.set_ylim(min_coord * aspect_ratio[1], max_coord * aspect_ratio[1])
     ax.set_xlim(min_coord * aspect_ratio[2], max_coord * aspect_ratio[2])
-    ax.scatter(
-        x_coords,
-        y_coords,
-        z_coords,
-        c=plot_style.vertex_color,
-        s=plot_style.vertex_size,
-        marker=plot_style.vertex_shape,
-    )
+    for i in range(len(vertex_list_ref)):
+        ax.scatter(
+            [x_coords[i]],
+            [y_coords[i]],
+            [z_coords[i]],
+            s=plot_style.vertex_size,
+            marker=plot_style.vertex_shape,
+            c=vertex_color_array[i]
+        )
 
     for i in range(len(edge_list_ref)):
         edge = edge_list_ref[i]
@@ -766,6 +786,71 @@ def _resolve_edge_colors(
     return edge_color_array, edge_list_ref
 
 
+def _resolve_vertex_colors(
+    framework: FrameworkBase,
+    vertex_color: str,
+    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
+) -> tuple[list, list]:
+    """
+    Return the lists of colors and vertices in the format for plotting.
+    """
+    G = framework._graph
+    vertex_list = graph_general.vertex_list(G)
+    vertex_list_ref = []
+    vertex_color_array = []
+
+    if vertex_colors_custom is None:
+        vertex_colors_custom = {}
+
+    if not isinstance(vertex_color, str):
+        raise TypeError("The provided `edge_color` is not a string. ")
+
+    if isinstance(vertex_colors_custom, list):
+        vertex_partition = vertex_colors_custom
+        colors = distinctipy.get_colors(
+            len(vertex_partition), colorblind_type="Deuteranomaly", pastel_factor=0.2
+        )
+        for i, part in enumerate(vertex_partition):
+            for v in part:
+                if not G.has_node(v):
+                    raise ValueError("The input includes a pair that is not an edge.")
+                vertex_color_array.append(colors[i])
+                vertex_list_ref.append(tuple(e))
+    elif isinstance(vertex_colors_custom, dict):
+        color_vertex_dict = vertex_colors_custom
+        for color, vertices in color_vertex_dict.items():
+            for v in vertices:
+                if not G.has_node(v):
+                    raise ValueError(
+                        "The input includes an vertex that is not part of the framework"
+                    )
+                vertex_color_array.append(color)
+                vertex_list_ref.append(v)
+    else:
+        raise ValueError(
+            "The input vertex_colors_custom has none of the supported formats."
+        )
+    for v in vertex_list:
+        if v not in vertex_list_ref and v not in vertex_list_ref:
+            vertex_color_array.append(vertex_color)
+            vertex_list_ref.append(v)
+    if len(vertex_list_ref) > G.number_of_vertices():
+        multiple_colored = [
+            v
+            for v in edge_list_ref
+            if (vertex_list_ref.count(v) > 1 or v in vertex_list_ref)
+        ]
+        duplicates = []
+        for v in multiple_colored:
+            if not (v in duplicates):
+                duplicates.append(v)
+        raise ValueError(
+            f"The color of the vertices in the following list"
+            f"was specified multiple times: {duplicates}."
+        )
+    return vertex_color_array, vertex_list_ref
+
+
 def plot2D(
     framework: FrameworkBase,
     plot_style: PlotStyle = None,
@@ -774,6 +859,7 @@ def plot2D(
     coordinates: Sequence[int] = None,
     inf_flex: int | InfFlex = None,
     stress: int | Stress = None,
+    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     stress_label_positions: dict[DirectedEdge, float] = None,
     arc_angles_dict: Sequence[float] | dict[DirectedEdge, float] = None,
@@ -827,6 +913,10 @@ def plot2D(
         If the edge order needs to be specified, a ``Dict[Edge, Number]``
         can be provided, which maps the edges to numbers
         (i.e. coordinates).
+    vertex_colors_custom:
+        It is possible to provide custom vertex colors through this parameter.
+        They can either be provided through a partition of vertices or a
+        dictionary with ``str`` color keywords that map to lists of vertices.
     edge_colors_custom:
         Optional parameter to specify the colors of edges. It can be
         a ``Sequence[Sequence[Edge]]`` to define groups of edges with the same color

--- a/pyrigi/framework/_plot/plot.py
+++ b/pyrigi/framework/_plot/plot.py
@@ -511,7 +511,6 @@ def _plot_with_2D_realization(
             pos=realization,
             ax=ax,
             node_size=plot_style.vertex_size,
-            node_color=plot_style.vertex_color,
             node_shape=plot_style.vertex_shape,
             with_labels=plot_style.vertex_labels,
             width=plot_style.edge_width,
@@ -834,7 +833,7 @@ def _resolve_vertex_colors(
         if v not in vertex_list_ref and v not in vertex_list_ref:
             vertex_color_array.append(vertex_color)
             vertex_list_ref.append(v)
-    if len(vertex_list_ref) > G.number_of_vertices():
+    if len(vertex_list_ref) > G.number_of_nodes():
         multiple_colored = [
             v
             for v in edge_list_ref
@@ -1019,6 +1018,7 @@ def plot2D(
         placement,
         plot_style=plot_style,
         edge_colors_custom=edge_colors_custom,
+        vertex_colors_custom=vertex_colors_custom,
         arc_angles_dict=arc_angles_dict,
     )
 
@@ -1194,6 +1194,7 @@ def plot3D(
     coordinates: Sequence[int] = None,
     inf_flex: int | InfFlex = None,
     stress: int | Stress = None,
+    vertex_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     edge_colors_custom: Sequence[Sequence[Edge]] | dict[str, Sequence[Edge]] = None,
     stress_label_positions: dict[DirectedEdge, float] = None,
     filename: str = None,
@@ -1247,6 +1248,12 @@ def plot3D(
         If the edge order needs to be specified, a ``Dict[Edge, Number]``
         can be provided, which maps the edges to numbers
         (i.e. coordinates).
+    vertex_colors_custom:
+        Optional parameter to specify the colors of vertices. It can be
+        a ``Sequence[Sequence[Vertex]]`` to define groups of vertices with the same color
+        or a ``dict[str, Sequence[Vertex]]`` where the keys are color strings and the
+        values are lists of vertices.
+        The ommited vertices are given the value ``plot_style.vertex_color``.
     edge_colors_custom:
         Optional parameter to specify the colors of edges. It can be
         a ``Sequence[Sequence[Edge]]`` to define groups of edges with the same color
@@ -1349,6 +1356,7 @@ def plot3D(
         ax,
         _placement,
         plot_style,
+        vertex_colors_custom=vertex_colors_custom,
         edge_colors_custom=edge_colors_custom,
     )
 

--- a/pyrigi/graph_drawer/graph_drawer.py
+++ b/pyrigi/graph_drawer/graph_drawer.py
@@ -897,8 +897,15 @@ class GraphDrawer(object):
         Return the plot style that is currently set in the graph drawer.
         """
         vertex_labels = True if (self._vertex_labels == 1) else False
-        return PlotStyle2D(vertex_color=self._vertex_color, edge_color=self._edge_color, vertex_size=20*self._radius, vertex_labels=vertex_labels, edge_width=0.8*self._edge_width, font_size=int(round(0.85*self._label_size)))
-    
+        return PlotStyle2D(
+            vertex_color=self._vertex_color,
+            edge_color=self._edge_color,
+            vertex_size=20 * self._radius,
+            vertex_labels=vertex_labels,
+            edge_width=0.8 * self._edge_width,
+            font_size=int(round(0.85 * self._label_size)),
+        )
+
     def custom_colors(self):
         """
         Return the colors of each vertex and edge in the graph drawer.
@@ -910,23 +917,25 @@ class GraphDrawer(object):
             if self._graph.nodes[v]["color"] in custom_vertex_colors:
                 custom_vertex_colors[self._graph.nodes[v]["color"]] += [v]
             else:
-                custom_vertex_colors |= {self._graph.nodes[v]["color"]:[v]}
+                custom_vertex_colors |= {self._graph.nodes[v]["color"]: [v]}
 
         custom_edge_colors = {}
         for edge in self._graph.edge_list(as_tuples=True):
             if self._graph[edge[0]][edge[1]]["color"] in custom_edge_colors:
-                custom_edge_colors[self._graph.nodes[edge[0]][edge[1]]["color"]] += [edge]
+                custom_edge_colors[self._graph.nodes[edge[0]][edge[1]]["color"]] += [
+                    edge
+                ]
             else:
-                custom_edge_colors |= {self._graph[edge[0]][edge[1]]["color"]:[edge]}
+                custom_edge_colors |= {self._graph[edge[0]][edge[1]]["color"]: [edge]}
 
         return custom_vertex_colors, custom_edge_colors
-    
+
     def vertex_colors_custom(self):
         """
         Return the colors of each vertex in the graph drawer
         """
         return self.custom_colors()[0]
-    
+
     def edge_colors_custom(self):
         """
         Return the colors of each edge in the graph drawer

--- a/pyrigi/graph_drawer/graph_drawer.py
+++ b/pyrigi/graph_drawer/graph_drawer.py
@@ -25,7 +25,7 @@ from pyrigi.data_type import Edge
 from pyrigi.framework import Framework
 from pyrigi.graph import Graph
 from pyrigi.graph._export import export as graph_export
-from pyrigi.plot_style import PlotStyle, PlotStyle2D
+from pyrigi.plot_style import PlotStyle2D
 
 
 class GraphDrawer(object):
@@ -922,9 +922,7 @@ class GraphDrawer(object):
         custom_edge_colors = {}
         for edge in self._graph.edge_list(as_tuples=True):
             if self._graph[edge[0]][edge[1]]["color"] in custom_edge_colors:
-                custom_edge_colors[self._graph.nodes[edge[0]][edge[1]]["color"]] += [
-                    edge
-                ]
+                custom_edge_colors[self._graph[edge[0]][edge[1]]["color"]] += [edge]
             else:
                 custom_edge_colors |= {self._graph[edge[0]][edge[1]]["color"]: [edge]}
 

--- a/pyrigi/graph_drawer/graph_drawer.py
+++ b/pyrigi/graph_drawer/graph_drawer.py
@@ -897,7 +897,7 @@ class GraphDrawer(object):
         Return the plot style that is currently set in the graph drawer.
         """
         vertex_labels = True if (self._vertex_labels == 1) else False
-        return PlotStyle2D(vertex_color=self._vertex_color, edge_color=self._edge_color, vertex_size=20*self._radius, vertex_labels=vertex_labels, edge_width=0.85*self._edge_width, font_size=int(round(0.85*self._label_size)))
+        return PlotStyle2D(vertex_color=self._vertex_color, edge_color=self._edge_color, vertex_size=20*self._radius, vertex_labels=vertex_labels, edge_width=0.8*self._edge_width, font_size=int(round(0.85*self._label_size)))
     
     def custom_colors(self):
         """
@@ -917,7 +917,7 @@ class GraphDrawer(object):
             if self._graph[edge[0]][edge[1]]["color"] in custom_edge_colors:
                 custom_edge_colors[self._graph.nodes[edge[0]][edge[1]]["color"]] += [edge]
             else:
-                custom_edge_colors |= {edge:self._graph[edge[0]][edge[1]]["color"]}
+                custom_edge_colors |= {self._graph[edge[0]][edge[1]]["color"]:[edge]}
 
         return custom_vertex_colors, custom_edge_colors
     

--- a/pyrigi/graph_drawer/graph_drawer.py
+++ b/pyrigi/graph_drawer/graph_drawer.py
@@ -25,6 +25,7 @@ from pyrigi.data_type import Edge
 from pyrigi.framework import Framework
 from pyrigi.graph import Graph
 from pyrigi.graph._export import export as graph_export
+from pyrigi.plot_style import PlotStyle, PlotStyle2D
 
 
 class GraphDrawer(object):
@@ -890,3 +891,44 @@ class GraphDrawer(object):
             for v in H.nodes:
                 posdict[v] = [Rational(x, self._grid_size) for x in posdict[v]]
         return Framework(graph=H, realization=posdict)
+
+    def plot_style(self):
+        """
+        Return the plot style that is currently set in the graph drawer.
+        """
+        vertex_labels = True if (self._vertex_labels == 1) else False
+        return PlotStyle2D(vertex_color=self._vertex_color, edge_color=self._edge_color, vertex_size=20*self._radius, vertex_labels=vertex_labels, edge_width=0.85*self._edge_width, font_size=int(round(0.85*self._label_size)))
+    
+    def custom_colors(self):
+        """
+        Return the colors of each vertex and edge in the graph drawer.
+
+        The custom vertex and edge colors are returned as a tuple of two dictionaries.
+        """
+        custom_vertex_colors = {}
+        for v in self._graph.nodes:
+            if self._graph.nodes[v]["color"] in custom_vertex_colors:
+                custom_vertex_colors[self._graph.nodes[v]["color"]] += [v]
+            else:
+                custom_vertex_colors |= {self._graph.nodes[v]["color"]:[v]}
+
+        custom_edge_colors = {}
+        for edge in self._graph.edge_list(as_tuples=True):
+            if self._graph[edge[0]][edge[1]]["color"] in custom_edge_colors:
+                custom_edge_colors[self._graph.nodes[edge[0]][edge[1]]["color"]] += [edge]
+            else:
+                custom_edge_colors |= {edge:self._graph[edge[0]][edge[1]]["color"]}
+
+        return custom_vertex_colors, custom_edge_colors
+    
+    def vertex_colors_custom(self):
+        """
+        Return the colors of each vertex in the graph drawer
+        """
+        return self.custom_colors()[0]
+    
+    def edge_colors_custom(self):
+        """
+        Return the colors of each edge in the graph drawer
+        """
+        return self.custom_colors()[1]

--- a/pyrigi/motion/approximate_motion.py
+++ b/pyrigi/motion/approximate_motion.py
@@ -609,7 +609,6 @@ class ApproximateMotion(Motion):
         realizations = self._motion_samples
         return super().animate(
             realizations,
-            None,
             **kwargs,
         )
 

--- a/pyrigi/motion/parametric_motion.py
+++ b/pyrigi/motion/parametric_motion.py
@@ -225,6 +225,5 @@ class ParametricMotion(Motion):
 
         return super().animate(
             realizations,
-            None,
             **kwargs,
         )


### PR DESCRIPTION
Now, we can create a `Framework` or `Graph` from a `GraphDrawer` plot and export the color attributes. It is also possible to export custom color attributes that have been set in the ` GraphDrawer` using the methods `custom_colors`, `vertex_colors_custom` and `edge_colors_custom`. The most recent style choices can be exported as a `PlotStyle2D` via the method `plot_style`.