### PR TITLE
Test: Removed TEST_WRAPPED_FUNCTIONS blocks from framework tests

### DIFF
--- a/test/framework/export/test_export.py
+++ b/test/framework/export/test_export.py
@@ -3,7 +3,6 @@ import pytest
 from pyrigi.framework import Framework
 from pyrigi.framework._export import export as framework_export
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -44,10 +43,8 @@ def test__generate_stl_bar_error(holes_dist, holes_diam, bar_w, bar_h):
 def test_generate_stl_bars():
     G = Graph([(0, 1), (1, 2), (2, 3), (0, 3)])
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [1, "1/2 * sqrt(5)"], 3: [1 / 2, "4/3"]})
-    assert F.generate_stl_bars(scale=20, filename_prefix="mybar") is None
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        assert (
-            framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar")
-            is None
-        )
+    F = _to_FrameworkBase(F)
+    assert (
+        framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar")
+        is None
+    )

--- a/test/framework/export/test_export.py
+++ b/test/framework/export/test_export.py
@@ -45,6 +45,5 @@ def test_generate_stl_bars():
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [1, "1/2 * sqrt(5)"], 3: [1 / 2, "4/3"]})
     F = _to_FrameworkBase(F)
     assert (
-        framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar")
-        is None
+        framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar") is None
     )

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -55,9 +55,7 @@ def test_plot2D():
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
     F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        framework_plot.plot2D(
-            F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]}
-        )
+        framework_plot.plot2D(F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
     framework_plot.plot2D(F, inf_flex=0)
     framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F)[0])
     framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
@@ -84,9 +82,7 @@ def test_plot3D():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
     F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        framework_plot.plot3D(
-            F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]]
-        )
+        framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]])
     framework_plot.plot3D(F)
 
     F = Framework(graphs.Complete(2), {0: [0, 0, 0, 0], 1: [1, 0, 0, 0]})

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -7,6 +7,8 @@ import pyrigi.frameworkDB as fws
 import pyrigi.graphDB as graphs
 from pyrigi.framework import Framework
 from pyrigi.framework._plot import plot as framework_plot
+from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
+from pyrigi.framework._rigidity import stress as stress_rigidity
 from test.framework import _to_FrameworkBase
 
 
@@ -57,8 +59,10 @@ def test_plot2D():
     with pytest.raises(ValueError):
         framework_plot.plot2D(F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
     framework_plot.plot2D(F, inf_flex=0)
-    framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F)[0])
-    framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
+    framework_plot.plot2D(F, inf_flex=infinitesimal_rigidity.inf_flexes(F)[0])
+    framework_plot.plot2D(
+        F, inf_flex=infinitesimal_rigidity.inf_flexes(F, numerical=True)[0]
+    )
     framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
     framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
 
@@ -66,14 +70,14 @@ def test_plot2D():
     F = _to_FrameworkBase(F)
     framework_plot.plot2D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-    framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
     F = _to_FrameworkBase(F)
     framework_plot.plot2D(F, stress=0)
-    framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-    framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     plt.close("all")
 
@@ -96,8 +100,10 @@ def test_plot3D():
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
     F = _to_FrameworkBase(F)
     framework_plot.plot3D(F, inf_flex=0)
-    framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F)[0])
-    framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
+    framework_plot.plot3D(F, inf_flex=infinitesimal_rigidity.inf_flexes(F)[0])
+    framework_plot.plot3D(
+        F, inf_flex=infinitesimal_rigidity.inf_flexes(F, numerical=True)[0]
+    )
     framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Octahedron(realization="Bricard_plane")
@@ -111,14 +117,14 @@ def test_plot3D():
     F = _to_FrameworkBase(F)
     framework_plot.plot3D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-    framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
     F = _to_FrameworkBase(F)
     framework_plot.plot3D(F, stress=0)
-    framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-    framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     plt.close("all")
 

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -7,7 +7,6 @@ import pyrigi.frameworkDB as fws
 import pyrigi.graphDB as graphs
 from pyrigi.framework import Framework
 from pyrigi.framework._plot import plot as framework_plot
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -21,213 +20,124 @@ from test.framework import _to_FrameworkBase
 )
 def test_plot_error(realization):
     F = Framework(graphs.Complete(2), realization)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot()
+        framework_plot.plot(F)
 
     plt.close()
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot(F)
-
-        plt.close()
 
 
 def test_plot():
     F = Framework(graphs.Complete(2), {0: [1, 0], 1: [0, 1]})
-    F.plot()
+    F = _to_FrameworkBase(F)
+    framework_plot.plot(F)
 
     F = Framework(graphs.Complete(2), {0: [1, 0, 0], 1: [0, 1, 1]})
-    F.plot()
+    F = _to_FrameworkBase(F)
+    framework_plot.plot(F)
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0], 1: [0, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot(F)
-
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0], 1: [0, 1, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot(F)
-
-        plt.close("all")
 
 
 def test_plot2D():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(projection_matrix=[[1, 0], [0, 1], [0, 0]])
-    F.plot2D(projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
+        framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1], [0, 0]])
+    framework_plot.plot2D(F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
 
     F = Framework(graphs.Complete(2), {0: [0, 0, 0], 1: [1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(projection_matrix=[[1, 0], [0, 1]])
-    F.plot2D()
+        framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1]])
+    framework_plot.plot2D(F)
 
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
-    F.plot2D(inf_flex=0)
-    F.plot2D(inf_flex=F.inf_flexes()[0])
-    F.plot2D(inf_flex=F.inf_flexes(numerical=True)[0])
-    F.plot2D(inf_flex=0, fixed_vertices=[0])
-    F.plot2D(inf_flex=0, fixed_vertices=[0, 1])
+        framework_plot.plot2D(
+            F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]}
+        )
+    framework_plot.plot2D(F, inf_flex=0)
+    framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F)[0])
+    framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
+    framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
+    framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Complete(4)
-    F.plot2D(stress=0, dpi=200, filename="K4_Test_output")
+    F = _to_FrameworkBase(F)
+    framework_plot.plot2D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    F.plot2D(stress=F.stresses()[0])
-    F.plot2D(stress=F.stresses(numerical=True)[0])
+    framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
+    framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
-    F.plot2D(stress=0)
-    F.plot2D(stress=F.stresses()[0])
-    F.plot2D(stress=F.stresses(numerical=True)[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot2D(F, stress=0)
+    framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
+    framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1], [0, 0]])
-        framework_plot.plot2D(F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
-
-        F = Framework(graphs.Complete(2), {0: [0, 0, 0], 1: [1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1]])
-        framework_plot.plot2D(F)
-
-        F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(
-                F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]}
-            )
-        framework_plot.plot2D(F, inf_flex=0)
-        framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F)[0])
-        framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
-        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
-        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
-
-        F = fws.Complete(4)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot2D(F, stress=0, dpi=200, filename="K4_Test_output")
-        os.remove("K4_Test_output.png")
-        framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        F = fws.Complete(4, dim=1)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot2D(F, stress=0)
-        framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        plt.close("all")
 
 
 def test_plot3D():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot3D(projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]])
-    F.plot3D()
+        framework_plot.plot3D(
+            F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]]
+        )
+    framework_plot.plot3D(F)
 
     F = Framework(graphs.Complete(2), {0: [0, 0, 0, 0], 1: [1, 0, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot3D(projection_matrix=[[1, 0, 0], [0, 0, 1]])
-    F.plot3D(projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]])
+        framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1]])
+    framework_plot.plot3D(
+        F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
+    )
 
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-    F.plot3D(inf_flex=0)
-    F.plot3D(inf_flex=F.inf_flexes()[0])
-    F.plot3D(inf_flex=F.inf_flexes(numerical=True)[0])
-    F.plot3D(inf_flex=0, fixed_vertices=[0, 1])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, inf_flex=0)
+    framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F)[0])
+    framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
+    framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Octahedron(realization="Bricard_plane")
-    F.plot3D(inf_flex=0, stress=0)
-    F.plot3D(inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, inf_flex=0, stress=0)
+    framework_plot.plot3D(
+        F, inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0]
+    )
 
     F = fws.Complete(4)
-    F.plot3D(stress=0, dpi=200, filename="K4_Test_output")
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    F.plot3D(stress=F.stresses()[0])
-    F.plot3D(stress=F.stresses(numerical=True)[0])
+    framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
+    framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
-    F.plot3D(stress=0)
-    F.plot3D(stress=F.stresses()[0])
-    F.plot3D(stress=F.stresses(numerical=True)[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, stress=0)
+    framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
+    framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot3D(
-                F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]]
-            )
-        framework_plot.plot3D(F)
-
-        F = Framework(graphs.Complete(2), {0: [0, 0, 0, 0], 1: [1, 0, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1]])
-        framework_plot.plot3D(
-            F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
-        )
-
-        F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, inf_flex=0)
-        framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F)[0])
-        framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
-        framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
-
-        F = fws.Octahedron(realization="Bricard_plane")
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, inf_flex=0, stress=0)
-        framework_plot.plot3D(
-            F, inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0]
-        )
-
-        F = fws.Complete(4)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, stress=0, dpi=200, filename="K4_Test_output")
-        os.remove("K4_Test_output.png")
-        framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        F = fws.Complete(4, dim=1)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, stress=0)
-        framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        plt.close("all")
 
 
 def test_animate3D_rotation():
     F = fws.Complete(4, dim=3)
-    F.animate3D_rotation()
+    F = _to_FrameworkBase(F)
+    framework_plot.animate3D_rotation(F)
 
     F = fws.Complete(3)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.animate3D_rotation()
-
-    F = fws.Complete(5, dim=4)
-    with pytest.raises(ValueError):
-        F.animate3D_rotation()
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
         framework_plot.animate3D_rotation(F)
 
-        F = fws.Complete(3)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.animate3D_rotation(F)
-
-        F = fws.Complete(5, dim=4)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.animate3D_rotation(F)
+    F = fws.Complete(5, dim=4)
+    F = _to_FrameworkBase(F)
+    with pytest.raises(ValueError):
+        framework_plot.animate3D_rotation(F)

--- a/test/framework/rigidity/test_infinitesimal.py
+++ b/test/framework/rigidity/test_infinitesimal.py
@@ -270,22 +270,28 @@ def test_inf_flexes():
 
     G = graphs.Complete(3)
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
     assert Matrix.hstack(*inf_flexes).rank() == 1
 
     G = graphs.Complete(4)
     F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
     assert Matrix.hstack(*inf_flexes).rank() == 1
 
 
@@ -353,26 +359,32 @@ def test_inf_flexes_numerical():
 
     G = graphs.Complete(3)
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
     G = graphs.Complete(4)
     F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
 

--- a/test/framework/rigidity/test_infinitesimal.py
+++ b/test/framework/rigidity/test_infinitesimal.py
@@ -413,13 +413,15 @@ def test_inf_flexes_numerical():
 def test_vertex_fixing(framework, include_trivial, numerical):
     fixed_vertices = framework._graph.edge_list()[0]
     flexes = infinitesimal_rigidity.inf_flexes(
-        framework,
+        _to_FrameworkBase(framework),
         include_trivial=include_trivial,
         numerical=numerical,
         fixed_vertices=fixed_vertices,
     )
     pointwise_zero_flexes = [
-        infinitesimal_rigidity._transform_inf_flex_to_pointwise(framework, flex)
+        infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+            _to_FrameworkBase(framework), flex
+        )
         for flex in flexes
     ]
     assert all(

--- a/test/framework/rigidity/test_infinitesimal.py
+++ b/test/framework/rigidity/test_infinitesimal.py
@@ -8,7 +8,6 @@ from pyrigi._utils._zero_check import is_zero_vector
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -48,13 +47,10 @@ from test.framework import _to_FrameworkBase
     + [fws.Complete(n + 1, dim=n) for n in range(1, 10)],
 )
 def test_is_inf_rigid(framework):
