### PR TITLE
Test: Removed TEST_WRAPPED_FUNCTIONS blocks from graph rigidity tests

### DIFF
--- a/test/graph/rigidity/test_generic_rigidity.py
+++ b/test/graph/rigidity/test_generic_rigidity.py
@@ -70,9 +70,7 @@ def test_is_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_rigid_d1(graph, algorithm):
-    assert not generic_rigidity.is_rigid(
-        nx.Graph(graph), dim=1, algorithm=algorithm
-    )
+    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -109,9 +107,7 @@ def test_is_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_not_is_rigid_d2(graph, algorithm):
-    assert not generic_rigidity.is_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
-    )
+    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -142,9 +138,7 @@ def test_is_rigid_dimension_sparsity_error(method, params):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_min_rigid_d1(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=1, algorithm=algorithm
-    )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -180,9 +174,7 @@ def test_is_not_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_min_rigid_d2(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
-    )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -222,9 +214,7 @@ def test_is_not_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_min_rigid_d3(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=3, algorithm=algorithm
-    )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=3, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(

--- a/test/graph/rigidity/test_generic_rigidity.py
+++ b/test/graph/rigidity/test_generic_rigidity.py
@@ -9,7 +9,6 @@ import pyrigi.graph._sparsity.sparsity as sparsity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.warning import RandomizedAlgorithmWarning
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import (
     is_rigid_algorithms_all_d,
     is_rigid_algorithms_d1,
@@ -38,9 +37,7 @@ is_min_rigid_algorithms_d1 = is_min_rigid_algorithms_all_d + ["graphic"]
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_rigid(graph, dim, algorithm):
-    assert graph.is_rigid(dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -60,9 +57,7 @@ def test_is_rigid(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_rigid_d1(graph, algorithm):
-    assert graph.is_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -75,11 +70,9 @@ def test_is_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_rigid_d1(graph, algorithm):
-    assert not graph.is_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_rigid(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -100,9 +93,7 @@ def test_is_not_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_rigid_d2(graph, algorithm):
-    assert graph.is_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -118,11 +109,9 @@ def test_is_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_not_is_rigid_d2(graph, algorithm):
-    assert not graph.is_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_rigid(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,12 +124,8 @@ def test_not_is_rigid_d2(graph, algorithm):
 def test_is_rigid_dimension_sparsity_error(method, params):
     G = graphs.DoubleBanana()
     with pytest.raises(ValueError):
-        func = getattr(G, method)
-        func(*params, algorithm="sparsity")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            func = getattr(generic_rigidity, method)
-            func(nx.Graph(G), *params, algorithm="sparsity")
+        func = getattr(generic_rigidity, method)
+        func(nx.Graph(G), *params, algorithm="sparsity")
 
 
 ###############################################################
@@ -157,11 +142,9 @@ def test_is_rigid_dimension_sparsity_error(method, params):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_min_rigid_d1(graph, algorithm):
-    assert graph.is_min_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -180,11 +163,9 @@ def test_is_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_not_min_rigid_d1(graph, algorithm):
-    assert not graph.is_min_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -199,11 +180,9 @@ def test_is_not_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_min_rigid_d2(graph, algorithm):
-    assert graph.is_min_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -225,11 +204,9 @@ def test_is_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_not_min_rigid_d2(graph, algorithm):
-    assert not graph.is_min_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -245,11 +222,9 @@ def test_is_not_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_min_rigid_d3(graph, algorithm):
-    assert graph.is_min_rigid(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -265,11 +240,9 @@ def test_is_min_rigid_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_not_min_rigid_d3(graph, algorithm):
-    assert not graph.is_min_rigid(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -317,70 +290,51 @@ def test_rigid_components(graph, components, dim):
 
     if dim == 1:
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="graphic")) == comps_set
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="graphic"
+                )
+            )
+            == comps_set
         )
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="graphic"
-                    )
-                )
-                == comps_set
-            )
     elif dim == 2:
-        assert to_sets(graph.rigid_components(dim=dim, algorithm="pebble")) == comps_set
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="pebble"
-                    )
+        assert (
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="pebble"
                 )
-                == comps_set
             )
+            == comps_set
+        )
         if graph.number_of_nodes() <= 8:  # since it runs through all subgraphs
             assert (
-                to_sets(graph.rigid_components(dim=dim, algorithm="subgraphs-pebble"))
+                to_sets(
+                    generic_rigidity.rigid_components(
+                        nx.Graph(graph), dim=dim, algorithm="subgraphs-pebble"
+                    )
+                )
                 == comps_set
             )
