### PR TITLE
Test: Removed TEST_WRAPPED_FUNCTIONS blocks from remaining graph tests

### DIFF
--- a/test/graph/constructions/test_constructions.py
+++ b/test/graph/constructions/test_constructions.py
@@ -3,20 +3,12 @@ import networkx as nx
 import pyrigi.graphDB as graphs
 from pyrigi.graph._constructions import constructions as graph_constructions
 from pyrigi.graph._general import max_degree
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 def test_cone():
-    G = graphs.Complete(5).cone()
+    G = graph_constructions.cone(nx.Graph(graphs.Complete(5)))
     assert set(G.nodes) == set([0, 1, 2, 3, 4, 5]) and len(G.nodes) == 6
-    G = graphs.Complete(4).cone(vertex="a")
+    G = graph_constructions.cone(nx.Graph(graphs.Complete(4)), vertex="a")
     assert "a" in G.nodes
-    G = graphs.Cycle(4).cone()
-    assert G.number_of_nodes() == G.max_degree() + 1
-    if TEST_WRAPPED_FUNCTIONS:
-        G = graph_constructions.cone(nx.Graph(graphs.Complete(5)))
-        assert set(G.nodes) == set([0, 1, 2, 3, 4, 5]) and len(G.nodes) == 6
-        G = graph_constructions.cone(nx.Graph(graphs.Complete(4)), vertex="a")
-        assert "a" in G.nodes
-        G = graph_constructions.cone(nx.Graph(graphs.Cycle(4)))
-        assert G.number_of_nodes() == max_degree(G) + 1
+    G = graph_constructions.cone(nx.Graph(graphs.Cycle(4)))
+    assert G.number_of_nodes() == max_degree(G) + 1

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -180,11 +180,7 @@ def test_all_k_extensions2(graph, k, dim, sol):
 
 def test_all_k_extension_error():
     with pytest.raises(ValueError):
-        list(
-            extension.all_k_extensions(
-                nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1
-            )
-        )
+        list(extension.all_k_extensions(nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1))
 
 
 ###############################################################
@@ -208,9 +204,7 @@ def test_all_k_extension_error():
 )
 def test_all_extensions(graph, dim, sol):
     assert is_isomorphic_graph_list(
-        list(
-            extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)
-        ),
+        list(extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)),
         [Graph.from_int(igraph) for igraph in sol],
     )
 
@@ -263,9 +257,7 @@ def test_all_extensions_single(graph, dim):
 def test_all_extensions_value_error(graph, dim, k_min, k_max):
     with pytest.raises(ValueError):
         list(
-            extension.all_extensions(
-                nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-            )
+            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
         )
 
 
@@ -286,9 +278,7 @@ def test_all_extensions_value_error(graph, dim, k_min, k_max):
 def test_all_extensions_type_error(graph, dim, k_min, k_max):
     with pytest.raises(TypeError):
         list(
-            extension.all_extensions(
-                nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-            )
+            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
         )
 
 
@@ -338,15 +328,11 @@ def test_has_not_extension_sequence(graph):
 # extension_sequence
 ###############################################################
 def test_extension_sequence_solution():
-    assert extension.extension_sequence(
-        graphs.Complete(2), return_type="graphs"
-    ) == [
+    assert extension.extension_sequence(graphs.Complete(2), return_type="graphs") == [
         Graph([[0, 1]]),
     ]
 
-    assert extension.extension_sequence(
-        graphs.Complete(3), return_type="graphs"
-    ) == [
+    assert extension.extension_sequence(graphs.Complete(3), return_type="graphs") == [
         Graph([[1, 2]]),
         Graph([[0, 1], [0, 2], [1, 2]]),
     ]
@@ -511,9 +497,7 @@ def test_extension_sequence_dim(graph, dim):
     ],
 )
 def test_extension_sequence_min_rigid(graph, dim):
-    ext = extension.extension_sequence(
-        nx.Graph(graph), dim=dim, return_type="graphs"
-    )
+    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="graphs")
     assert ext is not None
     for current in ext:
         assert generic_rigidity.is_min_rigid(current, dim)
@@ -562,6 +546,4 @@ def test_extension_sequence_dim_none(graph, dim):
 
 def test_extension_sequence_error():
     with pytest.raises(NotSupportedValueError):