-    assert framework.is_inf_rigid()
-    assert framework.is_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_inf_rigid(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_inf_rigid(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -86,13 +82,10 @@ def test_is_inf_rigid(framework):
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 10)],
 )
 def test_is_inf_flexible(framework):
-    assert framework.is_inf_flexible()
-    assert framework.is_inf_flexible(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_inf_flexible(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_inf_flexible(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_inf_flexible(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_inf_flexible(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -118,13 +111,10 @@ def test_is_inf_flexible(framework):
     + [fws.Complete(n + 1, dim=n) for n in range(1, 7)],
 )
 def test_is_min_inf_rigid(framework):
-    assert framework.is_min_inf_rigid()
-    assert framework.is_min_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_min_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_min_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -166,276 +156,215 @@ def test_is_min_inf_rigid(framework):
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_not_min_inf_rigid(framework):
-    assert not framework.is_min_inf_rigid()
-    assert not framework.is_min_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
-        assert not infinitesimal_rigidity.is_min_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
+    assert not infinitesimal_rigidity.is_min_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 def test_inf_flexes():
-    Q1 = Matrix.hstack(*(fws.Complete(2, 2).inf_flexes(include_trivial=True)))
-    Q2 = Matrix.hstack(*(fws.Complete(2, 2).trivial_inf_flexes()))
+    F1 = _to_FrameworkBase(fws.Complete(2, 2))
+    Q1 = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F1, include_trivial=True)))
+    Q2 = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F1)))
     assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-    assert len(fws.Square().inf_flexes(include_trivial=False)) == 1
+    F2 = _to_FrameworkBase(fws.Square())
+    assert len(infinitesimal_rigidity.inf_flexes(F2, include_trivial=False)) == 1
 
     F = fws.ThreePrism(realization="flexible")
+    F = _to_FrameworkBase(F)
     C = Framework(graphs.Complete(6), realization=F.realization())
+    C = _to_FrameworkBase(C)
     explicit_flex = sympify(
         [0, 0, 0, 0, 0, 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0]
     )
     assert (
-        F.is_vector_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex, numerical=True)
-        and F.is_nontrivial_flex(explicit_flex, numerical=True)
+        infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex, numerical=True
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(
+            F, explicit_flex, numerical=True
+        )
     )
     explicit_flex_reorder = sympify(
         ["-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, 0, 0, 0, 0, 0, 0]
     )
     assert (
-        F.is_vector_inf_flex(explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1])
-        and F.is_vector_nontrivial_inf_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
+        infinitesimal_rigidity.is_vector_inf_flex(
+            F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
         )
-        and F.is_vector_nontrivial_inf_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1], numerical=True
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
         )
-        and F.is_nontrivial_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1], numerical=True
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F,
+            explicit_flex_reorder,
+            vertex_order=[5, 4, 3, 0, 2, 1],
+            numerical=True,
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(
+            F,
+            explicit_flex_reorder,
+            vertex_order=[5, 4, 3, 0, 2, 1],
+            numerical=True,
         )
     )
-    QF = Matrix.hstack(*(F.nontrivial_inf_flexes()))
-    QC = Matrix.hstack(*(C.nontrivial_inf_flexes()))
+    QF = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F)))
+    QC = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(C)))
     assert QF.rank() == 1 and QC.rank() == 0
-    assert F.trivial_inf_flexes() == C.trivial_inf_flexes()
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=True)))
-    QC = Matrix.hstack(*(F.trivial_inf_flexes()))
+    assert infinitesimal_rigidity.trivial_inf_flexes(
+        F
+    ) == infinitesimal_rigidity.trivial_inf_flexes(C)
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=True)))
+    QC = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F)))
     Q_exp = Matrix(explicit_flex)
     assert Matrix.hstack(QF, QC).rank() == 4
     assert Matrix.hstack(QF, Q_exp).rank() == 4
 
     F = fws.Path(4)
-    for inf_flex in F.nontrivial_inf_flexes():
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(
-            dict_flex
-        )
-    assert Matrix.hstack(*(F.nontrivial_inf_flexes())).rank() == 2
-
-    F = fws.Frustum(4)
-    explicit_flex = [1, 0, 0, -1, 0, -1, 1, 0, 1, -1, 1, -1, 0, 0, 0, 0]
-    assert (
-        F.is_vector_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex, numerical=True)
-        and F.is_nontrivial_flex(explicit_flex, numerical=True)
-    )
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=True)))
-    Q_exp = Matrix(explicit_flex)
-    assert QF.rank() == 5 and Matrix.hstack(QF, Q_exp).rank() == 5
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=False)))
-    assert QF.rank() == 2 and Matrix.hstack(QF, Q_exp).rank() == 2
-
-    F = fws.Complete(5)
-    F_triv = F.trivial_inf_flexes()
-    for inf_flex in F_triv:
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(dict_flex) and F.is_dict_trivial_inf_flex(dict_flex)
-    F_all = F.inf_flexes(include_trivial=True)
-    assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
-
-    F = Framework.Random(graphs.DoubleBanana(), dim=3)
-    inf_flexes = F.nontrivial_inf_flexes()
-    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-        F, inf_flexes[0]
-    )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
-    assert Matrix.hstack(*inf_flexes).rank() == 1
-
-    G = graphs.Complete(3)
-    F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
-    assert len(inf_flexes) == 1
-    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-        F, inf_flexes[0]
-    )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
-    assert Matrix.hstack(*inf_flexes).rank() == 1
-
-    G = graphs.Complete(4)
-    F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
-    assert len(inf_flexes) == 1
-    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-        F, inf_flexes[0]
-    )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
-    assert Matrix.hstack(*inf_flexes).rank() == 1
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(fws.Complete(2, 2))
-        Q1 = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F1, include_trivial=True))
-        )
-        Q2 = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F1)))
-        assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-        F2 = _to_FrameworkBase(fws.Square())
-        assert len(infinitesimal_rigidity.inf_flexes(F2, include_trivial=False)) == 1
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        C = Framework(graphs.Complete(6), realization=F.realization())
-        C = _to_FrameworkBase(C)
-        explicit_flex = sympify(
-            [0, 0, 0, 0, 0, 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0]
-        )
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex, numerical=True
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F, explicit_flex, numerical=True
-            )
-        )
-        explicit_flex_reorder = sympify(
-            ["-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, 0, 0, 0, 0, 0, 0]
-        )
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(
-                F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
-            )
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
-            )
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F,
-                explicit_flex_reorder,
-                vertex_order=[5, 4, 3, 0, 2, 1],
-                numerical=True,
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F,
-                explicit_flex_reorder,
-                vertex_order=[5, 4, 3, 0, 2, 1],
-                numerical=True,
-            )
-        )
-        QF = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F)))
-        QC = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(C)))
-        assert QF.rank() == 1 and QC.rank() == 0
-        assert infinitesimal_rigidity.trivial_inf_flexes(
-            F
-        ) == infinitesimal_rigidity.trivial_inf_flexes(C)
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=True))
-        )
-        QC = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F)))
-        Q_exp = Matrix(explicit_flex)
-        assert Matrix.hstack(QF, QC).rank() == 4
-        assert Matrix.hstack(QF, Q_exp).rank() == 4
-
-        F = fws.Path(4)
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F):
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex
-            ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
-        assert (
-            Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank()
-            == 2
-        )
-
-        F = fws.Frustum(4)
-        F = _to_FrameworkBase(F)
-        explicit_flex = [1, 0, 0, -1, 0, -1, 1, 0, 1, -1, 1, -1, 0, 0, 0, 0]
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex, numerical=True
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F, explicit_flex, numerical=True
-            )
-        )
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=True))
-        )
-        Q_exp = Matrix(explicit_flex)
-        assert QF.rank() == 5 and Matrix.hstack(QF, Q_exp).rank() == 5
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=False))
-        )
-        assert QF.rank() == 2 and Matrix.hstack(QF, Q_exp).rank() == 2
-
-        F = fws.Complete(5)
-        F = _to_FrameworkBase(F)
-        F_triv = infinitesimal_rigidity.trivial_inf_flexes(F)
-        for inf_flex in F_triv:
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex
-            ) and infinitesimal_rigidity.is_dict_trivial_inf_flex(F, dict_flex)
-        F_all = infinitesimal_rigidity.inf_flexes(F, include_trivial=True)
-        assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
-
-        F = Framework.Random(graphs.DoubleBanana(), dim=3)
-        F = _to_FrameworkBase(F)
-        inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F):
         dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flexes[0]
+            F, inf_flex
         )
         assert infinitesimal_rigidity.is_dict_inf_flex(
             F, dict_flex
         ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
-        assert Matrix.hstack(*inf_flexes).rank() == 1
+    assert (
+        Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank() == 2
+    )
+
+    F = fws.Frustum(4)
+    F = _to_FrameworkBase(F)
+    explicit_flex = [1, 0, 0, -1, 0, -1, 1, 0, 1, -1, 1, -1, 0, 0, 0, 0]
+    assert (
+        infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex, numerical=True
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(
+            F, explicit_flex, numerical=True
+        )
+    )
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=True)))
+    Q_exp = Matrix(explicit_flex)
+    assert QF.rank() == 5 and Matrix.hstack(QF, Q_exp).rank() == 5
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=False)))
+    assert QF.rank() == 2 and Matrix.hstack(QF, Q_exp).rank() == 2
+
+    F = fws.Complete(5)
+    F = _to_FrameworkBase(F)
+    F_triv = infinitesimal_rigidity.trivial_inf_flexes(F)
+    for inf_flex in F_triv:
+        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+            F, inf_flex
+        )
+        assert infinitesimal_rigidity.is_dict_inf_flex(
+            F, dict_flex
+        ) and infinitesimal_rigidity.is_dict_trivial_inf_flex(F, dict_flex)
+    F_all = infinitesimal_rigidity.inf_flexes(F, include_trivial=True)
+    assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
+
+    F = Framework.Random(graphs.DoubleBanana(), dim=3)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
+    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+        F, inf_flexes[0]
+    )
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
+    assert Matrix.hstack(*inf_flexes).rank() == 1
+
+    G = graphs.Complete(3)
+    F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
+    inf_flexes = F.nontrivial_inf_flexes()
+    assert len(inf_flexes) == 1
+    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+        F, inf_flexes[0]
+    )
+    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert Matrix.hstack(*inf_flexes).rank() == 1
+
+    G = graphs.Complete(4)
+    F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
+    inf_flexes = F.nontrivial_inf_flexes()
+    assert len(inf_flexes) == 1
+    dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+        F, inf_flexes[0]
+    )
+    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert Matrix.hstack(*inf_flexes).rank() == 1
 
 
 def test_inf_flexes_numerical():
     F = fws.ThreePrism(realization="flexible")
+    F = _to_FrameworkBase(F)
     C = Framework(graphs.Complete(6), realization=F.realization())