-            if TEST_WRAPPED_FUNCTIONS:
-                assert (
-                    to_sets(
-                        generic_rigidity.rigid_components(
-                            nx.Graph(graph), dim=dim, algorithm="subgraphs-pebble"
-                        )
-                    )
-                    == comps_set
-                )
 
     # randomized algorithm is tested for all dimensions for graphs
     # with at most 8 vertices (since it runs through all subgraphs)
     if graph.number_of_nodes() <= 8:
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="randomized"))
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="randomized"
+                )
+            )
             == comps_set
         )
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="numerical")) == comps_set
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="numerical"
+                )
+            )
+            == comps_set
         )
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="randomized"
-                    )
-                )
-                == comps_set
-            )
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="numerical"
-                    )
-                )
-                == comps_set
-            )
 
 
 @pytest.mark.parametrize(
@@ -436,22 +390,15 @@ def test_rigid_components_pebble_random_graphs(graph):
     ],
 )
 def test_max_rigid_dimension(graph, k):
-    assert graph.max_rigid_dimension() == k
-    assert graph.max_rigid_dimension(algorithm="numerical") == k
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.max_rigid_dimension(nx.Graph(graph)) == k
-        assert (
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
-            == k
-        )
+    assert generic_rigidity.max_rigid_dimension(nx.Graph(graph)) == k
+    assert (
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        == k
+    )
 
 
 def test_max_rigid_dimension_warning():
     graph = graphs.K66MinusPerfectMatching()
     with pytest.warns(RandomizedAlgorithmWarning):
-        graph.max_rigid_dimension()
-        graph.max_rigid_dimension(algorithm="numerical")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.warns(RandomizedAlgorithmWarning):
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph))
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph))
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")

--- a/test/graph/rigidity/test_global_rigidity.py
+++ b/test/graph/rigidity/test_global_rigidity.py
@@ -6,7 +6,6 @@ import pytest
 import pyrigi.graph._rigidity.global_ as global_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_globally, read_redundantly
 
 ###############################################################
@@ -47,9 +46,7 @@ from test.graph.test_graph import read_globally, read_redundantly
     ],
 )
 def test_is_globally_rigid(graph, dim):
-    assert graph.is_globally_rigid(dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -98,9 +95,7 @@ def test_is_globally_rigid(graph, dim):
     ],
 )
 def test_is_not_globally_rigid(graph, dim):
-    assert not graph.is_globally_rigid(dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -116,9 +111,7 @@ def test_is_not_globally_rigid(graph, dim):
     ],
 )
 def test_is_globally_rigid_d2(graph):
-    assert graph.is_globally_rigid(dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
 
 
 @pytest.mark.parametrize(
@@ -136,9 +129,7 @@ def test_is_globally_rigid_d2(graph):
     ],
 )
 def test_is_not_globally_d2(graph):
-    assert not graph.is_globally_rigid(dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
 
 
 ###############################################################
@@ -261,6 +252,4 @@ def test_is_weakly_globally_linked_for_redundantly_rigid_graphs(graph):
     ],
 )
 def test_is_weakly_globally_linked_articles_graphs(graph, u, v):
-    assert graph.is_weakly_globally_linked(u, v, dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v, dim=2)
+    assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v, dim=2)

--- a/test/graph/rigidity/test_matroidal_rigidity.py
+++ b/test/graph/rigidity/test_matroidal_rigidity.py
@@ -5,7 +5,6 @@ import pyrigi.graph._rigidity.matroidal as matroidal_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.warning import RandomizedAlgorithmWarning
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_sparsity
 
 Rd_algorithms_all_d = ["default", "randomized"]