-        extension.extension_sequence(
-            nx.Graph(graphs.Complete(3)), return_type="Test"
-        )
+        extension.extension_sequence(nx.Graph(graphs.Complete(3)), return_type="Test")

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -142,7 +142,7 @@ def test_all_k_extensions():
         == all_diamond_0_2[2]
     )
     all_diamond_1_2 = extension.all_k_extensions(
-        graphs.Diamond(), 1, 2, only_non_isomorphic=True
+        nx.Graph(graphs.Diamond()), 1, 2, only_non_isomorphic=True
     )
     assert Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]) == next(
         all_diamond_1_2
@@ -328,11 +328,15 @@ def test_has_not_extension_sequence(graph):
 # extension_sequence
 ###############################################################
 def test_extension_sequence_solution():
-    assert extension.extension_sequence(graphs.Complete(2), return_type="graphs") == [
+    assert extension.extension_sequence(
+        nx.Graph(graphs.Complete(2)), return_type="graphs"
+    ) == [
         Graph([[0, 1]]),
     ]
 
-    assert extension.extension_sequence(graphs.Complete(3), return_type="graphs") == [
+    assert extension.extension_sequence(
+        nx.Graph(graphs.Complete(3)), return_type="graphs"
+    ) == [
         Graph([[1, 2]]),
         Graph([[0, 1], [0, 2], [1, 2]]),
     ]
@@ -358,7 +362,7 @@ def test_extension_sequence_solution():
     ]
     assert (
         extension.extension_sequence(
-            graphs.CompleteBipartite(3, 3), return_type="graphs"
+            nx.Graph(graphs.CompleteBipartite(3, 3)), return_type="graphs"
         )
         == solution
     )
@@ -375,13 +379,17 @@ def test_extension_sequence_solution():
         if i < len(solution_ext):
             extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
-    assert extension.extension_sequence(graphs.Diamond(), return_type="graphs") == [
+    assert extension.extension_sequence(
+        nx.Graph(graphs.Diamond()), return_type="graphs"
+    ) == [
         Graph([[2, 3]]),
         Graph([[0, 2], [0, 3], [2, 3]]),
         Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
     ]
 
-    result = extension.extension_sequence(graphs.ThreePrism(), return_type="graphs")
+    result = extension.extension_sequence(
+        nx.Graph(graphs.ThreePrism()), return_type="graphs"
+    )
     solution = [
         Graph([[4, 5]]),
         Graph([[3, 4], [3, 5], [4, 5]]),
@@ -500,7 +508,7 @@ def test_extension_sequence_min_rigid(graph, dim):
     ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="graphs")
     assert ext is not None
     for current in ext:
-        assert generic_rigidity.is_min_rigid(current, dim)
+        assert generic_rigidity.is_min_rigid(nx.Graph(current), dim)
 
 
 @pytest.mark.parametrize(

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -7,7 +7,6 @@ import pyrigi.graphDB as graphs
 from pyrigi.exception import NotSupportedValueError
 from pyrigi.graph import Graph
 from pyrigi.graph._utils.utils import is_isomorphic_graph_list
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 ###############################################################
@@ -45,30 +44,29 @@ def test_k_extension():
     assert graphs.Cycle(6).k_extension(
         4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], dim=1
     ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
-    if TEST_WRAPPED_FUNCTIONS:
-        assert Graph(
-            [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]
-        ) == extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)),
-            2,
-            [0, 1, 3],
-            [(0, 3), (1, 3)],
-            dim=1,
-        )
-        assert Graph(
-            [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
-        ) == extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
-        )
-        assert Graph(
-            [(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]
-        ) == extension.k_extension(
-            nx.Graph(graphs.Cycle(6)),
-            4,
-            [0, 1, 2, 3, 4],
-            [(0, 1), (1, 2), (2, 3), (3, 4)],
-            dim=1,
-        )
+    assert Graph(
+        [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]
+    ) == extension.k_extension(
+        nx.Graph(graphs.CompleteBipartite(3, 2)),
+        2,
+        [0, 1, 3],
+        [(0, 3), (1, 3)],
+        dim=1,
+    )
+    assert Graph(
+        [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
+    ) == extension.k_extension(
+        nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+    )
+    assert Graph(
+        [(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]
+    ) == extension.k_extension(
+        nx.Graph(graphs.Cycle(6)),
+        4,
+        [0, 1, 2, 3, 4],
+        [(0, 1), (1, 2), (2, 3), (3, 4)],
+        dim=1,
+    )
 
 
 @pytest.mark.parametrize(
@@ -83,10 +81,7 @@ def test_k_extension():
 )
 def test_k_extension_dim_error(graph, k, vertices, edges, dim):
     with pytest.raises(ValueError):
-        graph.k_extension(k, vertices, edges, dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            extension.k_extension(nx.Graph(graph), k, vertices, edges, dim=dim)
+        extension.k_extension(nx.Graph(graph), k, vertices, edges, dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -109,18 +104,15 @@ def test_k_extension_dim_error(graph, k, vertices, edges, dim):
 )
 def test_k_extension_error(graph, k, vertices, edges):
     with pytest.raises(ValueError):
-        graph.k_extension(k, vertices, edges)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            extension.k_extension(nx.Graph(graph), k, vertices, edges)
+        extension.k_extension(nx.Graph(graph), k, vertices, edges)
 
 
 ###############################################################
 # all_k_extensions
 ###############################################################
 def test_all_k_extensions():
-    for ext in graphs.Complete(4).all_k_extensions(1, 1):
-        assert ext in [
+    for ext in extension.all_k_extensions(nx.Graph(graphs.Complete(4)), 1, 1):
+        assert Graph(ext) in [
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3]]),
             Graph([[0, 1], [0, 3], [0, 4], [1, 2], [1, 3], [2, 3], [2, 4]]),
             Graph([[0, 1], [0, 2], [0, 4], [1, 2], [1, 3], [2, 3], [3, 4]]),
@@ -128,68 +120,35 @@ def test_all_k_extensions():
             Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]]),
             Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 4], [3, 4]]),
         ]
-    for ext in graphs.Complete(4).all_k_extensions(2, 2, only_non_isomorphic=True):
-        assert ext in [
+    for ext in extension.all_k_extensions(
+        nx.Graph(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
+    ):
+        assert Graph(ext) in [
             Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 4], [3, 4]]),
         ]
     all_diamond_0_2 = list(
-        graphs.Diamond().all_k_extensions(0, 2, only_non_isomorphic=True)
+        extension.all_k_extensions(
+            nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
+        )
     )
     assert (
         len(all_diamond_0_2) == 3
-        and all_diamond_0_2[0]
-        == Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
-        and all_diamond_0_2[1]
-        == Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
-        and all_diamond_0_2[2]
-        == Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
+        and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
+        == all_diamond_0_2[0]
+        and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
+        == all_diamond_0_2[1]
+        and Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
+        == all_diamond_0_2[2]
     )