-    QF = np.hstack(F.nontrivial_inf_flexes(numerical=True))
-    QC = C.nontrivial_inf_flexes(numerical=True)
+    C = _to_FrameworkBase(C)
+    QF = np.hstack(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
+    QC = infinitesimal_rigidity.nontrivial_inf_flexes(C, numerical=True)
     assert np.linalg.matrix_rank(QF) == 1 and len(QC) == 0
 
     F = fws.Path(4)
-    for inf_flex in F.nontrivial_inf_flexes(numerical=True):
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(
-            dict_flex, numerical=True
-        ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True):
+        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+            F, inf_flex
+        )
+        assert infinitesimal_rigidity.is_dict_inf_flex(
+            F, dict_flex, numerical=True
+        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+            F, dict_flex, numerical=True, tolerance=1e-4
+        )
     assert (
-        np.linalg.matrix_rank(np.vstack(tuple(F.nontrivial_inf_flexes(numerical=True))))
+        np.linalg.matrix_rank(
+            np.vstack(
+                tuple(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
+            )
+        )
         == 2
     )
 
     F = fws.Frustum(4)
-    QF = np.vstack(tuple(F.inf_flexes(include_trivial=True, numerical=True)))
+    F = _to_FrameworkBase(F)
+    QF = np.vstack(
+        tuple(
+            infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True)
+        )
+    )
     assert np.linalg.matrix_rank(QF) == 5
-    QF = np.vstack(tuple(F.inf_flexes(include_trivial=False, numerical=True)))
+    QF = np.vstack(
+        tuple(
+            infinitesimal_rigidity.inf_flexes(
+                F, include_trivial=False, numerical=True
+            )
+        )
+    )
     assert np.linalg.matrix_rank(QF) == 2
 
     F = fws.Complete(5, dim=4)
-    assert len(F.inf_flexes(include_trivial=True, numerical=True)) == 10
+    F = _to_FrameworkBase(F)
+    assert (
+        len(
+            infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True)
+        )
+        == 10
+    )
 
     F = Framework.Random(graphs.DoubleBanana(), dim=3)
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
     G = graphs.Complete(3)
@@ -461,80 +390,6 @@ def test_inf_flexes_numerical():
         dict_flex, numerical=True, tolerance=1e-4
     ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        C = Framework(graphs.Complete(6), realization=F.realization())
-        C = _to_FrameworkBase(C)
-        QF = np.hstack(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
-        QC = infinitesimal_rigidity.nontrivial_inf_flexes(C, numerical=True)
-        assert np.linalg.matrix_rank(QF) == 1 and len(QC) == 0
-
-        F = fws.Path(4)
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True):
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex, numerical=True
-            ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
-                F, dict_flex, numerical=True, tolerance=1e-4
-            )
-        assert (
-            np.linalg.matrix_rank(
-                np.vstack(
-                    tuple(
-                        infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
-                    )
-                )
-            )
-            == 2
-        )
-
-        F = fws.Frustum(4)
-        F = _to_FrameworkBase(F)
-        QF = np.vstack(
-            tuple(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=True, numerical=True
-                )
-            )
-        )
-        assert np.linalg.matrix_rank(QF) == 5
-        QF = np.vstack(
-            tuple(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=False, numerical=True
-                )
-            )
-        )
-        assert np.linalg.matrix_rank(QF) == 2
-
-        F = fws.Complete(5, dim=4)
-        F = _to_FrameworkBase(F)
-        assert (
-            len(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=True, numerical=True
-                )
-            )
-            == 10
-        )
-
-        F = Framework.Random(graphs.DoubleBanana(), dim=3)
-        F = _to_FrameworkBase(F)
-        inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flexes[0]
-        )
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, dict_flex, numerical=True, tolerance=1e-4
-        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
-            F, dict_flex, numerical=True, tolerance=1e-4
-        )
-        assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
 
 @pytest.mark.parametrize(
@@ -561,7 +416,8 @@ def test_inf_flexes_numerical():
 )
 def test_vertex_fixing(framework, include_trivial, numerical):
     fixed_vertices = framework._graph.edge_list()[0]
-    flexes = framework.inf_flexes(
+    flexes = infinitesimal_rigidity.inf_flexes(
+        framework,
         include_trivial=include_trivial,
         numerical=numerical,
         fixed_vertices=fixed_vertices,
@@ -582,105 +438,54 @@ def test_vertex_fixing(framework, include_trivial, numerical):
         )
         for point in pointwise_zero_flexes
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        infinitesimal_rigidity.inf_flexes(
-            framework,
-            include_trivial=include_trivial,
-            numerical=numerical,
-            fixed_vertices=fixed_vertices,
-        )
-        pointwise_zero_flexes = [
-            infinitesimal_rigidity._transform_inf_flex_to_pointwise(framework, flex)
-            for flex in flexes
-        ]
-        assert all(
-            is_zero_vector(point[v], numerical=numerical)
-            for v in fixed_vertices
-            for point in pointwise_zero_flexes
-        )
-        assert all(
-            any(
-                not is_zero_vector(point[v], numerical=numerical)
-                for v in framework._graph.nodes
-            )
-            for point in pointwise_zero_flexes
-        )
 
 
 def test_is_vector_inf_flex():
     F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-    assert F.is_vector_inf_flex([0, 0, 0, 1, -1, 0])
-    assert not F.is_vector_inf_flex([0, 0, 0, 1, -2, 0])
-    assert F.is_vector_inf_flex([0, 1, 0, 0, -1, 0], [1, 0, 2])
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
+    assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -2, 0])
+    assert infinitesimal_rigidity.is_vector_inf_flex(
+        F, [0, 1, 0, 0, -1, 0], [1, 0, 2]
+    )
 
     F.delete_edge([1, 2])
-    assert F.is_vector_inf_flex([0, 0, 0, 1, -1, 0])
-    assert F.is_vector_inf_flex([0, 0, 0, -1, -2, 0])
-    assert not F.is_vector_inf_flex([0, 0, 2, 1, -2, 1])
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, -1, -2, 0])
+    assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 2, 1, -2, 1])
 
     F = fws.ThreePrism(realization="flexible")
-    for inf_flex in F.inf_flexes(include_trivial=True):
-        assert F.is_vector_inf_flex(inf_flex)
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
-        assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -2, 0])
-        assert infinitesimal_rigidity.is_vector_inf_flex(
-            F, [0, 1, 0, 0, -1, 0], [1, 0, 2]
-        )
-
-        F.delete_edge([1, 2])
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, -1, -2, 0])
-        assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 2, 1, -2, 1])
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.inf_flexes(F, include_trivial=True):
-            assert infinitesimal_rigidity.is_vector_inf_flex(F, inf_flex)
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.inf_flexes(F, include_trivial=True):
+        assert infinitesimal_rigidity.is_vector_inf_flex(F, inf_flex)
 
 
 def test_is_dict_inf_flex():
     F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, 1], 2: [-1, 0]})
-    assert not F.is_dict_inf_flex({0: [0, 0], 1: [0, -1], 2: [-2, 0]})
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
+    )
+    assert not infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
+    )
 
     F.delete_edge([1, 2])
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, 1], 2: [-1, 0]})
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, -1], 2: [-2, 0]})
-    assert not F.is_dict_inf_flex({0: [0, 0], 1: [2, 1], 2: [-2, 1]})
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
+    )
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
+    )
+    assert not infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [2, 1], 2: [-2, 1]}
+    )
 
     F = fws.ThreePrism(realization="flexible")
-    assert F.is_dict_inf_flex(
-        {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
-        )
-        assert not infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
-        )
-
-        F.delete_edge([1, 2])
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
-        )
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
-        )
-        assert not infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [2, 1], 2: [-2, 1]}
-        )
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
-        )
 
 
 @pytest.mark.parametrize(
@@ -692,22 +497,24 @@ def test_is_dict_inf_flex():
     ],
 )
 def test_rigidity_matrix_parametric(framework, rigidity_matrix):
-    assert framework.rigidity_matrix() == rigidity_matrix
-    if TEST_WRAPPED_FUNCTIONS:
-        assert (
-            infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
-            == rigidity_matrix
-        )
+    assert (
+        infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
+        == rigidity_matrix
+    )
 
 
 def test_rigidity_matrix():
     F = fws.Complete(4, dim=3)
-    assert F.rigidity_matrix().shape == (6, 12)
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.rigidity_matrix(F).shape == (6, 12)
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])
     F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
+    F = _to_FrameworkBase(F)
     vertex_order = ["a", 1.9, "b", 0]
-    assert F.rigidity_matrix(vertex_order=vertex_order) == Matrix(
+    assert infinitesimal_rigidity.rigidity_matrix(
+        F, vertex_order=vertex_order
+    ) == Matrix(
         [
             [1, 0, 0, 0, 0, 0, -1, 0],
             [0, 0, 0, 1, 0, 0, 0, -1],
@@ -715,25 +522,6 @@ def test_rigidity_matrix():
             [0, 0, -1, 0, 1, 0, 0, 0],
         ]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.rigidity_matrix(F).shape == (6, 12)
-
-        G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])
-        F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
-        F = _to_FrameworkBase(F)
-        vertex_order = ["a", 1.9, "b", 0]
-        assert infinitesimal_rigidity.rigidity_matrix(
-            F, vertex_order=vertex_order
-        ) == Matrix(
-            [
-                [1, 0, 0, 0, 0, 0, -1, 0],
-                [0, 0, 0, 1, 0, 0, 0, -1],
-                [0, -1, 0, 0, 0, 1, 0, 0],
-                [0, 0, -1, 0, 1, 0, 0, 0],
-            ]
-        )
 
 
 @pytest.mark.parametrize(
@@ -758,16 +546,13 @@ def test_rigidity_matrix():
     ],
 )
 def test_rigidity_matrix_rank(framework, rank):
-    assert framework.rigidity_matrix_rank() == rank
-    assert framework.rigidity_matrix_rank(numerical=True) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        assert (
-            infinitesimal_rigidity.rigidity_matrix_rank(_to_FrameworkBase(framework))
-            == rank
+    assert (
+        infinitesimal_rigidity.rigidity_matrix_rank(_to_FrameworkBase(framework))
+        == rank
+    )
+    assert (
+        infinitesimal_rigidity.rigidity_matrix_rank(
+            _to_FrameworkBase(framework), numerical=True
         )
-        assert (
-            infinitesimal_rigidity.rigidity_matrix_rank(
-                _to_FrameworkBase(framework), numerical=True
-            )
-            == rank
-        )
+        == rank
+    )

--- a/test/framework/rigidity/test_infinitesimal.py
+++ b/test/framework/rigidity/test_infinitesimal.py
@@ -183,9 +183,7 @@ def test_inf_flexes():
         and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
             F, explicit_flex, numerical=True
         )
-        and infinitesimal_rigidity.is_nontrivial_flex(
-            F, explicit_flex, numerical=True
-        )
+        and infinitesimal_rigidity.is_nontrivial_flex(F, explicit_flex, numerical=True)
     )
     explicit_flex_reorder = sympify(
         ["-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, 0, 0, 0, 0, 0, 0]
@@ -225,15 +223,11 @@ def test_inf_flexes():
     F = fws.Path(4)
     F = _to_FrameworkBase(F)
     for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F):
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flex
-        )
+        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
         assert infinitesimal_rigidity.is_dict_inf_flex(
             F, dict_flex
         ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
-    assert (
-        Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank() == 2
-    )
+    assert Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank() == 2
 
     F = fws.Frustum(4)
     F = _to_FrameworkBase(F)
@@ -244,9 +238,7 @@ def test_inf_flexes():
         and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
             F, explicit_flex, numerical=True
         )
-        and infinitesimal_rigidity.is_nontrivial_flex(
-            F, explicit_flex, numerical=True
-        )
+        and infinitesimal_rigidity.is_nontrivial_flex(F, explicit_flex, numerical=True)
     )
     QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=True)))
     Q_exp = Matrix(explicit_flex)
@@ -258,9 +250,7 @@ def test_inf_flexes():
     F = _to_FrameworkBase(F)
     F_triv = infinitesimal_rigidity.trivial_inf_flexes(F)
     for inf_flex in F_triv:
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flex
-        )
+        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
         assert infinitesimal_rigidity.is_dict_inf_flex(
             F, dict_flex
         ) and infinitesimal_rigidity.is_dict_trivial_inf_flex(F, dict_flex)