@@ -27,11 +26,9 @@ is_Rd_closed_algorithms_d2 = is_Rd_closed_algorithms_all_d + ["pebble"]
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_circuit_d1(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -52,11 +49,9 @@ def test_is_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_not_Rd_circuit_d1(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -76,11 +71,9 @@ def test_is_not_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_circuit_d2(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -118,11 +111,9 @@ def test_is_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_not_Rd_circuit_d2(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,11 +126,9 @@ def test_is_not_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_circuit_d3(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -154,11 +143,9 @@ def test_is_Rd_circuit_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_not_Rd_circuit_d3(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -175,11 +162,9 @@ def test_is_not_Rd_circuit_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_Rd_closed(graph, dim, algorithm):
-    assert graph.is_Rd_closed(dim=dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=dim, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=dim, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -191,11 +176,9 @@ def test_is_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_not_Rd_closed(graph, dim, algorithm):
-    assert not graph.is_Rd_closed(dim=dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=dim, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=dim, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -207,11 +190,9 @@ def test_is_not_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_Rd_closed_d1(graph, algorithm):
-    assert graph.is_Rd_closed(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -222,11 +203,9 @@ def test_is_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_not_Rd_closed_d1(graph, algorithm):
-    assert not graph.is_Rd_closed(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -239,11 +218,9 @@ def test_is_not_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_Rd_closed_d2(graph, algorithm):
-    assert graph.is_Rd_closed(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -256,11 +233,9 @@ def test_is_Rd_closed_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_not_Rd_closed_d2(graph, algorithm):
-    assert not graph.is_Rd_closed(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -280,11 +255,9 @@ def test_is_not_Rd_closed_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_dependent_d1(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -297,11 +270,9 @@ def test_is_Rd_dependent_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_independent_d1(graph, algorithm):
-    assert graph.is_Rd_independent(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -318,11 +289,9 @@ def test_is_Rd_independent_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_dependent_d2(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -340,11 +309,9 @@ def test_is_Rd_dependent_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_independent_d2(graph, algorithm):
-    assert graph.is_Rd_independent(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -353,11 +320,9 @@ def test_is_Rd_independent_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_dependent_d3(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -373,17 +338,12 @@ def test_is_Rd_dependent_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_independent_d3(graph, algorithm):
-    assert graph.is_Rd_independent(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 def test_is_Rd_independent_d3_warning():
     G = graphs.K33plusEdge()
     with pytest.warns(RandomizedAlgorithmWarning):
-        G.is_Rd_independent(dim=3)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.warns(RandomizedAlgorithmWarning):
-            matroidal_rigidity.is_Rd_independent(nx.Graph(G), dim=3)
+        matroidal_rigidity.is_Rd_independent(nx.Graph(G), dim=3)

--- a/test/graph/rigidity/test_matroidal_rigidity.py
+++ b/test/graph/rigidity/test_matroidal_rigidity.py
@@ -245,7 +245,7 @@ def test_is_not_Rd_closed_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_dependent_d1(graph, algorithm):
-    assert not matroidal_rigidity.is_Rd_independent(
+    assert matroidal_rigidity.is_Rd_dependent(
         nx.Graph(graph), dim=1, algorithm=algorithm
     )
 
@@ -279,7 +279,7 @@ def test_is_Rd_independent_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_dependent_d2(graph, algorithm):
-    assert not matroidal_rigidity.is_Rd_independent(
+    assert matroidal_rigidity.is_Rd_dependent(
         nx.Graph(graph), dim=2, algorithm=algorithm
     )
 
@@ -310,7 +310,7 @@ def test_is_Rd_independent_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_dependent_d3(graph, algorithm):
-    assert not matroidal_rigidity.is_Rd_independent(
+    assert matroidal_rigidity.is_Rd_dependent(
         nx.Graph(graph), dim=3, algorithm=algorithm
     )
 

--- a/test/graph/rigidity/test_matroidal_rigidity.py
+++ b/test/graph/rigidity/test_matroidal_rigidity.py
@@ -26,9 +26,7 @@ is_Rd_closed_algorithms_d2 = is_Rd_closed_algorithms_all_d + ["pebble"]
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_circuit_d1(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=1, algorithm=algorithm
-    )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -71,9 +69,7 @@ def test_is_not_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_circuit_d2(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=2, algorithm=algorithm
-    )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -126,9 +122,7 @@ def test_is_not_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_circuit_d3(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=3, algorithm=algorithm
-    )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=3, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -190,9 +184,7 @@ def test_is_not_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_Rd_closed_d1(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=1, algorithm=algorithm
-    )
+    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -218,9 +210,7 @@ def test_is_not_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_Rd_closed_d2(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=2, algorithm=algorithm
-    )
+    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(

--- a/test/graph/rigidity/test_redundant_rigidity.py
+++ b/test/graph/rigidity/test_redundant_rigidity.py
@@ -4,7 +4,6 @@ import pytest
 import pyrigi.graph._rigidity.redundant as redundant_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import (
     is_rigid_algorithms_all_d,
     is_rigid_algorithms_d1,
@@ -63,11 +62,9 @@ def test_is_not_vertex_redundantly_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -81,11 +78,9 @@ def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -106,11 +101,9 @@ def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -127,11 +120,9 @@ def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -159,11 +150,9 @@ def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -190,11 +179,9 @@ def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -217,11 +204,9 @@ def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -235,11 +220,9 @@ def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -259,11 +242,9 @@ def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -277,11 +258,9 @@ def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -293,11 +272,9 @@ def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -326,11 +303,9 @@ def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -397,11 +372,9 @@ def test_is_not_redundantly_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -414,11 +387,9 @@ def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -441,11 +412,9 @@ def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -470,11 +439,9 @@ def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -503,11 +470,9 @@ def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -530,11 +495,9 @@ def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -557,11 +520,9 @@ def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -577,11 +538,9 @@ def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -601,11 +560,9 @@ def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -620,11 +577,9 @@ def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -637,11 +592,9 @@ def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -657,8 +610,6 @@ def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )


### PR DESCRIPTION
## Summary
- `test_wrapper_parameter_forwarding` (#393) now generically verifies that every
  `@copy_doc` wrapper correctly forwards to its module-level function, making the
  per-test `if TEST_WRAPPED_FUNCTIONS:` duplicate assertions redundant.
- Removes those blocks from the graph rigidity tests, keeping the direct
  module-function calls and dropping the now-unused `TEST_WRAPPED_FUNCTIONS` import.

Files: `test_generic_rigidity.py`, `test_global_rigidity.py`,
`test_matroidal_rigidity.py`, `test_redundant_rigidity.py` (62 blocks total).

## Test plan
- `pytest test/graph/rigidity -q` passes
- Full suite matches baseline (no new failures)