-    all_diamond_1_2 = graphs.Diamond().all_k_extensions(1, 2, only_non_isomorphic=True)
-    assert next(all_diamond_1_2) == Graph(
-        [[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]
-    ) and next(all_diamond_1_2) == Graph(
-        [[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]
+    all_diamond_1_2 = extension.all_k_extensions(
+        graphs.Diamond(), 1, 2, only_non_isomorphic=True
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        for ext in extension.all_k_extensions(nx.Graph(graphs.Complete(4)), 1, 1):
-            assert Graph(ext) in [
-                Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3]]),
-                Graph([[0, 1], [0, 3], [0, 4], [1, 2], [1, 3], [2, 3], [2, 4]]),
-                Graph([[0, 1], [0, 2], [0, 4], [1, 2], [1, 3], [2, 3], [3, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 3], [1, 4], [2, 3], [2, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 4], [3, 4]]),
-            ]
-        for ext in extension.all_k_extensions(
-            nx.Graph(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
-        ):
-            assert Graph(ext) in [
-                Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
-                Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 4], [3, 4]]),
-            ]
-        all_diamond_0_2 = list(
-            extension.all_k_extensions(
-                nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
-            )
-        )
-        assert (
-            len(all_diamond_0_2) == 3
-            and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
-            == all_diamond_0_2[0]
-            and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
-            == all_diamond_0_2[1]
-            and Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
-            == all_diamond_0_2[2]
-        )
-        all_diamond_1_2 = extension.all_k_extensions(
-            graphs.Diamond(), 1, 2, only_non_isomorphic=True
-        )
-        assert Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]) == next(
-            all_diamond_1_2
-        ) and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]) == next(
-            all_diamond_1_2
-        )
+    assert Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]) == next(
+        all_diamond_1_2
+    ) and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]) == next(
+        all_diamond_1_2
+    )
 
 
 @pytest.mark.parametrize(
@@ -210,30 +169,22 @@ def test_all_k_extensions():
 )
 def test_all_k_extensions2(graph, k, dim, sol):
     assert is_isomorphic_graph_list(
-        list(graph.all_k_extensions(k, dim, only_non_isomorphic=True)),
+        list(
+            extension.all_k_extensions(
+                nx.Graph(graph), k, dim, only_non_isomorphic=True
+            )
+        ),
         [Graph.from_int(igraph) for igraph in sol],
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        assert is_isomorphic_graph_list(
-            list(
-                extension.all_k_extensions(
-                    nx.Graph(graph), k, dim, only_non_isomorphic=True
-                )
-            ),
-            [Graph.from_int(igraph) for igraph in sol],
-        )
 
 
 def test_all_k_extension_error():
     with pytest.raises(ValueError):
-        list(Graph.from_vertices([0, 1, 2]).all_k_extensions(1, 1))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            list(
-                extension.all_k_extensions(
-                    nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1
-                )
+        list(
+            extension.all_k_extensions(
+                nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1
             )
+        )
 
 
 ###############################################################
@@ -257,16 +208,11 @@ def test_all_k_extension_error():
 )
 def test_all_extensions(graph, dim, sol):
     assert is_isomorphic_graph_list(
-        list(graph.all_extensions(dim, only_non_isomorphic=True)),
+        list(
+            extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)
+        ),
         [Graph.from_int(igraph) for igraph in sol],
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        assert is_isomorphic_graph_list(
-            list(
-                extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)
-            ),
-            [Graph.from_int(igraph) for igraph in sol],
-        )
 
 
 @pytest.mark.parametrize(
@@ -285,31 +231,21 @@ def test_all_extensions(graph, dim, sol):
 def test_all_extensions_single(graph, dim):
     for k in range(0, dim):
         assert is_isomorphic_graph_list(
-            list(graph.all_extensions(dim, only_non_isomorphic=True, k_min=k, k_max=k)),
-            list(graph.all_k_extensions(k, dim, only_non_isomorphic=True)),
+            list(
+                extension.all_extensions(
+                    nx.Graph(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
+                )
+            ),
+            list(
+                extension.all_k_extensions(
+                    nx.Graph(graph), k, dim, only_non_isomorphic=True
+                )
+            ),
         )
         assert is_isomorphic_graph_list(
-            list(graph.all_extensions(dim, k_min=k, k_max=k)),
-            list(graph.all_k_extensions(k, dim)),
+            list(extension.all_extensions(nx.Graph(graph), dim, k_min=k, k_max=k)),
+            list(extension.all_k_extensions(nx.Graph(graph), k, dim)),
         )
-    if TEST_WRAPPED_FUNCTIONS:
-        for k in range(0, dim):
-            assert is_isomorphic_graph_list(
-                list(
-                    extension.all_extensions(
-                        nx.Graph(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
-                    )
-                ),
-                list(
-                    extension.all_k_extensions(
-                        nx.Graph(graph), k, dim, only_non_isomorphic=True
-                    )
-                ),
-            )
-            assert is_isomorphic_graph_list(
-                list(extension.all_extensions(nx.Graph(graph), dim, k_min=k, k_max=k)),
-                list(extension.all_k_extensions(nx.Graph(graph), k, dim)),
-            )
 
 
 @pytest.mark.parametrize(
@@ -326,14 +262,11 @@ def test_all_extensions_single(graph, dim):
 )
 def test_all_extensions_value_error(graph, dim, k_min, k_max):
     with pytest.raises(ValueError):
-        list(graph.all_extensions(dim=dim, k_min=k_min, k_max=k_max))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            list(
-                extension.all_extensions(
-                    nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-                )
+        list(
+            extension.all_extensions(
+                nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
             )
+        )
 
 
 @pytest.mark.parametrize(
@@ -352,14 +285,11 @@ def test_all_extensions_value_error(graph, dim, k_min, k_max):
 )
 def test_all_extensions_type_error(graph, dim, k_min, k_max):
     with pytest.raises(TypeError):
-        list(graph.all_extensions(dim=dim, k_min=k_min, k_max=k_max))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            list(
-                extension.all_extensions(
-                    nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-                )
+        list(
+            extension.all_extensions(
+                nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
             )
+        )
 
 
 ###############################################################
@@ -382,9 +312,7 @@ def test_all_extensions_type_error(graph, dim, k_min, k_max):
     ],
 )
 def test_has_extension_sequence(graph):
-    assert graph.has_extension_sequence()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.has_extension_sequence(nx.Graph(graph))
+    assert extension.has_extension_sequence(nx.Graph(graph))
 
 
 @pytest.mark.parametrize(
@@ -403,20 +331,22 @@ def test_has_extension_sequence(graph):
     ],
 )
 def test_has_not_extension_sequence(graph):
-    assert not graph.has_extension_sequence()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not extension.has_extension_sequence(nx.Graph(graph))
+    assert not extension.has_extension_sequence(nx.Graph(graph))
 
 
 ###############################################################
 # extension_sequence
 ###############################################################
 def test_extension_sequence_solution():
-    assert graphs.Complete(2).extension_sequence(return_type="graphs") == [
+    assert extension.extension_sequence(
+        graphs.Complete(2), return_type="graphs"
+    ) == [
         Graph([[0, 1]]),
     ]
 
-    assert graphs.Complete(3).extension_sequence(return_type="graphs") == [
+    assert extension.extension_sequence(
+        graphs.Complete(3), return_type="graphs"
+    ) == [
         Graph([[1, 2]]),
         Graph([[0, 1], [0, 2], [1, 2]]),
     ]
@@ -427,11 +357,23 @@ def test_extension_sequence_solution():
         Graph([[1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
         Graph([[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4]]),
         Graph(
-            [[0, 3], [0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5]],
+            [
+                [0, 3],
+                [0, 4],
+                [0, 5],
+                [1, 3],
+                [1, 4],
+                [1, 5],
+                [2, 3],
+                [2, 4],
+                [2, 5],
+            ],
         ),
     ]
     assert (
-        graphs.CompleteBipartite(3, 3).extension_sequence(return_type="graphs")
+        extension.extension_sequence(
+            graphs.CompleteBipartite(3, 3), return_type="graphs"
+        )
         == solution
     )
 
@@ -445,22 +387,32 @@ def test_extension_sequence_solution():
     for i in range(len(solution)):
         assert solution[i] == G
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
+            extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
-    assert graphs.Diamond().extension_sequence(return_type="graphs") == [
+    assert extension.extension_sequence(graphs.Diamond(), return_type="graphs") == [
         Graph([[2, 3]]),
         Graph([[0, 2], [0, 3], [2, 3]]),
         Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
     ]
 
-    result = graphs.ThreePrism().extension_sequence(return_type="graphs")
+    result = extension.extension_sequence(graphs.ThreePrism(), return_type="graphs")
     solution = [
         Graph([[4, 5]]),
         Graph([[3, 4], [3, 5], [4, 5]]),
         Graph([[1, 3], [1, 4], [3, 4], [3, 5], [4, 5]]),
         Graph([[1, 2], [1, 3], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]),
         Graph(
-            [[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]],
+            [
+                [0, 1],
+                [0, 2],
+                [0, 3],
+                [1, 2],
+                [1, 4],
+                [2, 5],
+                [3, 4],
+                [3, 5],
+                [4, 5],
+            ],
         ),
     ]
     assert solution == result
@@ -474,97 +426,7 @@ def test_extension_sequence_solution():
     for i in range(len(result)):
         assert result[i] == G
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(
-            graphs.Complete(2), return_type="graphs"
-        ) == [
-            Graph([[0, 1]]),
-        ]
-
-        assert extension.extension_sequence(
-            graphs.Complete(3), return_type="graphs"
-        ) == [
-            Graph([[1, 2]]),
-            Graph([[0, 1], [0, 2], [1, 2]]),
-        ]
-
-        solution = [
-            Graph([[3, 4]]),
-            Graph([[2, 3], [2, 4], [3, 4]]),
-            Graph([[1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
-            Graph([[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4]]),
-            Graph(
-                [
-                    [0, 3],
-                    [0, 4],
-                    [0, 5],
-                    [1, 3],
-                    [1, 4],
-                    [1, 5],
-                    [2, 3],
-                    [2, 4],
-                    [2, 5],
-                ],
-            ),
-        ]
-        assert (
-            extension.extension_sequence(
-                graphs.CompleteBipartite(3, 3), return_type="graphs"
-            )
-            == solution
-        )
-
-        solution_ext = [
-            [0, [3, 4], [], 2],  # k, vertices, edges, new_vertex
-            [0, [3, 4], [], 1],
-            [0, [1, 2], [], 5],
-            [1, [3, 4, 5], [(3, 4)], 0],
-        ]
-        G = Graph([[3, 4]])
-        for i in range(len(solution)):
-            assert solution[i] == G
-            if i < len(solution_ext):
-                extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
-
-        assert extension.extension_sequence(graphs.Diamond(), return_type="graphs") == [
-            Graph([[2, 3]]),
-            Graph([[0, 2], [0, 3], [2, 3]]),
-            Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
-        ]
-
-        result = extension.extension_sequence(graphs.ThreePrism(), return_type="graphs")
-        solution = [
-            Graph([[4, 5]]),
-            Graph([[3, 4], [3, 5], [4, 5]]),
-            Graph([[1, 3], [1, 4], [3, 4], [3, 5], [4, 5]]),
-            Graph([[1, 2], [1, 3], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]),
-            Graph(
-                [
-                    [0, 1],
-                    [0, 2],
-                    [0, 3],
-                    [1, 2],
-                    [1, 4],
-                    [2, 5],
-                    [3, 4],
-                    [3, 5],
-                    [4, 5],
-                ],
-            ),
-        ]
-        assert solution == result
-        solution_ext = [
-            [0, [4, 5], [], 3],  # k, vertices, edges, new_vertex
-            [0, [3, 4], [], 1],
-            [0, [1, 5], [], 2],
-            [1, [1, 2, 3], [(1, 3)], 0],
-        ]
-        G = Graph([[4, 5]])
-        for i in range(len(result)):
-            assert result[i] == G
-            if i < len(solution_ext):
-                extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
+            extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
 
 @pytest.mark.parametrize(
@@ -584,19 +446,12 @@ def test_extension_sequence_solution():
     ],
 )
 def test_extension_sequence(graph):
-    ext = graph.extension_sequence(return_type="both")
+    ext = extension.extension_sequence(nx.Graph(graph), return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = current.k_extension(*ext[i][1])
-        assert current == ext[i][0]
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(nx.Graph(graph), return_type="both")
-        assert ext is not None
-        current = ext[0]
-        for i in range(1, len(ext)):
-            current = extension.k_extension(nx.Graph(current), *ext[i][1])
-            assert Graph(current) == ext[i][0]
+        current = extension.k_extension(nx.Graph(current), *ext[i][1])
+        assert Graph(current) == ext[i][0]
 
 
 @pytest.mark.parametrize(
@@ -626,19 +481,12 @@ def test_extension_sequence(graph):
     ],
 )
 def test_extension_sequence_dim(graph, dim):
-    ext = graph.extension_sequence(dim=dim, return_type="both")
+    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = current.k_extension(*ext[i][1], dim=dim)
-        assert current == ext[i][0]
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="both")
-        assert ext is not None
-        current = ext[0]
-        for i in range(1, len(ext)):
-            current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
-            assert Graph(current) == ext[i][0]
+        current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
+        assert Graph(current) == ext[i][0]
 
 
 @pytest.mark.parametrize(
@@ -663,17 +511,12 @@ def test_extension_sequence_dim(graph, dim):
     ],
 )
 def test_extension_sequence_min_rigid(graph, dim):
-    ext = graph.extension_sequence(dim=dim, return_type="graphs")
+    ext = extension.extension_sequence(
+        nx.Graph(graph), dim=dim, return_type="graphs"
+    )
     assert ext is not None
     for current in ext:
-        assert current.is_min_rigid(dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(
-            nx.Graph(graph), dim=dim, return_type="graphs"
-        )
-        assert ext is not None
-        for current in ext:
-            assert generic_rigidity.is_min_rigid(current, dim)
+        assert generic_rigidity.is_min_rigid(current, dim)
 
 
 @pytest.mark.parametrize(
@@ -692,9 +535,7 @@ def test_extension_sequence_min_rigid(graph, dim):
     ],
 )
 def test_extension_sequence_none(graph):
-    assert graph.extension_sequence() is None
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(nx.Graph(graph)) is None
+    assert extension.extension_sequence(nx.Graph(graph)) is None
 
 
 @pytest.mark.parametrize(
@@ -716,16 +557,11 @@ def test_extension_sequence_none(graph):
     ],
 )
 def test_extension_sequence_dim_none(graph, dim):
-    assert graph.extension_sequence(dim) is None
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(nx.Graph(graph), dim) is None
+    assert extension.extension_sequence(nx.Graph(graph), dim) is None
 
 
 def test_extension_sequence_error():
     with pytest.raises(NotSupportedValueError):
-        graphs.Complete(3).extension_sequence(return_type="Test")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(NotSupportedValueError):
-            extension.extension_sequence(
-                nx.Graph(graphs.Complete(3)), return_type="Test"
-            )
+        extension.extension_sequence(
+            nx.Graph(graphs.Complete(3)), return_type="Test"
+        )

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -373,7 +373,7 @@ def test_extension_sequence_solution():
         [0, [1, 2], [], 5],
         [1, [3, 4, 5], [(3, 4)], 0],
     ]
-    G = Graph([[3, 4]])
+    G = nx.Graph([[3, 4]])
     for i in range(len(solution)):
         assert solution[i] == G
         if i < len(solution_ext):
@@ -416,9 +416,9 @@ def test_extension_sequence_solution():
         [0, [1, 5], [], 2],
         [1, [1, 2, 3], [(1, 3)], 0],
     ]
-    G = Graph([[4, 5]])
+    G = nx.Graph([[4, 5]])
     for i in range(len(result)):
-        assert result[i] == G
+        assert result[i] == Graph(G)
         if i < len(solution_ext):
             extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -35,37 +35,53 @@ def test_k_extension():
         ]
     )
 
-    assert graphs.CompleteBipartite(3, 2).k_extension(
-        2, [0, 1, 3], [(0, 3), (1, 3)], dim=1
-    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)])
-    assert graphs.CompleteBipartite(3, 2).k_extension(
-        2, [0, 1, 3, 4], [(0, 3), (1, 3)]
-    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)])
-    assert graphs.Cycle(6).k_extension(
-        4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], dim=1
-    ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
     assert Graph(
-        [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]
-    ) == extension.k_extension(
-        nx.Graph(graphs.CompleteBipartite(3, 2)),
-        2,
-        [0, 1, 3],
-        [(0, 3), (1, 3)],
-        dim=1,
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)),
+            2,
+            [0, 1, 3],
+            [(0, 3), (1, 3)],
+            dim=1,
+        )
+    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)])
+    assert Graph(
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+        )
+    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)])
+    assert Graph(
+        extension.k_extension(
+            nx.Graph(graphs.Cycle(6)),
+            4,
+            [0, 1, 2, 3, 4],
+            [(0, 1), (1, 2), (2, 3), (3, 4)],
+            dim=1,
+        )
+    ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
+    assert Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)),
+            2,
+            [0, 1, 3],
+            [(0, 3), (1, 3)],
+            dim=1,
+        )
     )
     assert Graph(
         [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
-    ) == extension.k_extension(
-        nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+    ) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+        )
     )