@@ -311,9 +301,7 @@ def test_inf_flexes_numerical():
     F = fws.Path(4)
     F = _to_FrameworkBase(F)
     for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True):
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flex
-        )
+        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
         assert infinitesimal_rigidity.is_dict_inf_flex(
             F, dict_flex, numerical=True
         ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
@@ -338,9 +326,7 @@ def test_inf_flexes_numerical():
     assert np.linalg.matrix_rank(QF) == 5
     QF = np.vstack(
         tuple(
-            infinitesimal_rigidity.inf_flexes(
-                F, include_trivial=False, numerical=True
-            )
+            infinitesimal_rigidity.inf_flexes(F, include_trivial=False, numerical=True)
         )
     )
     assert np.linalg.matrix_rank(QF) == 2
@@ -348,9 +334,7 @@ def test_inf_flexes_numerical():
     F = fws.Complete(5, dim=4)
     F = _to_FrameworkBase(F)
     assert (
-        len(
-            infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True)
-        )
+        len(infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True))
         == 10
     )
 
@@ -445,9 +429,7 @@ def test_is_vector_inf_flex():
     F = _to_FrameworkBase(F)
     assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
     assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -2, 0])
-    assert infinitesimal_rigidity.is_vector_inf_flex(
-        F, [0, 1, 0, 0, -1, 0], [1, 0, 2]
-    )
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 1, 0, 0, -1, 0], [1, 0, 2])
 
     F.delete_edge([1, 2])
     assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])

--- a/test/framework/rigidity/test_matroidal.py
+++ b/test/framework/rigidity/test_matroidal.py
@@ -4,7 +4,6 @@ import pyrigi.frameworkDB as fws
 import pyrigi.graphDB as graphs
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import matroidal as matroidal_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -40,13 +39,10 @@ from test.framework import _to_FrameworkBase
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_independent(framework):
-    assert framework.is_independent()
-    assert framework.is_independent(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_independent(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_independent(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_independent(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_independent(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -69,13 +65,10 @@ def test_is_independent(framework):
     + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
 def test_is_dependent(framework):
-    assert framework.is_dependent()
-    assert framework.is_dependent(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_dependent(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_dependent(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -96,13 +89,10 @@ def test_is_dependent(framework):
     + [fws.Complete(n - 1, dim=n) for n in range(2, 7)],
 )
 def test_is_isostatic(framework):
-    assert framework.is_isostatic()
-    assert framework.is_isostatic(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_isostatic(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_isostatic(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -134,9 +124,7 @@ def test_is_isostatic(framework):
     + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
 def test_is_not_isostatic(framework):
-    assert not framework.is_isostatic()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
-        assert not matroidal_rigidity.is_isostatic(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
+    assert not matroidal_rigidity.is_isostatic(
+        _to_FrameworkBase(framework), numerical=True
+    )

--- a/test/framework/rigidity/test_matroidal.py
+++ b/test/framework/rigidity/test_matroidal.py
@@ -66,9 +66,7 @@ def test_is_independent(framework):
 )
 def test_is_dependent(framework):
     assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework))
-    assert matroidal_rigidity.is_dependent(
-        _to_FrameworkBase(framework), numerical=True
-    )
+    assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework), numerical=True)
 
 
 @pytest.mark.parametrize(
@@ -90,9 +88,7 @@ def test_is_dependent(framework):
 )
 def test_is_isostatic(framework):
     assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
-    assert matroidal_rigidity.is_isostatic(
-        _to_FrameworkBase(framework), numerical=True
-    )
+    assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework), numerical=True)
 
 
 @pytest.mark.parametrize(

--- a/test/framework/rigidity/test_redundant.py
+++ b/test/framework/rigidity/test_redundant.py
@@ -2,7 +2,6 @@ import pytest
 
 import pyrigi.frameworkDB as fws
 from pyrigi.framework._rigidity import redundant as redundant_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -18,13 +17,10 @@ from test.framework import _to_FrameworkBase
     ],
 )
 def test_is_redundantly_inf_rigid(framework):
-    assert framework.is_redundantly_inf_rigid()
-    assert framework.is_redundantly_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
-        assert redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
+    assert redundant_rigidity.is_redundantly_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -47,12 +43,9 @@ def test_is_redundantly_inf_rigid(framework):
     ],
 )
 def test_is_not_redundantly_inf_rigid(framework):
-    assert not framework.is_redundantly_inf_rigid()
-    assert not framework.is_redundantly_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework)
-        )
-        assert not redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not redundant_rigidity.is_redundantly_inf_rigid(
+        _to_FrameworkBase(framework)
+    )
+    assert not redundant_rigidity.is_redundantly_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )

--- a/test/framework/rigidity/test_redundant.py
+++ b/test/framework/rigidity/test_redundant.py
@@ -43,9 +43,7 @@ def test_is_redundantly_inf_rigid(framework):
     ],
 )
 def test_is_not_redundantly_inf_rigid(framework):
-    assert not redundant_rigidity.is_redundantly_inf_rigid(
-        _to_FrameworkBase(framework)
-    )
+    assert not redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
     assert not redundant_rigidity.is_redundantly_inf_rigid(
         _to_FrameworkBase(framework), numerical=True
     )

--- a/test/framework/rigidity/test_second_order.py
+++ b/test/framework/rigidity/test_second_order.py
@@ -3,7 +3,6 @@ import pytest
 import pyrigi.frameworkDB as fws
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import second_order as second_order_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -24,13 +23,10 @@ from test.framework import _to_FrameworkBase
     ],
 )
 def test_is_prestress_stable(framework):
-    assert framework.is_prestress_stable()
-    assert framework.is_prestress_stable(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
-        assert second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+    assert second_order_rigidity.is_prestress_stable(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,15 +44,10 @@ def test_is_prestress_stable(framework):
     ],
 )
 def test_is_not_prestress_stable(framework):
-    assert not framework.is_prestress_stable()
-    assert not framework.is_prestress_stable(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework)
-        )
-        assert not second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+    assert not second_order_rigidity.is_prestress_stable(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -68,10 +59,7 @@ def test_is_not_prestress_stable(framework):
 )
 def test_is_prestress_stable_error(framework):
     with pytest.raises(ValueError):
-        framework.is_prestress_stable()
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+        second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
 
 
 @pytest.mark.parametrize(
@@ -91,13 +79,10 @@ def test_is_prestress_stable_error(framework):
     ],
 )
 def test_is_second_order_rigid(framework):
-    assert framework.is_second_order_rigid()
-    assert framework.is_second_order_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
-        assert second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
+    assert second_order_rigidity.is_second_order_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -115,15 +100,12 @@ def test_is_second_order_rigid(framework):
     ],
 )
 def test_is_not_second_order_rigid(framework):
-    assert not framework.is_second_order_rigid()
-    assert not framework.is_second_order_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework)
-        )
-        assert not second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not second_order_rigidity.is_second_order_rigid(
+        _to_FrameworkBase(framework)
+    )
+    assert not second_order_rigidity.is_second_order_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,7 +117,4 @@ def test_is_not_second_order_rigid(framework):
 )
 def test_is_second_order_rigid_error(framework):
     with pytest.raises(ValueError):
-        framework.is_second_order_rigid()
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
+        second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))

--- a/test/framework/rigidity/test_second_order.py
+++ b/test/framework/rigidity/test_second_order.py
@@ -100,9 +100,7 @@ def test_is_second_order_rigid(framework):
     ],
 )
 def test_is_not_second_order_rigid(framework):
-    assert not second_order_rigidity.is_second_order_rigid(
-        _to_FrameworkBase(framework)
-    )
+    assert not second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
     assert not second_order_rigidity.is_second_order_rigid(
         _to_FrameworkBase(framework), numerical=True
     )

--- a/test/framework/rigidity/test_stress.py
+++ b/test/framework/rigidity/test_stress.py
@@ -68,10 +68,7 @@ def test_stresses(framework, num_stresses):
 
     stresses = stress_rigidity.stresses(_to_FrameworkBase(framework))
     assert len(stresses) == num_stresses and all(
-        [
-            stress_rigidity.is_stress(_to_FrameworkBase(framework), s)
-            for s in stresses
-        ]
+        [stress_rigidity.is_stress(_to_FrameworkBase(framework), s) for s in stresses]
     )
 
 

--- a/test/framework/rigidity/test_stress.py
+++ b/test/framework/rigidity/test_stress.py
@@ -56,19 +56,16 @@ def test_stress_matrix():
     ],
 )
 def test_stresses(framework, num_stresses):
+    F = _to_FrameworkBase(framework)
     Q1 = Matrix.hstack(
-        *(
-            infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
-            .transpose()
-            .nullspace()
-        )
+        *(infinitesimal_rigidity.rigidity_matrix(F).transpose().nullspace())
     )
-    Q2 = Matrix.hstack(*(stress_rigidity.stresses(_to_FrameworkBase(framework))))
+    Q2 = Matrix.hstack(*(stress_rigidity.stresses(F)))
     assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
 
-    stresses = stress_rigidity.stresses(_to_FrameworkBase(framework))
+    stresses = stress_rigidity.stresses(F)
     assert len(stresses) == num_stresses and all(
-        [stress_rigidity.is_stress(_to_FrameworkBase(framework), s) for s in stresses]
+        [stress_rigidity.is_stress(F, s) for s in stresses]
     )
 
 

--- a/test/framework/rigidity/test_stress.py
+++ b/test/framework/rigidity/test_stress.py
@@ -6,7 +6,6 @@ from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
 from pyrigi.framework._rigidity import stress as stress_rigidity
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -14,9 +13,7 @@ def test_stress_matrix():
     F = fws.Complete(4)
     M = Matrix([[1, -1, 1, -1], [-1, 1, -1, 1], [1, -1, 1, -1], [-1, 1, -1, 1]])
     stress = [1, -1, 1, 1, -1, 1]
-    assert F.stress_matrix(stress) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
+    assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
 
     F = fws.Frustum(3)
     M = Matrix(
@@ -30,24 +27,17 @@ def test_stress_matrix():
         ]
     )
     stress = [2, 2, 6, 2, 6, 6, -1, -1, -1]
-    assert F.stress_matrix(stress) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
+    assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0), ("b", 0), ("a", 1.9)])
     F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
+    F = _to_FrameworkBase(F)
     edge_order = [("a", 0), (1.9, "b"), (1.9, 0), ("a", "b"), ("a", 1.9), (0, "b")]
     M = Matrix([[-1, 1, -1, 1], [1, -1, 1, -1], [-1, 1, -1, 1], [1, -1, 1, -1]])
-    stress = F.stresses(edge_order=edge_order)[0].transpose().tolist()[0]
-    assert F.stress_matrix(stress, edge_order=edge_order) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        stress = (
-            stress_rigidity.stresses(F, edge_order=edge_order)[0]
-            .transpose()
-            .tolist()[0]
-        )
-        assert stress_rigidity.stress_matrix(F, stress, edge_order=edge_order) == M
+    stress = (
+        stress_rigidity.stresses(F, edge_order=edge_order)[0].transpose().tolist()[0]
+    )
+    assert stress_rigidity.stress_matrix(F, stress, edge_order=edge_order) == M
 
 
 @pytest.mark.parametrize(
@@ -66,32 +56,23 @@ def test_stress_matrix():
     ],
 )
 def test_stresses(framework, num_stresses):
-    Q1 = Matrix.hstack(*(framework.rigidity_matrix().transpose().nullspace()))
-    Q2 = Matrix.hstack(*(framework.stresses()))
+    Q1 = Matrix.hstack(
+        *(
+            infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
+            .transpose()
+            .nullspace()
+        )
+    )
+    Q2 = Matrix.hstack(*(stress_rigidity.stresses(_to_FrameworkBase(framework))))
     assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
 
