### PR TITLE
Doc: Fixed inccorect links in NAC documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 The PyRigi Developers
+Copyright (c) 2024-2026 The PyRigi Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/math/rigidity/nac-colorings.md
+++ b/doc/math/rigidity/nac-colorings.md
@@ -14,6 +14,8 @@ every cycle of the graph is either monochromatic or it contains each color at le
 {{references}} {cite:p}`GraseggerLegerskySchicho2019`
 
 {{pyrigi_crossref}} {meth}`~.Graph.NAC_colorings`
+{meth}`~.Graph.has_NAC_coloring`
+{meth}`~.Graph.single_NAC_coloring`
 :::
 
 

--- a/pyrigi/graph/_flexibility/nac/facade.py
+++ b/pyrigi/graph/_flexibility/nac/facade.py
@@ -88,16 +88,14 @@ def has_NAC_coloring(
     """
     Return if the graph has a NAC-coloring.
 
-    Same as :func:`pyrigi.graph._flexibility.nac.facade.single_NAC_coloring`,
+    Same as :func:`Graph.single_NAC_coloring`,
     but no certificate of existence is provided.
+
+    See :meth:`.Graph.NAC_colorings` for parameter descriptions.
 
     Definitions
     -----------
     * :prf:ref:`NAC-coloring <def-nac>`
-
-    Parameters
-    ----------
-    See :meth:`~pyrigi.graph.Graph.NAC_colorings` for parameters description.
     """
     _check_input_graph_for_NAC_coloring(graph)
 
@@ -127,13 +125,11 @@ def single_NAC_coloring(
     Some polynomial time checks are run.
     If they fail, an exhaustive search is run.
 
+    See :meth:`.Graph.NAC_colorings` for parameter descriptions.
+
     Definitions
     -----------
     * :prf:ref:`NAC-coloring <def-nac>`
-
-    Parameters
-    ----------
-    See :meth:`~pyrigi.graph.Graph.NAC_colorings` for parameters description.
     """
     _check_input_graph_for_NAC_coloring(graph)
 

--- a/pyrigi/graph/_other/separating_set.py
+++ b/pyrigi/graph/_other/separating_set.py
@@ -254,9 +254,8 @@ def is_stable_separating_set(
     """
     Return whether ``vertices`` are a stable separating set.
 
-    See :meth:`~pyrigi.graph.Graph.is_stable_set` and
-    :meth:`~pyrigi.graph.Graph.is_separating_set` for
-    the description of the parameters.
+    See :meth:`~Graph.is_stable_set` and :meth:`~Graph.is_separating_set`
+    for the description of the parameters.
 
     Definitions
     -----------


### PR DESCRIPTION
Replaced links and moved "see <other-method>" to the description.