-    assert Graph(
-        [(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]
-    ) == extension.k_extension(
-        nx.Graph(graphs.Cycle(6)),
-        4,
-        [0, 1, 2, 3, 4],
-        [(0, 1), (1, 2), (2, 3), (3, 4)],
-        dim=1,
+    assert Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.Cycle(6)),
+            4,
+            [0, 1, 2, 3, 4],
+            [(0, 1), (1, 2), (2, 3), (3, 4)],
+            dim=1,
+        )
     )
 
 
@@ -127,11 +143,12 @@ def test_all_k_extensions():
             Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 4], [3, 4]]),
         ]
-    all_diamond_0_2 = list(
-        extension.all_k_extensions(
+    all_diamond_0_2 = [
+        Graph(G)
+        for G in extension.all_k_extensions(
             nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
         )
-    )
+    ]
     assert (
         len(all_diamond_0_2) == 3
         and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
@@ -141,13 +158,17 @@ def test_all_k_extensions():
         and Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
         == all_diamond_0_2[2]
     )
-    all_diamond_1_2 = extension.all_k_extensions(
-        nx.Graph(graphs.Diamond()), 1, 2, only_non_isomorphic=True
-    )
-    assert Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]) == next(
-        all_diamond_1_2
-    ) and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]) == next(
-        all_diamond_1_2
+    all_diamond_1_2 = [
+        Graph(G)
+        for G in extension.all_k_extensions(
+            nx.Graph(graphs.Diamond()), 1, 2, only_non_isomorphic=True
+        )
+    ]
+    assert (
+        Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]])
+        == all_diamond_1_2[0]
+        and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]])
+        == all_diamond_1_2[1]
     )
 
 