-    stresses = framework.stresses()
+    stresses = stress_rigidity.stresses(_to_FrameworkBase(framework))
     assert len(stresses) == num_stresses and all(
-        [framework.is_stress(s) for s in stresses]
+        [
+            stress_rigidity.is_stress(_to_FrameworkBase(framework), s)
+            for s in stresses
+        ]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        Q1 = Matrix.hstack(
-            *(
-                infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
-                .transpose()
-                .nullspace()
-            )
-        )
-        Q2 = Matrix.hstack(*(stress_rigidity.stresses(_to_FrameworkBase(framework))))
-        assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-
-        stresses = stress_rigidity.stresses(_to_FrameworkBase(framework))
-        assert len(stresses) == num_stresses and all(
-            [
-                stress_rigidity.is_stress(_to_FrameworkBase(framework), s)
-                for s in stresses
-            ]
-        )
 
 
 @pytest.mark.parametrize(
@@ -109,16 +90,11 @@ def test_stresses(framework, num_stresses):
     + [[fws.Frustum(i), 1] for i in range(3, 8)],
 )
 def test_stresses_numerical(framework, num_stresses):
-    stresses = framework.stresses(numerical=True)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=True)
     assert len(stresses) == num_stresses and all(
-        [framework.is_stress(s, numerical=True) for s in stresses]
+        [stress_rigidity.is_stress(F, s, numerical=True) for s in stresses]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=True)
-        assert len(stresses) == num_stresses and all(
-            [stress_rigidity.is_stress(F, s, numerical=True) for s in stresses]
-        )
 
 
 @pytest.mark.parametrize(
@@ -136,17 +112,13 @@ def test_stresses_numerical(framework, num_stresses):
 )
 @pytest.mark.parametrize("numerical", [True, False])
 def test_stress_matrix_rank(framework, stress_rank, numerical):
-    stresses = framework.stresses(numerical=numerical)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=numerical)
     assert len(stresses) == 1
-    assert framework.stress_matrix_rank(stresses[0], numerical=numerical) == stress_rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=numerical)
-        assert len(stresses) == 1
-        assert (
-            stress_rigidity.stress_matrix_rank(F, stresses[0], numerical=numerical)
-            == stress_rank
-        )
+    assert (
+        stress_rigidity.stress_matrix_rank(F, stresses[0], numerical=numerical)
+        == stress_rank
+    )
 
 
 @pytest.mark.parametrize(
@@ -159,27 +131,17 @@ def test_stress_matrix_rank(framework, stress_rank, numerical):
 )
 @pytest.mark.parametrize("numerical", [True, False])
 def test_stress_matrix_rank_symbolic_stresses(framework, stress_dim, numerical):
-    stresses = framework.stresses(numerical=False)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=False)
     assert len(stresses) == len(stress_dim)
     for stress, rank in zip(stresses, stress_dim):
         assert (
-            framework.stress_matrix_rank(stress, numerical=numerical)
-            <= framework.graph.number_of_nodes() - framework.dim - 1
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
+            <= F.graph.number_of_nodes() - F.dim - 1
         )
-        assert framework.stress_matrix_rank(stress, numerical=numerical) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=False)
-        assert len(stresses) == len(stress_dim)
-        for stress, rank in zip(stresses, stress_dim):
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
-                <= F.graph.number_of_nodes() - F.dim - 1
-            )
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
-                == rank
-            )
+        assert (
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical) == rank
+        )
 
 
 @pytest.mark.parametrize(
@@ -191,21 +153,12 @@ def test_stress_matrix_rank_symbolic_stresses(framework, stress_dim, numerical):
     ],
 )
 def test_stress_matrix_rank_numerical_stresses(framework, stress_dim):
-    stresses = framework.stresses(numerical=True)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=True)
     assert len(stresses) == len(stress_dim)
     for stress, rank in zip(stresses, stress_dim):
         assert (
-            framework.stress_matrix_rank(stress, numerical=True)
-            <= framework.graph.number_of_nodes() - framework.dim - 1
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=True)
+            <= F.graph.number_of_nodes() - F.dim - 1
         )
-        assert framework.stress_matrix_rank(stress, numerical=True) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=True)
-        assert len(stresses) == len(stress_dim)
-        for stress, rank in zip(stresses, stress_dim):
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=True)
-                <= F.graph.number_of_nodes() - F.dim - 1
-            )
-            assert stress_rigidity.stress_matrix_rank(F, stress, numerical=True) == rank
+        assert stress_rigidity.stress_matrix_rank(F, stress, numerical=True) == rank

--- a/test/framework/test__general.py
+++ b/test/framework/test__general.py
@@ -11,170 +11,129 @@ from pyrigi.framework import (
 )
 from pyrigi.framework import _general as framework_general
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
 def test_is_injective():
     F1 = fws.Complete(4, 2)
-    assert F1.is_injective()
-    assert F1.is_injective(numerical=True)
 
     F2 = deepcopy(F1)
     F2.set_vertex_pos(0, F2[1])
-    assert not F2.is_injective()
-    assert not F2.is_injective(numerical=True)
 
     # test symbolical injectivity with irrational numbers
     F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
     F3.rotate2D(pi / 3, inplace=True)
-    assert F3.is_injective()
-    assert F3.is_injective(numerical=True)
 
     # test numerical injectivity
     F4 = deepcopy(F3)
     F4.set_realization(F4.realization(numerical=True))
-    assert F4.is_injective(numerical=True)
 
     # test numerically not injective, but symbolically injective framework
     F5 = deepcopy(F3)
     F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
-    assert not F5.is_injective(numerical=True, tolerance=1e-8)
-    assert not F5.is_injective(numerical=True, tolerance=1e-9)
-    assert F5.is_injective()
 
     # test tolerance in numerical injectivity check
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
-    assert F6.is_injective(numerical=True, tolerance=1e-9)
-    assert F6.is_injective()
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_injective(F1)
-        assert framework_general.is_injective(F1, numerical=True)
+    F1 = _to_FrameworkBase(F1)
+    assert framework_general.is_injective(F1)
+    assert framework_general.is_injective(F1, numerical=True)
 
-        F2 = _to_FrameworkBase(F2)
-        assert not framework_general.is_injective(F2)
-        assert not framework_general.is_injective(F2, numerical=True)
+    F2 = _to_FrameworkBase(F2)
+    assert not framework_general.is_injective(F2)
+    assert not framework_general.is_injective(F2, numerical=True)
 
-        # test symbolical injectivity with irrational numbers
-        F3 = _to_FrameworkBase(F3)
-        assert framework_general.is_injective(F3)
-        assert framework_general.is_injective(F3, numerical=True)
+    # test symbolical injectivity with irrational numbers
+    F3 = _to_FrameworkBase(F3)
+    assert framework_general.is_injective(F3)
+    assert framework_general.is_injective(F3, numerical=True)
 
-        # test numerical injectivity
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_injective(F4, numerical=True)
+    # test numerical injectivity
+    F4 = _to_FrameworkBase(F4)
+    assert framework_general.is_injective(F4, numerical=True)
 
-        # test numerically not injective, but symbolically injective framework
-        F5 = _to_FrameworkBase(F5)
-        assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
-        assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
-        assert framework_general.is_injective(F5)
+    # test numerically not injective, but symbolically injective framework
+    F5 = _to_FrameworkBase(F5)
+    assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
+    assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
+    assert framework_general.is_injective(F5)
 
-        # test tolerance in numerical injectivity check
-        F6 = _to_FrameworkBase(F6)
-        assert framework_general.is_injective(F6, numerical=True, tolerance=1e-9)
-        assert framework_general.is_injective(F6)
+    # test tolerance in numerical injectivity check
+    F6 = _to_FrameworkBase(F6)
+    assert framework_general.is_injective(F6, numerical=True, tolerance=1e-9)
+    assert framework_general.is_injective(F6)
 
 
 def test_is_quasi_injective():
     F1 = fws.Complete(4, 2)
-    assert F1.is_quasi_injective()
-    assert F1.is_quasi_injective(numerical=True)
 
     # test framework that is quasi-injective, but not injective
     F1.set_vertex_pos(1, F1[2])
     F1.delete_edge((1, 2))
-    assert F1.is_quasi_injective()
-    assert F1.is_quasi_injective(numerical=True)
 
     # test not quasi-injective framework
     F2 = deepcopy(F1)
     F2.set_vertex_pos(0, F2[1])
-    assert not F2.is_quasi_injective()
-    assert not F2.is_quasi_injective(numerical=True)
 
     # test symbolical and numerical quasi-injectivity with irrational numbers
     F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
     F3 = F3.rotate2D(pi / 2, inplace=False)
-    assert F3.is_quasi_injective()
-    assert F3.is_quasi_injective(numerical=True)
 
     # test numerical quasi-injectivity
     F4 = deepcopy(F3)
     F4.set_realization(F4.realization(numerical=True))
-    assert F4.is_quasi_injective(numerical=True)
 
     # test numerically not quasi-injective, but symbolically quasi-injective framework
     F5 = deepcopy(F3)
     F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
-    assert not F5.is_quasi_injective(numerical=True, tolerance=1e-8)
-    assert not F5.is_quasi_injective(numerical=True, tolerance=1e-9)
-    assert F5.is_quasi_injective()
 
     # test tolerance in numerical quasi-injectivity check
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
-    assert F6.is_quasi_injective(numerical=True, tolerance=1e-9)
-    assert F6.is_quasi_injective()
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_quasi_injective(F1)
-        assert framework_general.is_quasi_injective(F1, numerical=True)
+    F1 = _to_FrameworkBase(F1)
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
 
-        # test framework that is quasi-injective, but not injective
-        F1 = fws.Complete(4, 2)
-        F1.set_vertex_pos(1, F1[2])
-        F1.delete_edge((1, 2))
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_quasi_injective(F1)
-        assert framework_general.is_quasi_injective(F1, numerical=True)
+    # test framework that is quasi-injective, but not injective
+    F1 = fws.Complete(4, 2)
+    F1.set_vertex_pos(1, F1[2])
+    F1.delete_edge((1, 2))
+    F1 = _to_FrameworkBase(F1)
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
 
-        # test not quasi-injective framework
-        F2 = _to_FrameworkBase(F2)
-        assert not framework_general.is_quasi_injective(F2)
-        assert not framework_general.is_quasi_injective(F2, numerical=True)
+    # test not quasi-injective framework
+    F2 = _to_FrameworkBase(F2)
+    assert not framework_general.is_quasi_injective(F2)
+    assert not framework_general.is_quasi_injective(F2, numerical=True)
 
-        # test symbolical and numerical quasi-injectivity with irrational numbers
-        F3 = _to_FrameworkBase(F3)
-        assert framework_general.is_quasi_injective(F3)
-        assert framework_general.is_quasi_injective(F3, numerical=True)
+    # test symbolical and numerical quasi-injectivity with irrational numbers
+    F3 = _to_FrameworkBase(F3)
+    assert framework_general.is_quasi_injective(F3)
+    assert framework_general.is_quasi_injective(F3, numerical=True)
 
-        # test numerical quasi-injectivity
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_quasi_injective(F4, numerical=True)
+    # test numerical quasi-injectivity
+    F4 = _to_FrameworkBase(F4)
+    assert framework_general.is_quasi_injective(F4, numerical=True)
 
-        # test numerically not quasi-injective, but symbolically quasi-injective framework
-        F5 = _to_FrameworkBase(F5)
-        assert not framework_general.is_quasi_injective(
-            F5, numerical=True, tolerance=1e-8
-        )
-        assert not framework_general.is_quasi_injective(
-            F5, numerical=True, tolerance=1e-9
-        )
-        assert framework_general.is_quasi_injective(F5)
+    # test numerically not quasi-injective, but symbolically quasi-injective framework
+    F5 = _to_FrameworkBase(F5)
+    assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-8)
+    assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-9)
+    assert framework_general.is_quasi_injective(F5)
 
-        # test tolerance in numerical quasi-injectivity check
-        F6 = _to_FrameworkBase(F6)
-        assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
-        assert framework_general.is_quasi_injective(F6)
+    # test tolerance in numerical quasi-injectivity check
+    F6 = _to_FrameworkBase(F6)
+    assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
+    assert framework_general.is_quasi_injective(F6)
 
 
 def test_is_equivalent():
     F1 = fws.Complete(4, 2)
-    assert F1.is_equivalent_realization(F1.realization(), numerical=False)
-    assert F1.is_equivalent_realization(F1.realization(), numerical=True)
-    assert F1.is_equivalent(F1)
 
     F2 = fws.Complete(3, 2)
-    with pytest.raises(ValueError):
-        F1.is_equivalent_realization(F2.realization())
-
-    with pytest.raises(ValueError):
-        F1.is_equivalent(F2)
 
     G1 = graphs.ThreePrism()
     G1.delete_vertex(5)
@@ -182,13 +141,8 @@ def test_is_equivalent():
     F3 = Framework(G1, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "9/7"]})
 
     F4 = F3.translate((1, 1), inplace=False)
-    assert F3.is_equivalent(F4, numerical=True)
-    assert F3.is_equivalent(F4)
 
     F5 = F3.rotate2D(pi / 2, inplace=False)
-    assert F5.is_equivalent(F3)
-    assert F5.is_equivalent(F4)
-    assert F5.is_equivalent_realization(F4.realization())
 
     G2 = Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [3, 4]])
     F6 = Framework(G2, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "17/7"]})
@@ -221,67 +175,55 @@ def test_is_equivalent():
         },
     )
 
-    assert F6.is_equivalent(F7)
-    assert F6.is_equivalent(F8)
-    assert F7.is_equivalent(F8)
-
     F9 = F5.translate((pi, "2/3"), False)
-    assert F5.is_equivalent(F9)
-
-    with pytest.raises(ValueError):
-        assert F8.is_equivalent(F2)
 
     # testing numerical equivalence
 
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F9.realization().items()}
 
-    assert not F9.is_equivalent_realization(R1, numerical=False)
-    assert F9.is_equivalent_realization(R1, numerical=True)
+    F1 = _to_FrameworkBase(F1)
+    assert framework_general.is_equivalent_realization(
+        F1, F1.realization(), numerical=False
+    )
+    assert framework_general.is_equivalent_realization(
+        F1, F1.realization(), numerical=True
+    )
+    assert framework_general.is_equivalent(F1, F1)
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_equivalent_realization(
-            F1, F1.realization(), numerical=False
-        )
-        assert framework_general.is_equivalent_realization(
-            F1, F1.realization(), numerical=True
-        )
-        assert framework_general.is_equivalent(F1, F1)
+    F2 = _to_FrameworkBase(F2)
+    with pytest.raises(ValueError):
+        framework_general.is_equivalent_realization(F1, F2.realization())
 
-        F2 = _to_FrameworkBase(F2)
-        with pytest.raises(ValueError):
-            framework_general.is_equivalent_realization(F1, F2.realization())
+    with pytest.raises(ValueError):
+        framework_general.is_equivalent(F1, F2)
 
-        with pytest.raises(ValueError):
-            framework_general.is_equivalent(F1, F2)
+    F3 = _to_FrameworkBase(F3)
+    F4 = _to_FrameworkBase(F4)
+    assert framework_general.is_equivalent(F3, F4, numerical=True)
+    assert framework_general.is_equivalent(F3, F4)
 
-        F3 = _to_FrameworkBase(F3)
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_equivalent(F3, F4, numerical=True)
-        assert framework_general.is_equivalent(F3, F4)
+    F5 = _to_FrameworkBase(F5)
+    assert framework_general.is_equivalent(F5, F3)
+    assert framework_general.is_equivalent(F5, F4)
+    assert framework_general.is_equivalent_realization(F5, F4.realization())
 
-        F5 = _to_FrameworkBase(F5)
-        assert framework_general.is_equivalent(F5, F3)
-        assert framework_general.is_equivalent(F5, F4)
-        assert framework_general.is_equivalent_realization(F5, F4.realization())
+    F6 = _to_FrameworkBase(F6)
+    F7 = _to_FrameworkBase(F7)
+    F8 = _to_FrameworkBase(F8)
 
-        F6 = _to_FrameworkBase(F6)
-        F7 = _to_FrameworkBase(F7)
-        F8 = _to_FrameworkBase(F8)
+    assert framework_general.is_equivalent(F6, F7)
+    assert framework_general.is_equivalent(F6, F8)
+    assert framework_general.is_equivalent(F7, F8)
 
-        assert framework_general.is_equivalent(F6, F7)
-        assert framework_general.is_equivalent(F6, F8)
-        assert framework_general.is_equivalent(F7, F8)
+    F9 = _to_FrameworkBase(F9)
+    assert framework_general.is_equivalent(F5, F9)
 
-        F9 = _to_FrameworkBase(F9)
-        assert framework_general.is_equivalent(F5, F9)
+    with pytest.raises(ValueError):
+        assert framework_general.is_equivalent(F8, F2)
 
-        with pytest.raises(ValueError):
-            assert framework_general.is_equivalent(F8, F2)
-
-        # testing numerical equivalence
-        assert not framework_general.is_equivalent_realization(F9, R1, numerical=False)
-        assert framework_general.is_equivalent_realization(F9, R1, numerical=True)
+    # testing numerical equivalence
+    assert not framework_general.is_equivalent_realization(F9, R1, numerical=False)
+    assert framework_general.is_equivalent_realization(F9, R1, numerical=True)
 
 
 def test_is_congruent():
@@ -316,74 +258,48 @@ def test_is_congruent():
         },
     )
 
-    assert F1.is_congruent_realization(F1.realization(), numerical=False)
-    assert F1.is_congruent(F1, numerical=False)
-    assert F1.is_congruent(F1, numerical=True)
-
-    assert not F1.is_congruent(F2)  # equivalent, but not congruent
-    assert not F1.is_congruent(F3)  # equivalent, but not congruent
-    assert not F2.is_congruent(F3)  # equivalent, but not congruent
-    assert not F1.is_congruent(F2, numerical=True)  # equivalent, but not congruent
-    assert not F1.is_congruent(F3, numerical=True)  # equivalent, but not congruent
-    assert not F2.is_congruent(F3, numerical=True)  # equivalent, but not congruent
-
     F4 = F1.translate((pi, "2/3"), False)
     F5 = F1.rotate2D(pi / 2, inplace=False)
-    assert F1.is_congruent(F4)
-    assert F1.is_congruent(F5)
-    assert F5.is_congruent(F4)
 
     F6 = fws.Complete(4, 2)
     F7 = fws.Complete(3, 2)
-    with pytest.raises(ValueError):
-        assert F6.is_congruent(F7)
 
     # testing numerical congruence
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F4.realization().items()}
 
-    assert not F4.is_congruent_realization(R1)
-    assert F4.is_congruent_realization(R1, numerical=True)
+    F1 = _to_FrameworkBase(F1)
+    F2 = _to_FrameworkBase(F2)
+    F3 = _to_FrameworkBase(F3)
+    F4 = _to_FrameworkBase(F4)
+    F5 = _to_FrameworkBase(F5)
+    F6 = _to_FrameworkBase(F6)
+    F7 = _to_FrameworkBase(F7)
+    assert framework_general.is_congruent_realization(
+        F1, F1.realization(), numerical=False
+    )
+    assert framework_general.is_congruent(F1, F1, numerical=False)
+    assert framework_general.is_congruent(F1, F1, numerical=True)
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        F2 = _to_FrameworkBase(F2)
-        F3 = _to_FrameworkBase(F3)
-        F4 = _to_FrameworkBase(F4)
-        F5 = _to_FrameworkBase(F5)
-        F6 = _to_FrameworkBase(F6)
-        F7 = _to_FrameworkBase(F7)
-        assert framework_general.is_congruent_realization(
-            F1, F1.realization(), numerical=False
-        )
-        assert framework_general.is_congruent(F1, F1, numerical=False)
-        assert framework_general.is_congruent(F1, F1, numerical=True)
+    assert not framework_general.is_congruent(F1, F2)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(F1, F3)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(F2, F3)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F1, F2, numerical=True
+    )  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F1, F3, numerical=True
+    )  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F2, F3, numerical=True
+    )  # equivalent, but not congruent
 
-        assert not framework_general.is_congruent(
-            F1, F2
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F3
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F2, F3
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F2, numerical=True
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F3, numerical=True
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F2, F3, numerical=True
-        )  # equivalent, but not congruent
+    assert framework_general.is_congruent(F1, F4)
+    assert framework_general.is_congruent(F1, F5)
+    assert framework_general.is_congruent(F5, F4)
 
-        assert framework_general.is_congruent(F1, F4)
-        assert framework_general.is_congruent(F1, F5)
-        assert framework_general.is_congruent(F5, F4)
+    with pytest.raises(ValueError):
+        assert framework_general.is_congruent(F6, F7)
 
-        with pytest.raises(ValueError):
-            assert framework_general.is_congruent(F6, F7)
-
-        # testing numerical congruence
-        assert not framework_general.is_congruent_realization(F4, R1)
-        assert framework_general.is_congruent_realization(F4, R1, numerical=True)
+    # testing numerical congruence
+    assert not framework_general.is_congruent_realization(F4, R1)
+    assert framework_general.is_congruent_realization(F4, R1, numerical=True)

--- a/test/framework/test__general.py
+++ b/test/framework/test__general.py
@@ -22,24 +22,7 @@ def test_is_injective():
     F1 = _to_FrameworkBase(F1)
 
     F2 = deepcopy(F1)
-    F2 = _to_FrameworkBase(F2)
     F2.set_vertex_pos(0, F2[1])
-
-    # test symbolical injectivity with irrational numbers
-    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
-    framework_transformations.rotate2D(F3, pi / 3, inplace=True)
-
-    # test numerical injectivity
-    F4 = deepcopy(F3)
-    F4.set_realization(F4.realization(numerical=True))
-
-    # test numerically not injective, but symbolically injective framework
-    F5 = deepcopy(F3)
-    F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
-
-    # test tolerance in numerical injectivity check
-    F6 = deepcopy(F3)
-    F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
 
     assert framework_general.is_injective(F1)
     assert framework_general.is_injective(F1, numerical=True)
@@ -48,19 +31,30 @@ def test_is_injective():
     assert not framework_general.is_injective(F2, numerical=True)
 
     # test symbolical injectivity with irrational numbers
+    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
+    framework_transformations.rotate2D(F3, pi / 3, inplace=True)
+
     assert framework_general.is_injective(F3)
     assert framework_general.is_injective(F3, numerical=True)
 
     # test numerical injectivity
+    F4 = deepcopy(F3)
+    F4.set_realization(F4.realization(numerical=True))
+
     assert framework_general.is_injective(F4, numerical=True)
 
     # test numerically not injective, but symbolically injective framework
+    F5 = deepcopy(F3)
+    F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
+
     assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
     assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
     assert framework_general.is_injective(F5)
 
     # test tolerance in numerical injectivity check
-    F6 = _to_FrameworkBase(F6)
+    F6 = deepcopy(F3)
+    F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
+
     assert framework_general.is_injective(F6, numerical=True, tolerance=1e-9)
     assert framework_general.is_injective(F6)
 
@@ -69,58 +63,48 @@ def test_is_quasi_injective():
     F1 = fws.Complete(4, 2)
     F1 = _to_FrameworkBase(F1)
 
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
+
     # test framework that is quasi-injective, but not injective
     F1.set_vertex_pos(1, F1[2])
     F1.delete_edge((1, 2))