@@ -169,11 +190,12 @@ def test_all_k_extensions():
 )
 def test_all_k_extensions2(graph, k, dim, sol):
     assert is_isomorphic_graph_list(
-        list(
-            extension.all_k_extensions(
+        [
+            Graph(G)
+            for G in extension.all_k_extensions(
                 nx.Graph(graph), k, dim, only_non_isomorphic=True
             )
-        ),
+        ],
         [Graph.from_int(igraph) for igraph in sol],
     )
 
@@ -204,7 +226,12 @@ def test_all_k_extension_error():
 )
 def test_all_extensions(graph, dim, sol):
     assert is_isomorphic_graph_list(
-        list(extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)),
+        [
+            Graph(G)
+            for G in extension.all_extensions(
+                nx.Graph(graph), dim, only_non_isomorphic=True
+            )
+        ],
         [Graph.from_int(igraph) for igraph in sol],
     )
 
@@ -328,15 +355,21 @@ def test_has_not_extension_sequence(graph):
 # extension_sequence
 ###############################################################
 def test_extension_sequence_solution():
-    assert extension.extension_sequence(
-        nx.Graph(graphs.Complete(2)), return_type="graphs"
-    ) == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Complete(2)), return_type="graphs"
+        )
+    ] == [
         Graph([[0, 1]]),
     ]
 