+
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
 
     # test not quasi-injective framework
     F2 = deepcopy(F1)
     F2.set_vertex_pos(0, F2[1])
 
+    assert not framework_general.is_quasi_injective(F2)
+    assert not framework_general.is_quasi_injective(F2, numerical=True)
+
     # test symbolical and numerical quasi-injectivity with irrational numbers
     F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
     F3 = framework_transformations.rotate2D(F3, pi / 2, inplace=False)
+
+    assert framework_general.is_quasi_injective(F3)
+    assert framework_general.is_quasi_injective(F3, numerical=True)
 
     # test numerical quasi-injectivity
     F4 = deepcopy(F3)
     F4.set_realization(F4.realization(numerical=True))
 
+    assert framework_general.is_quasi_injective(F4, numerical=True)
+
     # test numerically not quasi-injective, but symbolically quasi-injective framework
     F5 = deepcopy(F3)
     F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
 
-    # test tolerance in numerical quasi-injectivity check
-    F6 = deepcopy(F3)
-    F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
-
-    assert framework_general.is_quasi_injective(F1)
-    assert framework_general.is_quasi_injective(F1, numerical=True)
-
-    # test framework that is quasi-injective, but not injective
-    F1 = fws.Complete(4, 2)
-    F1 = _to_FrameworkBase(F1)
-    F1.set_vertex_pos(1, F1[2])
-    F1.delete_edge((1, 2))
-    assert framework_general.is_quasi_injective(F1)
-    assert framework_general.is_quasi_injective(F1, numerical=True)
-
-    # test not quasi-injective framework
-    assert not framework_general.is_quasi_injective(F2)
-    assert not framework_general.is_quasi_injective(F2, numerical=True)
-
-    # test symbolical and numerical quasi-injectivity with irrational numbers
-    assert framework_general.is_quasi_injective(F3)
-    assert framework_general.is_quasi_injective(F3, numerical=True)
-
-    # test numerical quasi-injectivity
-    assert framework_general.is_quasi_injective(F4, numerical=True)
-
-    # test numerically not quasi-injective, but symbolically quasi-injective framework
     assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-8)
     assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-9)
     assert framework_general.is_quasi_injective(F5)
 
     # test tolerance in numerical quasi-injectivity check
+    F6 = deepcopy(F3)
+    F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
+
     assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
     assert framework_general.is_quasi_injective(F6)
 
@@ -179,9 +163,6 @@ def test_is_equivalent():
     F8 = _to_FrameworkBase(F8)
 
     F9 = framework_transformations.translate(F5, (pi, "2/3"), False)
-
-    # testing numerical equivalence
-
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F9.realization().items()}
 
     assert framework_general.is_equivalent_realization(
@@ -264,7 +245,6 @@ def test_is_congruent():
     F7 = fws.Complete(3, 2)
     F7 = _to_FrameworkBase(F7)
 
-    # testing numerical congruence
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F4.realization().items()}
 
     assert framework_general.is_congruent_realization(

--- a/test/framework/test__general.py
+++ b/test/framework/test__general.py
@@ -10,19 +10,24 @@ from pyrigi.framework import (
     Framework,
 )
 from pyrigi.framework import _general as framework_general
+from pyrigi.framework._transformations import (
+    transformations as framework_transformations,
+)
 from pyrigi.graph import Graph
 from test.framework import _to_FrameworkBase
 
 
 def test_is_injective():
     F1 = fws.Complete(4, 2)
+    F1 = _to_FrameworkBase(F1)
 
     F2 = deepcopy(F1)
+    F2 = _to_FrameworkBase(F2)
     F2.set_vertex_pos(0, F2[1])
 
     # test symbolical injectivity with irrational numbers
-    F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
-    F3.rotate2D(pi / 3, inplace=True)
+    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
+    framework_transformations.rotate2D(F3, pi / 3, inplace=True)
 
     # test numerical injectivity
     F4 = deepcopy(F3)
@@ -36,25 +41,20 @@ def test_is_injective():
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
 
-    F1 = _to_FrameworkBase(F1)
     assert framework_general.is_injective(F1)
     assert framework_general.is_injective(F1, numerical=True)
 
-    F2 = _to_FrameworkBase(F2)
     assert not framework_general.is_injective(F2)
     assert not framework_general.is_injective(F2, numerical=True)
 
     # test symbolical injectivity with irrational numbers
-    F3 = _to_FrameworkBase(F3)
     assert framework_general.is_injective(F3)
     assert framework_general.is_injective(F3, numerical=True)
 
     # test numerical injectivity
-    F4 = _to_FrameworkBase(F4)
     assert framework_general.is_injective(F4, numerical=True)
 
     # test numerically not injective, but symbolically injective framework
-    F5 = _to_FrameworkBase(F5)
     assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
     assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
     assert framework_general.is_injective(F5)
@@ -67,6 +67,7 @@ def test_is_injective():
 
 def test_is_quasi_injective():
     F1 = fws.Complete(4, 2)
+    F1 = _to_FrameworkBase(F1)
 
     # test framework that is quasi-injective, but not injective
     F1.set_vertex_pos(1, F1[2])
@@ -77,8 +78,8 @@ def test_is_quasi_injective():
     F2.set_vertex_pos(0, F2[1])
 
     # test symbolical and numerical quasi-injectivity with irrational numbers
-    F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
-    F3 = F3.rotate2D(pi / 2, inplace=False)
+    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
+    F3 = framework_transformations.rotate2D(F3, pi / 2, inplace=False)
 
     # test numerical quasi-injectivity
     F4 = deepcopy(F3)
@@ -92,60 +93,59 @@ def test_is_quasi_injective():
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
 
-    F1 = _to_FrameworkBase(F1)
     assert framework_general.is_quasi_injective(F1)
     assert framework_general.is_quasi_injective(F1, numerical=True)
 
     # test framework that is quasi-injective, but not injective
     F1 = fws.Complete(4, 2)
+    F1 = _to_FrameworkBase(F1)
     F1.set_vertex_pos(1, F1[2])
     F1.delete_edge((1, 2))
-    F1 = _to_FrameworkBase(F1)
     assert framework_general.is_quasi_injective(F1)
     assert framework_general.is_quasi_injective(F1, numerical=True)
 
     # test not quasi-injective framework
-    F2 = _to_FrameworkBase(F2)
     assert not framework_general.is_quasi_injective(F2)
     assert not framework_general.is_quasi_injective(F2, numerical=True)
 
     # test symbolical and numerical quasi-injectivity with irrational numbers
-    F3 = _to_FrameworkBase(F3)
     assert framework_general.is_quasi_injective(F3)
     assert framework_general.is_quasi_injective(F3, numerical=True)
 
     # test numerical quasi-injectivity
-    F4 = _to_FrameworkBase(F4)
     assert framework_general.is_quasi_injective(F4, numerical=True)
 
     # test numerically not quasi-injective, but symbolically quasi-injective framework
-    F5 = _to_FrameworkBase(F5)
     assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-8)
     assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-9)
     assert framework_general.is_quasi_injective(F5)
 
     # test tolerance in numerical quasi-injectivity check
-    F6 = _to_FrameworkBase(F6)
     assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
     assert framework_general.is_quasi_injective(F6)
 
 
 def test_is_equivalent():
     F1 = fws.Complete(4, 2)
+    F1 = _to_FrameworkBase(F1)
 
     F2 = fws.Complete(3, 2)
+    F2 = _to_FrameworkBase(F2)
 
     G1 = graphs.ThreePrism()
     G1.delete_vertex(5)
 
     F3 = Framework(G1, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "9/7"]})
+    F3 = _to_FrameworkBase(F3)
 
-    F4 = F3.translate((1, 1), inplace=False)
+    F4 = framework_transformations.translate(F3, (1, 1), inplace=False)
 
-    F5 = F3.rotate2D(pi / 2, inplace=False)
+    F5 = framework_transformations.rotate2D(F3, pi / 2, inplace=False)
 
     G2 = Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [3, 4]])
     F6 = Framework(G2, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "17/7"]})
+    F6 = _to_FrameworkBase(F6)
+
     F7 = Framework(
         G2,
         {
@@ -160,6 +160,8 @@ def test_is_equivalent():
             ],
         },
     )
+    F7 = _to_FrameworkBase(F7)
+
     F8 = Framework(
         G2,
         {
@@ -174,14 +176,14 @@ def test_is_equivalent():
             ],
         },
     )
+    F8 = _to_FrameworkBase(F8)
 
-    F9 = F5.translate((pi, "2/3"), False)
+    F9 = framework_transformations.translate(F5, (pi, "2/3"), False)
 
     # testing numerical equivalence
 
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F9.realization().items()}
 
-    F1 = _to_FrameworkBase(F1)
     assert framework_general.is_equivalent_realization(
         F1, F1.realization(), numerical=False
     )
@@ -190,32 +192,23 @@ def test_is_equivalent():
     )
     assert framework_general.is_equivalent(F1, F1)
 
-    F2 = _to_FrameworkBase(F2)
     with pytest.raises(ValueError):
         framework_general.is_equivalent_realization(F1, F2.realization())
 
     with pytest.raises(ValueError):
         framework_general.is_equivalent(F1, F2)
 
-    F3 = _to_FrameworkBase(F3)
-    F4 = _to_FrameworkBase(F4)
     assert framework_general.is_equivalent(F3, F4, numerical=True)
     assert framework_general.is_equivalent(F3, F4)
 
-    F5 = _to_FrameworkBase(F5)
     assert framework_general.is_equivalent(F5, F3)
     assert framework_general.is_equivalent(F5, F4)
     assert framework_general.is_equivalent_realization(F5, F4.realization())
-
-    F6 = _to_FrameworkBase(F6)
-    F7 = _to_FrameworkBase(F7)
-    F8 = _to_FrameworkBase(F8)
 
     assert framework_general.is_equivalent(F6, F7)
     assert framework_general.is_equivalent(F6, F8)
     assert framework_general.is_equivalent(F7, F8)
 
-    F9 = _to_FrameworkBase(F9)
     assert framework_general.is_equivalent(F5, F9)
 
     with pytest.raises(ValueError):
@@ -229,6 +222,8 @@ def test_is_equivalent():
 def test_is_congruent():
     G1 = Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [3, 4]])
     F1 = Framework(G1, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "17/7"]})
+    F1 = _to_FrameworkBase(F1)
+
     F2 = Framework(
         G1,
         {
@@ -243,6 +238,8 @@ def test_is_congruent():
             ],
         },
     )
+    F2 = _to_FrameworkBase(F2)
+
     F3 = Framework(
         G1,
         {
@@ -257,23 +254,19 @@ def test_is_congruent():
             ],
         },
     )
+    F3 = _to_FrameworkBase(F3)
 
-    F4 = F1.translate((pi, "2/3"), False)
-    F5 = F1.rotate2D(pi / 2, inplace=False)
+    F4 = framework_transformations.translate(F1, (pi, "2/3"), False)
+    F5 = framework_transformations.rotate2D(F1, pi / 2, inplace=False)
 
     F6 = fws.Complete(4, 2)
+    F6 = _to_FrameworkBase(F6)
     F7 = fws.Complete(3, 2)
+    F7 = _to_FrameworkBase(F7)
 
     # testing numerical congruence
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F4.realization().items()}
 
-    F1 = _to_FrameworkBase(F1)
-    F2 = _to_FrameworkBase(F2)
-    F3 = _to_FrameworkBase(F3)
-    F4 = _to_FrameworkBase(F4)
-    F5 = _to_FrameworkBase(F5)
-    F6 = _to_FrameworkBase(F6)
-    F7 = _to_FrameworkBase(F7)
     assert framework_general.is_congruent_realization(
         F1, F1.realization(), numerical=False
     )