-    assert extension.extension_sequence(
-        nx.Graph(graphs.Complete(3)), return_type="graphs"
-    ) == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Complete(3)), return_type="graphs"
+        )
+    ] == [
         Graph([[1, 2]]),
         Graph([[0, 1], [0, 2], [1, 2]]),
     ]
@@ -360,12 +393,12 @@ def test_extension_sequence_solution():
             ],
         ),
     ]
-    assert (
-        extension.extension_sequence(
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
             nx.Graph(graphs.CompleteBipartite(3, 3)), return_type="graphs"
         )
-        == solution
-    )
+    ] == solution
 
     solution_ext = [
         [0, [3, 4], [], 2],  # k, vertices, edges, new_vertex
@@ -379,9 +412,12 @@ def test_extension_sequence_solution():
         if i < len(solution_ext):
             extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
-    assert extension.extension_sequence(
-        nx.Graph(graphs.Diamond()), return_type="graphs"
-    ) == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Diamond()), return_type="graphs"
+        )
+    ] == [
         Graph([[2, 3]]),
         Graph([[0, 2], [0, 3], [2, 3]]),
         Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
@@ -445,7 +481,7 @@ def test_extension_sequence(graph):
     current = ext[0]
     for i in range(1, len(ext)):
         current = extension.k_extension(nx.Graph(current), *ext[i][1])
-        assert Graph(current) == ext[i][0]
+        assert Graph(current) == Graph(ext[i][0])
 
 
 @pytest.mark.parametrize(
@@ -480,7 +516,7 @@ def test_extension_sequence_dim(graph, dim):
     current = ext[0]
     for i in range(1, len(ext)):
         current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
-        assert Graph(current) == ext[i][0]
+        assert Graph(current) == Graph(ext[i][0])
 
 
 @pytest.mark.parametrize(

--- a/test/graph/export/test_export.py
+++ b/test/graph/export/test_export.py
@@ -21,8 +21,8 @@ from pyrigi.graph._export import export
 def test_integer_representation(graph, gint):
     assert export.to_int(nx.Graph(graph)) == gint
     assert Graph.from_int(gint).is_isomorphic(graph)
-    assert Graph.from_int(gint).to_int() == gint
-    assert Graph.from_int(graph.to_int()).is_isomorphic(graph)
+    assert export.to_int(nx.Graph(Graph.from_int(gint))) == gint
+    assert Graph.from_int(export.to_int(nx.Graph(graph))).is_isomorphic(graph)
 
 
 def test_integer_representation_error():

--- a/test/graph/export/test_export.py
+++ b/test/graph/export/test_export.py
@@ -5,7 +5,6 @@ from sympy import Matrix
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph._export import export
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 @pytest.mark.parametrize(
@@ -20,21 +19,19 @@ from test import TEST_WRAPPED_FUNCTIONS
     ],
 )
 def test_integer_representation(graph, gint):
-    assert graph.to_int() == gint
+    assert export.to_int(nx.Graph(graph)) == gint
     assert Graph.from_int(gint).is_isomorphic(graph)
     assert Graph.from_int(gint).to_int() == gint
     assert Graph.from_int(graph.to_int()).is_isomorphic(graph)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert export.to_int(nx.Graph(graph)) == gint
 
 
 def test_integer_representation_error():
     with pytest.raises(ValueError):
-        Graph([]).to_int()
+        export.to_int(nx.Graph([]))
     with pytest.raises(ValueError):
         M = Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
         G = Graph.from_adjacency_matrix(M)
-        G.to_int()
+        export.to_int(nx.Graph(G))
     with pytest.raises(ValueError):
         Graph.from_int(0)
     with pytest.raises(TypeError):
@@ -43,10 +40,3 @@ def test_integer_representation_error():
         Graph.from_int(1.2)
     with pytest.raises(ValueError):
         Graph.from_int(-1)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            export.to_int(nx.Graph([]))
-        with pytest.raises(ValueError):
-            M = Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
-            G = Graph.from_adjacency_matrix(M)
-            export.to_int(nx.Graph(G))

--- a/test/graph/other/test_apex.py
+++ b/test/graph/other/test_apex.py
@@ -7,7 +7,6 @@ import pytest
 import pyrigi.graph._other.apex as apex
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 ###############################################################
@@ -31,9 +30,7 @@ from test import TEST_WRAPPED_FUNCTIONS
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_vertex_apex(graph, k):
-    assert graph.is_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_k_vertex_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -46,9 +43,7 @@ def test_is_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_vertex_apex(graph, k):
-    assert not graph.is_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_k_vertex_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -72,9 +67,7 @@ def test_is_not_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_edge_apex(graph, k):
-    assert graph.is_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_k_edge_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -88,9 +81,7 @@ def test_is_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_edge_apex(graph, k):
-    assert not graph.is_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_k_edge_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -114,9 +105,7 @@ def test_is_not_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_critically_k_vertex_apex(graph, k):
-    assert graph.is_critically_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -131,9 +120,7 @@ def test_is_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_critically_k_vertex_apex(graph, k):
-    assert not graph.is_critically_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -159,9 +146,7 @@ def test_is_not_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1 if n == 3 else 2 * n - 3] for n in range(3, 5)],
 )
 def test_is_critically_k_edge_apex(graph, k):