--- a/test/framework/transformations/test_transformations.py
+++ b/test/framework/transformations/test_transformations.py
@@ -8,68 +8,45 @@ from pyrigi.framework._general import is_congruent_realization
 from pyrigi.framework._transformations import (
     transformations as framework_transformations,
 )
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
 def test_translate():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.translate((0, 0), False)
+    newF = framework_transformations.translate(F, (0, 0), False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
     translation = Matrix([[1], [1]])
-    newF = F.translate(translation, False)
+    newF = framework_transformations.translate(F, translation, False)
     assert newF[0].equals(F[0] + translation)
     assert newF[1].equals(F[1] + translation)
     assert newF[2].equals(F[2] + translation)
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.translate(F, (0, 0), False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        translation = Matrix([[1], [1]])
-        newF = framework_transformations.translate(F, translation, False)
-        assert newF[0].equals(F[0] + translation)
-        assert newF[1].equals(F[1] + translation)
-        assert newF[2].equals(F[2] + translation)
 
 
 def test_rescale():
     G = graphs.Complete(4)
     F = Framework(G, {0: (-1, 0), 1: (2, 0), 2: (1, 1), 3: (3, -2)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.rescale(1, False)
+    newF = framework_transformations.rescale(F, 1, False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rescale(2, False)
+    newF = framework_transformations.rescale(F, 2, False)
     assert newF[0].equals(Matrix([p * 2 for p in F[0]]))
     assert newF[1].equals(Matrix([p * 2 for p in F[1]]))
     assert newF[2].equals(Matrix([p * 2 for p in F[2]]))
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (-1, 0), 1: (2, 0), 2: (1, 1), 3: (3, -2)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rescale(F, 1, False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rescale(F, 2, False)
-        assert newF[0].equals(Matrix([p * 2 for p in F[0]]))
-        assert newF[1].equals(Matrix([p * 2 for p in F[1]]))
-        assert newF[2].equals(Matrix([p * 2 for p in F[2]]))
-
 
 def test_projected_realization():
     F = fws.Complete(4, dim=3)
-    _r = F.projected_realization(
-        proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
+    F = _to_FrameworkBase(F)
+    _r = framework_transformations.projected_realization(
+        F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
     )
     assert (
         len(_r) == 2
@@ -80,143 +57,87 @@ def test_projected_realization():
         and _r[0][3] == (1, 1)
     )
 
-    _r = F.projected_realization(
-        proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    _r = framework_transformations.projected_realization(
+        F, proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     )
     assert (
         len(_r) == 2
         and all([len(val) == 3 for val in _r[0].values()])
-        and F.is_congruent_realization(_r[0])
+        and is_congruent_realization(F, _r[0])
     )
 
     with pytest.raises(ValueError):
-        F.projected_realization(proj_dim=2, projection_matrix=Matrix([[0, 1, 1]]))
-        F.projected_realization(proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]]))
+        framework_transformations.projected_realization(
+            F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1]])
+        )
+        framework_transformations.projected_realization(
+            F, proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]])
+        )
 
     F = fws.Complete(6, dim=5)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.projected_realization(proj_dim=4)
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
-        _r = framework_transformations.projected_realization(
-            F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
-        )
-        assert (
-            len(_r) == 2
-            and all([len(val) == 2 for val in _r[0].values()])
-            and _r[0][0] == (0, 0)
-            and _r[0][1] == (0, 1)
-            and _r[0][2] == (1, 0)
-            and _r[0][3] == (1, 1)
-        )
-
-        _r = framework_transformations.projected_realization(
-            F, proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        )
-        assert (
-            len(_r) == 2
-            and all([len(val) == 3 for val in _r[0].values()])
-            and is_congruent_realization(F, _r[0])
-        )
-
-        with pytest.raises(ValueError):
-            framework_transformations.projected_realization(
-                F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1]])
-            )
-            framework_transformations.projected_realization(
-                F, proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]])
-            )
-
-        F = fws.Complete(6, dim=5)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_transformations.projected_realization(F, proj_dim=4)
+        framework_transformations.projected_realization(F, proj_dim=4)
 
 
 def test_rotate2D():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-
-    newF = F.rotate2D(0, inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate2D(F, 0, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate2D(pi * 4, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi * 4, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate2D(pi / 2, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi / 2, inplace=False)
     assert newF[0].equals(Matrix([[0], [0]]))
     assert newF[1].equals(Matrix([[0], [2]]))
     assert newF[2].equals(Matrix([[-1], [1]]))
 
-    newF = F.rotate2D(pi / 4, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi / 4, inplace=False)
     assert newF[0].equals(Matrix([[0], [0]]))
     assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)]]))
     assert newF[2].equals(Matrix([[0], [sqrt(2)]]))
 
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (0, 2)})
-    newF = F.rotate2D(pi, rotation_center=[1, 1], inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate2D(
+        F, pi, rotation_center=[1, 1], inplace=False
+    )
     assert newF[0].equals(Matrix([[2], [2]]))
     assert newF[1].equals(Matrix([[0], [2]]))
     assert newF[2].equals(Matrix([[2], [0]]))
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rotate2D(F, 0, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate2D(F, pi * 4, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate2D(F, pi / 2, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0]]))
-        assert newF[1].equals(Matrix([[0], [2]]))
-        assert newF[2].equals(Matrix([[-1], [1]]))
-
-        newF = framework_transformations.rotate2D(F, pi / 4, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0]]))
-        assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)]]))
-        assert newF[2].equals(Matrix([[0], [sqrt(2)]]))
-
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (0, 2)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rotate2D(
-            F, pi, rotation_center=[1, 1], inplace=False
-        )
-        assert newF[0].equals(Matrix([[2], [2]]))
-        assert newF[1].equals(Matrix([[0], [2]]))
-        assert newF[2].equals(Matrix([[2], [0]]))
 
 
 def test_rotate3D():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (1, 1, 0)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.rotate3D(0, inplace=False)
+    newF = framework_transformations.rotate3D(F, 0, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate3D(pi * 4, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi * 4, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate3D(pi / 2, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi / 2, inplace=False)
     assert newF[0].equals(Matrix([[0], [0], [0]]))
     assert newF[1].equals(Matrix([[0], [2], [0]]))
     assert newF[2].equals(Matrix([[-1], [1], [0]]))
 
-    newF = F.rotate3D(pi / 4, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi / 4, inplace=False)
     assert newF[0].equals(Matrix([[0], [0], [0]]))
     assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)], [0]]))
     assert newF[2].equals(Matrix([[0], [sqrt(2)], [0]]))
 
-    F.rotate3D(pi / 2, axis_direction=[0, 1, 0], inplace=True)
+    framework_transformations.rotate3D(
+        F, pi / 2, axis_direction=[0, 1, 0], inplace=True
+    )
     assert F[0].equals(Matrix([[0], [0], [0]]))
     assert F[1].equals(Matrix([[0], [0], [-2]]))
     assert F[2].equals(Matrix([[0], [1], [-1]]))
@@ -237,49 +158,3 @@ def test_rotate3D():
     assert F[0].equals(Matrix([[2], [2], [0]]))
     assert F[1].equals(Matrix([[0], [2], [0]]))
     assert F[2].equals(Matrix([[2], [0], [0]]))
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (1, 1, 0)})
-        F = _to_FrameworkBase(F)
-
-        newF = framework_transformations.rotate3D(F, 0, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate3D(F, pi * 4, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate3D(F, pi / 2, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0], [0]]))
-        assert newF[1].equals(Matrix([[0], [2], [0]]))
-        assert newF[2].equals(Matrix([[-1], [1], [0]]))
-
-        newF = framework_transformations.rotate3D(F, pi / 4, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0], [0]]))
-        assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)], [0]]))
-        assert newF[2].equals(Matrix([[0], [sqrt(2)], [0]]))
-
-        framework_transformations.rotate3D(
-            F, pi / 2, axis_direction=[0, 1, 0], inplace=True
-        )
-        assert F[0].equals(Matrix([[0], [0], [0]]))
-        assert F[1].equals(Matrix([[0], [0], [-2]]))
-        assert F[2].equals(Matrix([[0], [1], [-1]]))
-
-        F = Framework(G, {0: (1, 0, 0), 1: (0, 1, 0), 2: (0, 0, 1)})
-        newF = F.rotate3D(2 * pi / 3, axis_direction=[1, 1, 1], inplace=False)
-        assert newF[0].equals(Matrix([[0], [1], [0]]))
-        assert newF[1].equals(Matrix([[0], [0], [1]]))
-        assert newF[2].equals(Matrix([[1], [0], [0]]))
-
-        F.rotate3D(4 * pi / 3, axis_direction=[1, 1, 1], inplace=True)
-        assert F[0].equals(Matrix([[0], [0], [1]]))
-        assert F[1].equals(Matrix([[1], [0], [0]]))
-        assert F[2].equals(Matrix([[0], [1], [0]]))
-
-        F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (0, 2, 0)})
-        F.rotate3D(pi, axis_shift=[1, 1, 0], inplace=True)
-        assert F[0].equals(Matrix([[2], [2], [0]]))
-        assert F[1].equals(Matrix([[0], [2], [0]]))
-        assert F[2].equals(Matrix([[2], [0], [0]]))

--- a/test/framework/transformations/test_transformations.py
+++ b/test/framework/transformations/test_transformations.py
@@ -143,18 +143,24 @@ def test_rotate3D():
     assert F[2].equals(Matrix([[0], [1], [-1]]))
 
     F = Framework(G, {0: (1, 0, 0), 1: (0, 1, 0), 2: (0, 0, 1)})
-    newF = F.rotate3D(2 * pi / 3, axis_direction=[1, 1, 1], inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate3D(
+        F, 2 * pi / 3, axis_direction=[1, 1, 1], inplace=False
+    )
     assert newF[0].equals(Matrix([[0], [1], [0]]))
     assert newF[1].equals(Matrix([[0], [0], [1]]))
     assert newF[2].equals(Matrix([[1], [0], [0]]))
 
-    F.rotate3D(4 * pi / 3, axis_direction=[1, 1, 1], inplace=True)
+    framework_transformations.rotate3D(
+        F, 4 * pi / 3, axis_direction=[1, 1, 1], inplace=True
+    )
     assert F[0].equals(Matrix([[0], [0], [1]]))
     assert F[1].equals(Matrix([[1], [0], [0]]))
     assert F[2].equals(Matrix([[0], [1], [0]]))
 
     F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (0, 2, 0)})
-    F.rotate3D(pi, axis_shift=[1, 1, 0], inplace=True)
+    F = _to_FrameworkBase(F)
+    framework_transformations.rotate3D(F, pi, axis_shift=[1, 1, 0], inplace=True)
     assert F[0].equals(Matrix([[2], [2], [0]]))
     assert F[1].equals(Matrix([[0], [2], [0]]))
     assert F[2].equals(Matrix([[2], [0], [0]]))


### PR DESCRIPTION
## Summary
- `test_wrapper_parameter_forwarding` (#393) now generically verifies that every
  `@copy_doc` wrapper correctly forwards to its module-level function, making the
  per-test `if TEST_WRAPPED_FUNCTIONS:` duplicate assertions redundant.
- Removes those blocks from the framework tests, keeping the direct
  module-function calls and dropping the now-unused `TEST_WRAPPED_FUNCTIONS` import.

Files: `test_export.py`, `test_plot.py`, `test_infinitesimal.py`,
`test_matroidal.py`, `test_redundant.py`, `test_second_order.py`, `test_stress.py`,
`test__general.py`, `test_transformations.py` (47 blocks total).

## Test plan
- `pytest test/framework -q` passes
- Full suite matches baseline (no new failures)