-    assert graph.is_critically_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_edge_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -176,9 +161,7 @@ def test_is_critically_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0 if n == 3 else 2 * n - 4] for n in range(3, 6)],
 )
 def test_is_not_critically_k_edge_apex(graph, k):
-    assert not graph.is_critically_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_edge_apex(nx.Graph(graph), k)
 
 
 ###############################################################

--- a/test/graph/sparsity/test_sparsity.py
+++ b/test/graph/sparsity/test_sparsity.py
@@ -8,7 +8,6 @@ import pytest
 import pyrigi.graph._sparsity.sparsity as sparsity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_sparsity
 
 is_kl_sparse_algorithms_sparsity_all_kl = ["default", "subgraph"]
@@ -38,12 +37,9 @@ is_kl_sparse_algorithms_sparsity_pebble = is_kl_sparse_algorithms_sparsity_all_k
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -59,12 +55,9 @@ def test_is_kl_sparse(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_not_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -84,12 +77,9 @@ def test_is_not_kl_sparse(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_sparse(graph):
-    assert graph.is_kl_sparse(2, 3, algorithm="subgraph")
-    assert graph.is_kl_sparse(2, 3, algorithm="pebble")
+    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
     assert graph.is_sparse()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-        assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -103,12 +93,9 @@ def test_is_2_3_sparse(graph):
     ],
 )
 def test_is_not_2_3_sparse(graph):
-    assert not graph.is_kl_sparse(2, 3, algorithm="subgraph")
-    assert not graph.is_kl_sparse(2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
     assert not graph.is_sparse()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -130,12 +117,9 @@ def test_is_not_2_3_sparse(graph):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -151,12 +135,9 @@ def test_is_kl_sparse_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -180,12 +161,9 @@ def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -203,12 +181,9 @@ def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -233,9 +208,7 @@ def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_not_sparse_graphs_big_random(graph, K, L):
-    assert not graph.is_kl_sparse(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -253,10 +226,7 @@ def test_is_not_sparse_graphs_big_random(graph, K, L):
 def test_is_kl_sparse_pebble_value_error(graph, K, L):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -273,10 +243,7 @@ def test_is_kl_sparse_pebble_value_error(graph, K, L):
 def test_is_kl_sparse_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -292,10 +259,7 @@ def test_is_kl_sparse_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(TypeError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -313,10 +277,7 @@ def test_is_kl_sparse_type_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -332,10 +293,7 @@ def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(TypeError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 ###############################################################
@@ -355,9 +313,7 @@ def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -377,9 +333,7 @@ def test_is_kl_tight(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_not_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -393,12 +347,9 @@ def test_is_not_kl_tight(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_tight(graph):
-    assert graph.is_kl_tight(2, 3, algorithm="pebble")
-    assert graph.is_kl_tight(2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
     assert graph.is_tight()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-        assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
 
 
 @pytest.mark.parametrize(
@@ -418,12 +369,9 @@ def test_is_2_3_tight(graph):
     ],
 )
 def test_is_not_2_3_tight(graph):
-    assert not graph.is_kl_tight(2, 3, algorithm="subgraph")
-    assert not graph.is_kl_tight(2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
     assert not graph.is_tight()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-        assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
 
 
 @pytest.mark.parametrize(
@@ -440,9 +388,7 @@ def test_is_not_2_3_tight(graph):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -465,9 +411,7 @@ def test_is_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -488,9 +432,7 @@ def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -517,9 +459,7 @@ def test_is_kl_tight_with_loops(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -540,9 +480,7 @@ def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_tight_big_random(graph, K, L):
-    assert graph.is_kl_tight(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm="pebble")
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 ###############################################################
@@ -563,17 +501,11 @@ def test_is_tight_big_random(graph, K, L):
 def test_spanning_kl_sparse_subgraph(graph):
     for K in range(1, 3):
         for L in range(0, 2 * K):
-            spanning_subgraph = graph.spanning_kl_sparse_subgraph(K, L)
-            assert spanning_subgraph.is_kl_sparse(K, L, algorithm="subgraph")
-            assert set(graph.vertex_list()) == set(spanning_subgraph.vertex_list())
-            if TEST_WRAPPED_FUNCTIONS:
-                spanning_subgraph = sparsity.spanning_kl_sparse_subgraph(
-                    nx.Graph(graph), K, L
-                )
-                assert sparsity.is_kl_sparse(
-                    spanning_subgraph, K, L, algorithm="subgraph"
-                )
-                assert set(graph.nodes) == set(spanning_subgraph.nodes)
+            spanning_subgraph = sparsity.spanning_kl_sparse_subgraph(
+                nx.Graph(graph), K, L
+            )
+            assert sparsity.is_kl_sparse(spanning_subgraph, K, L, algorithm="subgraph")
+            assert set(graph.nodes) == set(spanning_subgraph.nodes)
 
 
 ###############################################################

--- a/test/graph/test_general.py
+++ b/test/graph/test_general.py
@@ -7,26 +7,26 @@ from pyrigi.graph import _general as general
 
 
 def test_adjacency_matrix():
-    G = Graph()
-    assert G.adjacency_matrix() == Matrix([])
-    G = Graph([[2, 1], [2, 3]])
-    assert G.adjacency_matrix() == Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.adjacency_matrix(vertex_order=[2, 3, 1]) == Matrix(
+    G = nx.Graph()
+    assert general.adjacency_matrix(G) == Matrix([])
+    G = nx.Graph([[2, 1], [2, 3]])
+    assert general.adjacency_matrix(G) == Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+    assert general.adjacency_matrix(G, vertex_order=[2, 3, 1]) == Matrix(
         [[0, 1, 1], [1, 0, 0], [1, 0, 0]]
     )
-    assert graphs.Complete(4).adjacency_matrix() == Matrix.ones(4) - Matrix.diag(
-        [1, 1, 1, 1]
-    )
-    G = Graph.from_vertices(["C", 1, "D"])
-    assert G.adjacency_matrix() == Matrix.zeros(3)
+    assert general.adjacency_matrix(nx.Graph(graphs.Complete(4))) == Matrix.ones(
+        4
+    ) - Matrix.diag([1, 1, 1, 1])
+    G = nx.Graph(Graph.from_vertices(["C", 1, "D"]))
+    assert general.adjacency_matrix(G) == Matrix.zeros(3)
     G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
     assert general.adjacency_matrix(nx.Graph(G), vertex_order=["C", 1, "D"]) == Matrix(
         [[0, 0, 1], [0, 0, 1], [1, 1, 0]]
     )
     M = Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.from_adjacency_matrix(M).adjacency_matrix() == M
+    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
     M = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.from_adjacency_matrix(M).adjacency_matrix() == M
+    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
 
 
 def test_vertex_and_edge_lists():

--- a/test/graph/test_general.py
+++ b/test/graph/test_general.py
@@ -4,7 +4,6 @@ from sympy import Matrix
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph import _general as general
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 def test_adjacency_matrix():
@@ -21,46 +20,31 @@ def test_adjacency_matrix():
     G = Graph.from_vertices(["C", 1, "D"])
     assert G.adjacency_matrix() == Matrix.zeros(3)
     G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-    assert G.adjacency_matrix(vertex_order=["C", 1, "D"]) == Matrix(
-        [[0, 0, 1], [0, 0, 1], [1, 1, 0]]
-    )
+    assert general.adjacency_matrix(
+        nx.Graph(G), vertex_order=["C", 1, "D"]
+    ) == Matrix([[0, 0, 1], [0, 0, 1], [1, 1, 0]])
     M = Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     assert G.from_adjacency_matrix(M).adjacency_matrix() == M
     M = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 0]])
     assert G.from_adjacency_matrix(M).adjacency_matrix() == M
-    if TEST_WRAPPED_FUNCTIONS:
-        G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-        assert general.adjacency_matrix(
-            nx.Graph(G), vertex_order=["C", 1, "D"]
-        ) == Matrix([[0, 0, 1], [0, 0, 1], [1, 1, 0]])
 
 
 def test_vertex_and_edge_lists():
-    G = Graph([[2, 1], [2, 3]])
-    assert G.vertex_list() == [1, 2, 3]
-    assert G.edge_list() == [[1, 2], [2, 3]]
-    G = Graph([(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)])
-    assert set(G.vertex_list()) == {"C", 1, "D", 2, "E", 3, 0}
-    assert set(G.edge_list()) == {("C", 1), (1, 0), (1, 2), ("D", 2), (2, 3), ("E", 3)}
-    G = Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0])
-    assert set(G.vertex_list()) == {"C", 2, "E", 1, "D", 3, 0}
-    assert G.edge_list() == []
-    if TEST_WRAPPED_FUNCTIONS:
-        G = nx.Graph([[2, 1], [2, 3]])
-        assert general.vertex_list(G) == [1, 2, 3]
-        assert general.edge_list(G) == [[1, 2], [2, 3]]
-        G = nx.Graph(
-            [(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)]
-        )
-        assert set(general.vertex_list(G)) == {"C", 1, "D", 2, "E", 3, 0}
-        assert set(general.edge_list(G)) == {
-            ("C", 1),
-            (1, 0),
-            (1, 2),
-            ("D", 2),
-            (2, 3),
-            ("E", 3),
-        }
-        G = nx.Graph(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
-        assert set(general.vertex_list(G)) == {"C", 2, "E", 1, "D", 3, 0}
-        assert general.edge_list(G) == []
+    G = nx.Graph([[2, 1], [2, 3]])
+    assert general.vertex_list(G) == [1, 2, 3]
+    assert general.edge_list(G) == [[1, 2], [2, 3]]
+    G = nx.Graph(
+        [(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)]
+    )
+    assert set(general.vertex_list(G)) == {"C", 1, "D", 2, "E", 3, 0}
+    assert set(general.edge_list(G)) == {
+        ("C", 1),
+        (1, 0),
+        (1, 2),
+        ("D", 2),
+        (2, 3),
+        ("E", 3),
+    }
+    G = nx.Graph(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
+    assert set(general.vertex_list(G)) == {"C", 2, "E", 1, "D", 3, 0}
+    assert general.edge_list(G) == []

--- a/test/graph/test_general.py
+++ b/test/graph/test_general.py
@@ -20,9 +20,9 @@ def test_adjacency_matrix():
     G = Graph.from_vertices(["C", 1, "D"])
     assert G.adjacency_matrix() == Matrix.zeros(3)
     G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-    assert general.adjacency_matrix(
-        nx.Graph(G), vertex_order=["C", 1, "D"]
-    ) == Matrix([[0, 0, 1], [0, 0, 1], [1, 1, 0]])
+    assert general.adjacency_matrix(nx.Graph(G), vertex_order=["C", 1, "D"]) == Matrix(
+        [[0, 0, 1], [0, 0, 1], [1, 1, 0]]
+    )
     M = Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     assert G.from_adjacency_matrix(M).adjacency_matrix() == M
     M = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 0]])


### PR DESCRIPTION
## Summary
- Same cleanup as the rigidity PR, applied to the remaining graph test files
  (constructions, extension, export, apex, sparsity, general).
- Removes the redundant wrapper-style assertions and the `TEST_WRAPPED_FUNCTIONS`
  guard now that #393 covers wrapper forwarding generically.

Files: `test_constructions.py`, `test_extension.py`, `test_export.py`,
`test_apex.py`, `test_sparsity.py`, `test_general.py` (56 blocks total).

## Test plan
- `pytest test/graph -q` passes
