### PR TITLE
Test: Verified function wrapping and removed method tests

### DIFF
--- a/doc/development/howto/package_structure.md
+++ b/doc/development/howto/package_structure.md
@@ -87,17 +87,6 @@ accept {class}`pyrigi.framework.base.FrameworkBase` as the first parameter, call
 are wrapped as methods of {class}`pyrigi.Framework<.Framework>`,
 which is inherited from {class}`pyrigi.framework.base.FrameworkBase`.
 
-## Correct wrapping checks
-
-The test `test_signature` in `test/test_signature.py` checks whether the signatures
-of the methods and the wrapped function match.
-Hereby, "match" means that the parameters are the same, have the same default values,
-and have the same type (or inherited type).
-
-The plugin [`flake8-unused-arguments`](https://github.com/nhoad/flake8-unused-arguments) guarantees that all arguments of each method are indeed used when calling the wrapped function.
-This plugin is automatically used (calling `flake8`) once dependences are installed [via Poetry](#dependencies-poetry).
-
-
 ## Overview
 
 ```{literalinclude} ./pyrigi_structure.txt

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -18,12 +18,14 @@ Please, follow this naming convention for tests of a specific function/method:
 | `is_bar`  | `test_is_bar`    | that property `bar` holds
 | `is_bar`  | `test_is_not_bar`| that property `bar` does not hold
 
-There can be also more complex tests, i.e., testing more than a single method;
+There can be also more complex tests, i.e., testing more than a single function;
 please, choose a reasonable name for them following the idea above.
 
-Moreover, please add a section `EXAMPLES` in the docstring of the classes and methods that you introduce and provide there examples of the functionalities you implemented.
+Moreover, please add a section `EXAMPLES` in the docstring of the classes and functions
+that you introduce and provide there examples of the functionalities you implemented.
 
-Please keep in mind that whenever a pull request is opened, all the tests in the `test` folder and in the docstrings are run.
+Please keep in mind that, whenever a pull request is opened,
+all the tests in the `test` folder and in the docstrings are run.
 Therefore, before opening a pull request we **strongly advise** to run
 ```
 pytest
@@ -35,6 +37,35 @@ If you do not want to run doctests, run
 ```
 pytest -p no:doctestplus
 ```
+
+## Function vs. method testing
+
+As described in [Package Structure](#pkg_structure), most of the functionality of
+the classes {class}`.Graph` and {class}`.Framework` is implemented
+via functions in various modules, which are then wrapped as methods.
+Thanks to the tests described below, only the functions need
+to be tested as the wrapping is guaranteed to be correct.
+
+The test `test_signature` in `test/test_signature.py` checks whether the signatures
+of the methods and the wrapped function match.
+Hereby, "match" means that the parameters are the same, have the same default values,
+and have the same type (or inherited type).
+
+The plugin [`flake8-unused-arguments`](https://github.com/nhoad/flake8-unused-arguments)
+guarantees that all arguments of each method are indeed used when calling the wrapped
+function. This plugin is automatically used (calling `flake8`) once dependencies are
+installed [via Poetry](#dependencies-poetry).
+
+In addition, tests that verify correct wrapping are found in `test/wrapper/test_wrapper.py`.
+This test suite checks systematically that all
+`@copy_doc`-decorated methods of {class}`.Graph` and {class}`.Framework` correctly forward arguments
+to the underlying functions. It creates various mock arguments, invokes the method,
+and asserts that all parameters are properly passed through, both in name and value.
+
+The suite also includes negative tests using intentionally broken wrappers (see
+`test.wrapper._bad_wrapper._BadWrapper`), which verify that common mistakes in wrapping
+(such as missing, extra, or reordered arguments, or wrong function calls) are detected
+by the test helpers.
 
 ## Markers
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,3 @@
-TEST_WRAPPED_FUNCTIONS = True
-
-
 def is_marker_selected(config, marker_name: str) -> bool:
     """Return if the given marker is selected."""
     expr = config.getoption("-m")

--- a/test/framework/export/test_export.py
+++ b/test/framework/export/test_export.py
@@ -3,7 +3,6 @@ import pytest
 from pyrigi.framework import Framework
 from pyrigi.framework._export import export as framework_export
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -44,10 +43,7 @@ def test__generate_stl_bar_error(holes_dist, holes_diam, bar_w, bar_h):
 def test_generate_stl_bars():
     G = Graph([(0, 1), (1, 2), (2, 3), (0, 3)])
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [1, "1/2 * sqrt(5)"], 3: [1 / 2, "4/3"]})
-    assert F.generate_stl_bars(scale=20, filename_prefix="mybar") is None
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        assert (
-            framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar")
-            is None
-        )
+    F = _to_FrameworkBase(F)
+    assert (
+        framework_export.generate_stl_bars(F, scale=20, filename_prefix="mybar") is None
+    )

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -7,7 +7,8 @@ import pyrigi.frameworkDB as fws
 import pyrigi.graphDB as graphs
 from pyrigi.framework import Framework
 from pyrigi.framework._plot import plot as framework_plot
-from test import TEST_WRAPPED_FUNCTIONS
+from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
+from pyrigi.framework._rigidity import stress as stress_rigidity
 from test.framework import _to_FrameworkBase
 
 
@@ -21,213 +22,124 @@ from test.framework import _to_FrameworkBase
 )
 def test_plot_error(realization):
     F = Framework(graphs.Complete(2), realization)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot()
+        framework_plot.plot(F)
 
     plt.close()
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot(F)
-
-        plt.close()
 
 
 def test_plot():
     F = Framework(graphs.Complete(2), {0: [1, 0], 1: [0, 1]})
-    F.plot()
+    F = _to_FrameworkBase(F)
+    framework_plot.plot(F)
 
     F = Framework(graphs.Complete(2), {0: [1, 0, 0], 1: [0, 1, 1]})
-    F.plot()
+    F = _to_FrameworkBase(F)
+    framework_plot.plot(F)
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0], 1: [0, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot(F)
-
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0], 1: [0, 1, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot(F)
-
-        plt.close("all")
 
 
 def test_plot2D():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(projection_matrix=[[1, 0], [0, 1], [0, 0]])
-    F.plot2D(projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
+        framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1], [0, 0]])
+    framework_plot.plot2D(F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
 
     F = Framework(graphs.Complete(2), {0: [0, 0, 0], 1: [1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(projection_matrix=[[1, 0], [0, 1]])
-    F.plot2D()
+        framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1]])
+    framework_plot.plot2D(F)
 
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot2D(inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
-    F.plot2D(inf_flex=0)
-    F.plot2D(inf_flex=F.inf_flexes()[0])
-    F.plot2D(inf_flex=F.inf_flexes(numerical=True)[0])
-    F.plot2D(inf_flex=0, fixed_vertices=[0])
-    F.plot2D(inf_flex=0, fixed_vertices=[0, 1])
+        framework_plot.plot2D(F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]})
+    framework_plot.plot2D(F, inf_flex=0)
+    framework_plot.plot2D(F, inf_flex=infinitesimal_rigidity.inf_flexes(F)[0])
+    framework_plot.plot2D(
+        F, inf_flex=infinitesimal_rigidity.inf_flexes(F, numerical=True)[0]
+    )
+    framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
+    framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Complete(4)
-    F.plot2D(stress=0, dpi=200, filename="K4_Test_output")
+    F = _to_FrameworkBase(F)
+    framework_plot.plot2D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    F.plot2D(stress=F.stresses()[0])
-    F.plot2D(stress=F.stresses(numerical=True)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
-    F.plot2D(stress=0)
-    F.plot2D(stress=F.stresses()[0])
-    F.plot2D(stress=F.stresses(numerical=True)[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot2D(F, stress=0)
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot2D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1], [0, 0]])
-        framework_plot.plot2D(F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0]])
-
-        F = Framework(graphs.Complete(2), {0: [0, 0, 0], 1: [1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(F, projection_matrix=[[1, 0], [0, 1]])
-        framework_plot.plot2D(F)
-
-        F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot2D(
-                F, inf_flex={0: [-1, 0, 0], 1: [1, 0, 0], 2: [0, 0, 0]}
-            )
-        framework_plot.plot2D(F, inf_flex=0)
-        framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F)[0])
-        framework_plot.plot2D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
-        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0])
-        framework_plot.plot2D(F, inf_flex=0, fixed_vertices=[0, 1])
-
-        F = fws.Complete(4)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot2D(F, stress=0, dpi=200, filename="K4_Test_output")
-        os.remove("K4_Test_output.png")
-        framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        F = fws.Complete(4, dim=1)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot2D(F, stress=0)
-        framework_plot.plot2D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot2D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        plt.close("all")
 
 
 def test_plot3D():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot3D(projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]])
-    F.plot3D()
+        framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]])
+    framework_plot.plot3D(F)
 
     F = Framework(graphs.Complete(2), {0: [0, 0, 0, 0], 1: [1, 0, 0, 0]})
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.plot3D(projection_matrix=[[1, 0, 0], [0, 0, 1]])
-    F.plot3D(projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]])
+        framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1]])
+    framework_plot.plot3D(
+        F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
+    )
 
     F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-    F.plot3D(inf_flex=0)
-    F.plot3D(inf_flex=F.inf_flexes()[0])
-    F.plot3D(inf_flex=F.inf_flexes(numerical=True)[0])
-    F.plot3D(inf_flex=0, fixed_vertices=[0, 1])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, inf_flex=0)
+    framework_plot.plot3D(F, inf_flex=infinitesimal_rigidity.inf_flexes(F)[0])
+    framework_plot.plot3D(
+        F, inf_flex=infinitesimal_rigidity.inf_flexes(F, numerical=True)[0]
+    )
+    framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
 
     F = fws.Octahedron(realization="Bricard_plane")
-    F.plot3D(inf_flex=0, stress=0)
-    F.plot3D(inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, inf_flex=0, stress=0)
+    framework_plot.plot3D(
+        F, inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0]
+    )
 
     F = fws.Complete(4)
-    F.plot3D(stress=0, dpi=200, filename="K4_Test_output")
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, stress=0, dpi=200, filename="K4_Test_output")
     os.remove("K4_Test_output.png")
-    F.plot3D(stress=F.stresses()[0])
-    F.plot3D(stress=F.stresses(numerical=True)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     F = fws.Complete(4, dim=1)
-    F.plot3D(stress=0)
-    F.plot3D(stress=F.stresses()[0])
-    F.plot3D(stress=F.stresses(numerical=True)[0])
+    F = _to_FrameworkBase(F)
+    framework_plot.plot3D(F, stress=0)
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F)[0])
+    framework_plot.plot3D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
 
     plt.close("all")
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(graphs.Complete(2), {0: [1, 0, 0, 0], 1: [0, 1, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot3D(
-                F, projection_matrix=[[1, 0, 0], [0, 0, 1], [0, 0, 0]]
-            )
-        framework_plot.plot3D(F)
-
-        F = Framework(graphs.Complete(2), {0: [0, 0, 0, 0], 1: [1, 0, 0, 0]})
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.plot3D(F, projection_matrix=[[1, 0, 0], [0, 0, 1]])
-        framework_plot.plot3D(
-            F, projection_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]
-        )
-
-        F = Framework(graphs.Path(3), {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 1]})
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, inf_flex=0)
-        framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F)[0])
-        framework_plot.plot3D(F, inf_flex=Framework.inf_flexes(F, numerical=True)[0])
-        framework_plot.plot3D(F, inf_flex=0, fixed_vertices=[0, 1])
-
-        F = fws.Octahedron(realization="Bricard_plane")
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, inf_flex=0, stress=0)
-        framework_plot.plot3D(
-            F, inf_flex=0, stress=0, fixed_vertices=F._graph.edge_list()[0]
-        )
-
-        F = fws.Complete(4)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, stress=0, dpi=200, filename="K4_Test_output")
-        os.remove("K4_Test_output.png")
-        framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        F = fws.Complete(4, dim=1)
-        F = _to_FrameworkBase(F)
-        framework_plot.plot3D(F, stress=0)
-        framework_plot.plot3D(F, stress=Framework.stresses(F)[0])
-        framework_plot.plot3D(F, stress=Framework.stresses(F, numerical=True)[0])
-
-        plt.close("all")
 
 
 def test_animate3D_rotation():
     F = fws.Complete(4, dim=3)
-    F.animate3D_rotation()
+    F = _to_FrameworkBase(F)
+    framework_plot.animate3D_rotation(F)
 
     F = fws.Complete(3)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.animate3D_rotation()
-
-    F = fws.Complete(5, dim=4)
-    with pytest.raises(ValueError):
-        F.animate3D_rotation()
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
         framework_plot.animate3D_rotation(F)
 
-        F = fws.Complete(3)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.animate3D_rotation(F)
-
-        F = fws.Complete(5, dim=4)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_plot.animate3D_rotation(F)
+    F = fws.Complete(5, dim=4)
+    F = _to_FrameworkBase(F)
+    with pytest.raises(ValueError):
+        framework_plot.animate3D_rotation(F)

--- a/test/framework/rigidity/test_infinitesimal.py
+++ b/test/framework/rigidity/test_infinitesimal.py
@@ -8,7 +8,6 @@ from pyrigi._utils._zero_check import is_zero_vector
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -48,13 +47,10 @@ from test.framework import _to_FrameworkBase
     + [fws.Complete(n + 1, dim=n) for n in range(1, 10)],
 )
 def test_is_inf_rigid(framework):
-    assert framework.is_inf_rigid()
-    assert framework.is_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_inf_rigid(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_inf_rigid(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -86,13 +82,10 @@ def test_is_inf_rigid(framework):
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 10)],
 )
 def test_is_inf_flexible(framework):
-    assert framework.is_inf_flexible()
-    assert framework.is_inf_flexible(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_inf_flexible(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_inf_flexible(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_inf_flexible(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_inf_flexible(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -118,13 +111,10 @@ def test_is_inf_flexible(framework):
     + [fws.Complete(n + 1, dim=n) for n in range(1, 7)],
 )
 def test_is_min_inf_rigid(framework):
-    assert framework.is_min_inf_rigid()
-    assert framework.is_min_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
-        assert infinitesimal_rigidity.is_min_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
+    assert infinitesimal_rigidity.is_min_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -166,375 +156,236 @@ def test_is_min_inf_rigid(framework):
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_not_min_inf_rigid(framework):
-    assert not framework.is_min_inf_rigid()
-    assert not framework.is_min_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
-        assert not infinitesimal_rigidity.is_min_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not infinitesimal_rigidity.is_min_inf_rigid(_to_FrameworkBase(framework))
+    assert not infinitesimal_rigidity.is_min_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 def test_inf_flexes():
-    Q1 = Matrix.hstack(*(fws.Complete(2, 2).inf_flexes(include_trivial=True)))
-    Q2 = Matrix.hstack(*(fws.Complete(2, 2).trivial_inf_flexes()))
+    F1 = _to_FrameworkBase(fws.Complete(2, 2))
+    Q1 = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F1, include_trivial=True)))
+    Q2 = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F1)))
     assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-    assert len(fws.Square().inf_flexes(include_trivial=False)) == 1
+    F2 = _to_FrameworkBase(fws.Square())
+    assert len(infinitesimal_rigidity.inf_flexes(F2, include_trivial=False)) == 1
 
     F = fws.ThreePrism(realization="flexible")
+    F = _to_FrameworkBase(F)
     C = Framework(graphs.Complete(6), realization=F.realization())
+    C = _to_FrameworkBase(C)
     explicit_flex = sympify(
         [0, 0, 0, 0, 0, 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0]
     )
     assert (
-        F.is_vector_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex, numerical=True)
-        and F.is_nontrivial_flex(explicit_flex, numerical=True)
+        infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex, numerical=True
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(F, explicit_flex, numerical=True)
     )
     explicit_flex_reorder = sympify(
         ["-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, 0, 0, 0, 0, 0, 0]
     )
     assert (
-        F.is_vector_inf_flex(explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1])
-        and F.is_vector_nontrivial_inf_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
+        infinitesimal_rigidity.is_vector_inf_flex(
+            F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
         )
-        and F.is_vector_nontrivial_inf_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1], numerical=True
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
         )
-        and F.is_nontrivial_flex(
-            explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1], numerical=True
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F,
+            explicit_flex_reorder,
+            vertex_order=[5, 4, 3, 0, 2, 1],
+            numerical=True,
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(
+            F,
+            explicit_flex_reorder,
+            vertex_order=[5, 4, 3, 0, 2, 1],
+            numerical=True,
         )
     )
-    QF = Matrix.hstack(*(F.nontrivial_inf_flexes()))
-    QC = Matrix.hstack(*(C.nontrivial_inf_flexes()))
+    QF = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F)))
+    QC = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(C)))
     assert QF.rank() == 1 and QC.rank() == 0
-    assert F.trivial_inf_flexes() == C.trivial_inf_flexes()
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=True)))
-    QC = Matrix.hstack(*(F.trivial_inf_flexes()))
+    assert infinitesimal_rigidity.trivial_inf_flexes(
+        F
+    ) == infinitesimal_rigidity.trivial_inf_flexes(C)
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=True)))
+    QC = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F)))
     Q_exp = Matrix(explicit_flex)
     assert Matrix.hstack(QF, QC).rank() == 4
     assert Matrix.hstack(QF, Q_exp).rank() == 4
 
     F = fws.Path(4)
-    for inf_flex in F.nontrivial_inf_flexes():
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F):
         dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(
-            dict_flex
-        )
-    assert Matrix.hstack(*(F.nontrivial_inf_flexes())).rank() == 2
+        assert infinitesimal_rigidity.is_dict_inf_flex(
+            F, dict_flex
+        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
+    assert Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank() == 2
 
     F = fws.Frustum(4)
+    F = _to_FrameworkBase(F)
     explicit_flex = [1, 0, 0, -1, 0, -1, 1, 0, 1, -1, 1, -1, 0, 0, 0, 0]
     assert (
-        F.is_vector_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex)
-        and F.is_vector_nontrivial_inf_flex(explicit_flex, numerical=True)
-        and F.is_nontrivial_flex(explicit_flex, numerical=True)
+        infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
+        and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
+            F, explicit_flex, numerical=True
+        )
+        and infinitesimal_rigidity.is_nontrivial_flex(F, explicit_flex, numerical=True)
     )
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=True)))
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=True)))
     Q_exp = Matrix(explicit_flex)
     assert QF.rank() == 5 and Matrix.hstack(QF, Q_exp).rank() == 5
-    QF = Matrix.hstack(*(F.inf_flexes(include_trivial=False)))
+    QF = Matrix.hstack(*(infinitesimal_rigidity.inf_flexes(F, include_trivial=False)))
     assert QF.rank() == 2 and Matrix.hstack(QF, Q_exp).rank() == 2
 
     F = fws.Complete(5)
-    F_triv = F.trivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    F_triv = infinitesimal_rigidity.trivial_inf_flexes(F)
     for inf_flex in F_triv:
         dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(dict_flex) and F.is_dict_trivial_inf_flex(dict_flex)
-    F_all = F.inf_flexes(include_trivial=True)
+        assert infinitesimal_rigidity.is_dict_inf_flex(
+            F, dict_flex
+        ) and infinitesimal_rigidity.is_dict_trivial_inf_flex(F, dict_flex)
+    F_all = infinitesimal_rigidity.inf_flexes(F, include_trivial=True)
     assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
 
     F = Framework.Random(graphs.DoubleBanana(), dim=3)
-    inf_flexes = F.nontrivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
     assert Matrix.hstack(*inf_flexes).rank() == 1
 
     G = graphs.Complete(3)
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
     assert Matrix.hstack(*inf_flexes).rank() == 1
 
     G = graphs.Complete(4)
     F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
-    inf_flexes = F.nontrivial_inf_flexes()
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(dict_flex) and F.is_dict_nontrivial_inf_flex(dict_flex)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
     assert Matrix.hstack(*inf_flexes).rank() == 1
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(fws.Complete(2, 2))
-        Q1 = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F1, include_trivial=True))
-        )
-        Q2 = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F1)))
-        assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-        F2 = _to_FrameworkBase(fws.Square())
-        assert len(infinitesimal_rigidity.inf_flexes(F2, include_trivial=False)) == 1
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        C = Framework(graphs.Complete(6), realization=F.realization())
-        C = _to_FrameworkBase(C)
-        explicit_flex = sympify(
-            [0, 0, 0, 0, 0, 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0]
-        )
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex, numerical=True
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F, explicit_flex, numerical=True
-            )
-        )
-        explicit_flex_reorder = sympify(
-            ["-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, "-sqrt(2)*pi", 0, 0, 0, 0, 0, 0, 0]
-        )
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(
-                F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
-            )
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex_reorder, vertex_order=[5, 4, 3, 0, 2, 1]
-            )
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F,
-                explicit_flex_reorder,
-                vertex_order=[5, 4, 3, 0, 2, 1],
-                numerical=True,
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F,
-                explicit_flex_reorder,
-                vertex_order=[5, 4, 3, 0, 2, 1],
-                numerical=True,
-            )
-        )
-        QF = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F)))
-        QC = Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(C)))
-        assert QF.rank() == 1 and QC.rank() == 0
-        assert infinitesimal_rigidity.trivial_inf_flexes(
-            F
-        ) == infinitesimal_rigidity.trivial_inf_flexes(C)
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=True))
-        )
-        QC = Matrix.hstack(*(infinitesimal_rigidity.trivial_inf_flexes(F)))
-        Q_exp = Matrix(explicit_flex)
-        assert Matrix.hstack(QF, QC).rank() == 4
-        assert Matrix.hstack(QF, Q_exp).rank() == 4
-
-        F = fws.Path(4)
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F):
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex
-            ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
-        assert (
-            Matrix.hstack(*(infinitesimal_rigidity.nontrivial_inf_flexes(F))).rank()
-            == 2
-        )
-
-        F = fws.Frustum(4)
-        F = _to_FrameworkBase(F)
-        explicit_flex = [1, 0, 0, -1, 0, -1, 1, 0, 1, -1, 1, -1, 0, 0, 0, 0]
-        assert (
-            infinitesimal_rigidity.is_vector_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(F, explicit_flex)
-            and infinitesimal_rigidity.is_vector_nontrivial_inf_flex(
-                F, explicit_flex, numerical=True
-            )
-            and infinitesimal_rigidity.is_nontrivial_flex(
-                F, explicit_flex, numerical=True
-            )
-        )
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=True))
-        )
-        Q_exp = Matrix(explicit_flex)
-        assert QF.rank() == 5 and Matrix.hstack(QF, Q_exp).rank() == 5
-        QF = Matrix.hstack(
-            *(infinitesimal_rigidity.inf_flexes(F, include_trivial=False))
-        )
-        assert QF.rank() == 2 and Matrix.hstack(QF, Q_exp).rank() == 2
-
-        F = fws.Complete(5)
-        F = _to_FrameworkBase(F)
-        F_triv = infinitesimal_rigidity.trivial_inf_flexes(F)
-        for inf_flex in F_triv:
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex
-            ) and infinitesimal_rigidity.is_dict_trivial_inf_flex(F, dict_flex)
-        F_all = infinitesimal_rigidity.inf_flexes(F, include_trivial=True)
-        assert Matrix.hstack(*F_triv).rank() == Matrix.hstack(*(F_all + F_triv)).rank()
-
-        F = Framework.Random(graphs.DoubleBanana(), dim=3)
-        F = _to_FrameworkBase(F)
-        inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F)
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flexes[0]
-        )
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, dict_flex
-        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(F, dict_flex)
-        assert Matrix.hstack(*inf_flexes).rank() == 1
 
 
 def test_inf_flexes_numerical():
     F = fws.ThreePrism(realization="flexible")
+    F = _to_FrameworkBase(F)
     C = Framework(graphs.Complete(6), realization=F.realization())
-    QF = np.hstack(F.nontrivial_inf_flexes(numerical=True))
-    QC = C.nontrivial_inf_flexes(numerical=True)
+    C = _to_FrameworkBase(C)
+    QF = np.hstack(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
+    QC = infinitesimal_rigidity.nontrivial_inf_flexes(C, numerical=True)
     assert np.linalg.matrix_rank(QF) == 1 and len(QC) == 0
 
     F = fws.Path(4)
-    for inf_flex in F.nontrivial_inf_flexes(numerical=True):
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True):
         dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(F, inf_flex)
-        assert F.is_dict_inf_flex(
-            dict_flex, numerical=True
-        ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+        assert infinitesimal_rigidity.is_dict_inf_flex(
+            F, dict_flex, numerical=True
+        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+            F, dict_flex, numerical=True, tolerance=1e-4
+        )
     assert (
-        np.linalg.matrix_rank(np.vstack(tuple(F.nontrivial_inf_flexes(numerical=True))))
+        np.linalg.matrix_rank(
+            np.vstack(
+                tuple(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
+            )
+        )
         == 2
     )
 
     F = fws.Frustum(4)
-    QF = np.vstack(tuple(F.inf_flexes(include_trivial=True, numerical=True)))
+    F = _to_FrameworkBase(F)
+    QF = np.vstack(
+        tuple(
+            infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True)
+        )
+    )
     assert np.linalg.matrix_rank(QF) == 5
-    QF = np.vstack(tuple(F.inf_flexes(include_trivial=False, numerical=True)))
+    QF = np.vstack(
+        tuple(
+            infinitesimal_rigidity.inf_flexes(F, include_trivial=False, numerical=True)
+        )
+    )
     assert np.linalg.matrix_rank(QF) == 2
 
     F = fws.Complete(5, dim=4)
-    assert len(F.inf_flexes(include_trivial=True, numerical=True)) == 10
+    F = _to_FrameworkBase(F)
+    assert (
+        len(infinitesimal_rigidity.inf_flexes(F, include_trivial=True, numerical=True))
+        == 10
+    )
 
     F = Framework.Random(graphs.DoubleBanana(), dim=3)
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
     G = graphs.Complete(3)
     F = Framework(G, {0: [0, 0], 1: [1, 0], 2: [2, 0]})
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
     G = graphs.Complete(4)
     F = Framework(G, {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [0, 1, 0]})
-    inf_flexes = F.nontrivial_inf_flexes(numerical=True)
+    F = _to_FrameworkBase(F)
+    inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
     assert len(inf_flexes) == 1
     dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
         F, inf_flexes[0]
     )
-    assert F.is_dict_inf_flex(
-        dict_flex, numerical=True, tolerance=1e-4
-    ) and F.is_dict_nontrivial_inf_flex(dict_flex, numerical=True, tolerance=1e-4)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
+        F, dict_flex, numerical=True, tolerance=1e-4
+    )
     assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        C = Framework(graphs.Complete(6), realization=F.realization())
-        C = _to_FrameworkBase(C)
-        QF = np.hstack(infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True))
-        QC = infinitesimal_rigidity.nontrivial_inf_flexes(C, numerical=True)
-        assert np.linalg.matrix_rank(QF) == 1 and len(QC) == 0
-
-        F = fws.Path(4)
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True):
-            dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-                F, inf_flex
-            )
-            assert infinitesimal_rigidity.is_dict_inf_flex(
-                F, dict_flex, numerical=True
-            ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
-                F, dict_flex, numerical=True, tolerance=1e-4
-            )
-        assert (
-            np.linalg.matrix_rank(
-                np.vstack(
-                    tuple(
-                        infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
-                    )
-                )
-            )
-            == 2
-        )
-
-        F = fws.Frustum(4)
-        F = _to_FrameworkBase(F)
-        QF = np.vstack(
-            tuple(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=True, numerical=True
-                )
-            )
-        )
-        assert np.linalg.matrix_rank(QF) == 5
-        QF = np.vstack(
-            tuple(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=False, numerical=True
-                )
-            )
-        )
-        assert np.linalg.matrix_rank(QF) == 2
-
-        F = fws.Complete(5, dim=4)
-        F = _to_FrameworkBase(F)
-        assert (
-            len(
-                infinitesimal_rigidity.inf_flexes(
-                    F, include_trivial=True, numerical=True
-                )
-            )
-            == 10
-        )
-
-        F = Framework.Random(graphs.DoubleBanana(), dim=3)
-        F = _to_FrameworkBase(F)
-        inf_flexes = infinitesimal_rigidity.nontrivial_inf_flexes(F, numerical=True)
-        dict_flex = infinitesimal_rigidity._transform_inf_flex_to_pointwise(
-            F, inf_flexes[0]
-        )
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, dict_flex, numerical=True, tolerance=1e-4
-        ) and infinitesimal_rigidity.is_dict_nontrivial_inf_flex(
-            F, dict_flex, numerical=True, tolerance=1e-4
-        )
-        assert np.linalg.matrix_rank(np.vstack(inf_flexes)) == 1
 
 
 @pytest.mark.parametrize(
@@ -561,13 +412,16 @@ def test_inf_flexes_numerical():
 )
 def test_vertex_fixing(framework, include_trivial, numerical):
     fixed_vertices = framework._graph.edge_list()[0]
-    flexes = framework.inf_flexes(
+    flexes = infinitesimal_rigidity.inf_flexes(
+        _to_FrameworkBase(framework),
         include_trivial=include_trivial,
         numerical=numerical,
         fixed_vertices=fixed_vertices,
     )
     pointwise_zero_flexes = [
-        infinitesimal_rigidity._transform_inf_flex_to_pointwise(framework, flex)
+        infinitesimal_rigidity._transform_inf_flex_to_pointwise(
+            _to_FrameworkBase(framework), flex
+        )
         for flex in flexes
     ]
     assert all(
@@ -582,105 +436,52 @@ def test_vertex_fixing(framework, include_trivial, numerical):
         )
         for point in pointwise_zero_flexes
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        infinitesimal_rigidity.inf_flexes(
-            framework,
-            include_trivial=include_trivial,
-            numerical=numerical,
-            fixed_vertices=fixed_vertices,
-        )
-        pointwise_zero_flexes = [
-            infinitesimal_rigidity._transform_inf_flex_to_pointwise(framework, flex)
-            for flex in flexes
-        ]
-        assert all(
-            is_zero_vector(point[v], numerical=numerical)
-            for v in fixed_vertices
-            for point in pointwise_zero_flexes
-        )
-        assert all(
-            any(
-                not is_zero_vector(point[v], numerical=numerical)
-                for v in framework._graph.nodes
-            )
-            for point in pointwise_zero_flexes
-        )
 
 
 def test_is_vector_inf_flex():
     F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-    assert F.is_vector_inf_flex([0, 0, 0, 1, -1, 0])
-    assert not F.is_vector_inf_flex([0, 0, 0, 1, -2, 0])
-    assert F.is_vector_inf_flex([0, 1, 0, 0, -1, 0], [1, 0, 2])
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
+    assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -2, 0])
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 1, 0, 0, -1, 0], [1, 0, 2])
 
     F.delete_edge([1, 2])
-    assert F.is_vector_inf_flex([0, 0, 0, 1, -1, 0])
-    assert F.is_vector_inf_flex([0, 0, 0, -1, -2, 0])
-    assert not F.is_vector_inf_flex([0, 0, 2, 1, -2, 1])
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
+    assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, -1, -2, 0])
+    assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 2, 1, -2, 1])
 
     F = fws.ThreePrism(realization="flexible")
-    for inf_flex in F.inf_flexes(include_trivial=True):
-        assert F.is_vector_inf_flex(inf_flex)
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
-        assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -2, 0])
-        assert infinitesimal_rigidity.is_vector_inf_flex(
-            F, [0, 1, 0, 0, -1, 0], [1, 0, 2]
-        )
-
-        F.delete_edge([1, 2])
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, 1, -1, 0])
-        assert infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 0, -1, -2, 0])
-        assert not infinitesimal_rigidity.is_vector_inf_flex(F, [0, 0, 2, 1, -2, 1])
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        for inf_flex in infinitesimal_rigidity.inf_flexes(F, include_trivial=True):
-            assert infinitesimal_rigidity.is_vector_inf_flex(F, inf_flex)
+    F = _to_FrameworkBase(F)
+    for inf_flex in infinitesimal_rigidity.inf_flexes(F, include_trivial=True):
+        assert infinitesimal_rigidity.is_vector_inf_flex(F, inf_flex)
 
 
 def test_is_dict_inf_flex():
     F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, 1], 2: [-1, 0]})
-    assert not F.is_dict_inf_flex({0: [0, 0], 1: [0, -1], 2: [-2, 0]})
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
+    )
+    assert not infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
+    )
 
     F.delete_edge([1, 2])
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, 1], 2: [-1, 0]})
-    assert F.is_dict_inf_flex({0: [0, 0], 1: [0, -1], 2: [-2, 0]})
-    assert not F.is_dict_inf_flex({0: [0, 0], 1: [2, 1], 2: [-2, 1]})
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
+    )
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
+    )
+    assert not infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [2, 1], 2: [-2, 1]}
+    )
 
     F = fws.ThreePrism(realization="flexible")
-    assert F.is_dict_inf_flex(
-        {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.is_dict_inf_flex(
+        F, {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework.Complete([[0, 0], [1, 0], [0, 1]])
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
-        )
-        assert not infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
-        )
-
-        F.delete_edge([1, 2])
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 1], 2: [-1, 0]}
-        )
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, -1], 2: [-2, 0]}
-        )
-        assert not infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [2, 1], 2: [-2, 1]}
-        )
-
-        F = fws.ThreePrism(realization="flexible")
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.is_dict_inf_flex(
-            F, {0: [0, 0], 1: [0, 0], 2: [0, 0], 3: [1, 0], 4: [1, 0], 5: [1, 0]}
-        )
 
 
 @pytest.mark.parametrize(
@@ -692,22 +493,24 @@ def test_is_dict_inf_flex():
     ],
 )
 def test_rigidity_matrix_parametric(framework, rigidity_matrix):
-    assert framework.rigidity_matrix() == rigidity_matrix
-    if TEST_WRAPPED_FUNCTIONS:
-        assert (
-            infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
-            == rigidity_matrix
-        )
+    assert (
+        infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
+        == rigidity_matrix
+    )
 
 
 def test_rigidity_matrix():
     F = fws.Complete(4, dim=3)
-    assert F.rigidity_matrix().shape == (6, 12)
+    F = _to_FrameworkBase(F)
+    assert infinitesimal_rigidity.rigidity_matrix(F).shape == (6, 12)
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])
     F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
+    F = _to_FrameworkBase(F)
     vertex_order = ["a", 1.9, "b", 0]
-    assert F.rigidity_matrix(vertex_order=vertex_order) == Matrix(
+    assert infinitesimal_rigidity.rigidity_matrix(
+        F, vertex_order=vertex_order
+    ) == Matrix(
         [
             [1, 0, 0, 0, 0, 0, -1, 0],
             [0, 0, 0, 1, 0, 0, 0, -1],
@@ -715,25 +518,6 @@ def test_rigidity_matrix():
             [0, 0, -1, 0, 1, 0, 0, 0],
         ]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
-        assert infinitesimal_rigidity.rigidity_matrix(F).shape == (6, 12)
-
-        G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0)])
-        F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
-        F = _to_FrameworkBase(F)
-        vertex_order = ["a", 1.9, "b", 0]
-        assert infinitesimal_rigidity.rigidity_matrix(
-            F, vertex_order=vertex_order
-        ) == Matrix(
-            [
-                [1, 0, 0, 0, 0, 0, -1, 0],
-                [0, 0, 0, 1, 0, 0, 0, -1],
-                [0, -1, 0, 0, 0, 1, 0, 0],
-                [0, 0, -1, 0, 1, 0, 0, 0],
-            ]
-        )
 
 
 @pytest.mark.parametrize(
@@ -758,16 +542,13 @@ def test_rigidity_matrix():
     ],
 )
 def test_rigidity_matrix_rank(framework, rank):
-    assert framework.rigidity_matrix_rank() == rank
-    assert framework.rigidity_matrix_rank(numerical=True) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        assert (
-            infinitesimal_rigidity.rigidity_matrix_rank(_to_FrameworkBase(framework))
-            == rank
+    assert (
+        infinitesimal_rigidity.rigidity_matrix_rank(_to_FrameworkBase(framework))
+        == rank
+    )
+    assert (
+        infinitesimal_rigidity.rigidity_matrix_rank(
+            _to_FrameworkBase(framework), numerical=True
         )
-        assert (
-            infinitesimal_rigidity.rigidity_matrix_rank(
-                _to_FrameworkBase(framework), numerical=True
-            )
-            == rank
-        )
+        == rank
+    )

--- a/test/framework/rigidity/test_matroidal.py
+++ b/test/framework/rigidity/test_matroidal.py
@@ -4,7 +4,6 @@ import pyrigi.frameworkDB as fws
 import pyrigi.graphDB as graphs
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import matroidal as matroidal_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -40,13 +39,10 @@ from test.framework import _to_FrameworkBase
     + [fws.Cycle(n + 1, dim=n) for n in range(3, 7)],
 )
 def test_is_independent(framework):
-    assert framework.is_independent()
-    assert framework.is_independent(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_independent(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_independent(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_independent(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_independent(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -69,13 +65,8 @@ def test_is_independent(framework):
     + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
 def test_is_dependent(framework):
-    assert framework.is_dependent()
-    assert framework.is_dependent(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_dependent(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_dependent(_to_FrameworkBase(framework), numerical=True)
 
 
 @pytest.mark.parametrize(
@@ -96,13 +87,8 @@ def test_is_dependent(framework):
     + [fws.Complete(n - 1, dim=n) for n in range(2, 7)],
 )
 def test_is_isostatic(framework):
-    assert framework.is_isostatic()
-    assert framework.is_isostatic(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
-        assert matroidal_rigidity.is_isostatic(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
+    assert matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework), numerical=True)
 
 
 @pytest.mark.parametrize(
@@ -134,9 +120,7 @@ def test_is_isostatic(framework):
     + [Framework.Random(graphs.Complete(n), dim=n - 2) for n in range(3, 8)],
 )
 def test_is_not_isostatic(framework):
-    assert not framework.is_isostatic()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
-        assert not matroidal_rigidity.is_isostatic(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not matroidal_rigidity.is_isostatic(_to_FrameworkBase(framework))
+    assert not matroidal_rigidity.is_isostatic(
+        _to_FrameworkBase(framework), numerical=True
+    )

--- a/test/framework/rigidity/test_redundant.py
+++ b/test/framework/rigidity/test_redundant.py
@@ -2,7 +2,6 @@ import pytest
 
 import pyrigi.frameworkDB as fws
 from pyrigi.framework._rigidity import redundant as redundant_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -18,13 +17,10 @@ from test.framework import _to_FrameworkBase
     ],
 )
 def test_is_redundantly_inf_rigid(framework):
-    assert framework.is_redundantly_inf_rigid()
-    assert framework.is_redundantly_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
-        assert redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
+    assert redundant_rigidity.is_redundantly_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -47,12 +43,7 @@ def test_is_redundantly_inf_rigid(framework):
     ],
 )
 def test_is_not_redundantly_inf_rigid(framework):
-    assert not framework.is_redundantly_inf_rigid()
-    assert not framework.is_redundantly_inf_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework)
-        )
-        assert not redundant_rigidity.is_redundantly_inf_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not redundant_rigidity.is_redundantly_inf_rigid(_to_FrameworkBase(framework))
+    assert not redundant_rigidity.is_redundantly_inf_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )

--- a/test/framework/rigidity/test_second_order.py
+++ b/test/framework/rigidity/test_second_order.py
@@ -3,7 +3,6 @@ import pytest
 import pyrigi.frameworkDB as fws
 from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import second_order as second_order_rigidity
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -24,13 +23,10 @@ from test.framework import _to_FrameworkBase
     ],
 )
 def test_is_prestress_stable(framework):
-    assert framework.is_prestress_stable()
-    assert framework.is_prestress_stable(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
-        assert second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+    assert second_order_rigidity.is_prestress_stable(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,15 +44,10 @@ def test_is_prestress_stable(framework):
     ],
 )
 def test_is_not_prestress_stable(framework):
-    assert not framework.is_prestress_stable()
-    assert not framework.is_prestress_stable(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework)
-        )
-        assert not second_order_rigidity.is_prestress_stable(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+    assert not second_order_rigidity.is_prestress_stable(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -68,10 +59,7 @@ def test_is_not_prestress_stable(framework):
 )
 def test_is_prestress_stable_error(framework):
     with pytest.raises(ValueError):
-        framework.is_prestress_stable()
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
+        second_order_rigidity.is_prestress_stable(_to_FrameworkBase(framework))
 
 
 @pytest.mark.parametrize(
@@ -91,13 +79,10 @@ def test_is_prestress_stable_error(framework):
     ],
 )
 def test_is_second_order_rigid(framework):
-    assert framework.is_second_order_rigid()
-    assert framework.is_second_order_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
-        assert second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
+    assert second_order_rigidity.is_second_order_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -115,15 +100,10 @@ def test_is_second_order_rigid(framework):
     ],
 )
 def test_is_not_second_order_rigid(framework):
-    assert not framework.is_second_order_rigid()
-    assert not framework.is_second_order_rigid(numerical=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework)
-        )
-        assert not second_order_rigidity.is_second_order_rigid(
-            _to_FrameworkBase(framework), numerical=True
-        )
+    assert not second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
+    assert not second_order_rigidity.is_second_order_rigid(
+        _to_FrameworkBase(framework), numerical=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,7 +115,4 @@ def test_is_not_second_order_rigid(framework):
 )
 def test_is_second_order_rigid_error(framework):
     with pytest.raises(ValueError):
-        framework.is_second_order_rigid()
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))
+        second_order_rigidity.is_second_order_rigid(_to_FrameworkBase(framework))

--- a/test/framework/rigidity/test_stress.py
+++ b/test/framework/rigidity/test_stress.py
@@ -6,7 +6,6 @@ from pyrigi.framework import Framework
 from pyrigi.framework._rigidity import infinitesimal as infinitesimal_rigidity
 from pyrigi.framework._rigidity import stress as stress_rigidity
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
@@ -14,9 +13,7 @@ def test_stress_matrix():
     F = fws.Complete(4)
     M = Matrix([[1, -1, 1, -1], [-1, 1, -1, 1], [1, -1, 1, -1], [-1, 1, -1, 1]])
     stress = [1, -1, 1, 1, -1, 1]
-    assert F.stress_matrix(stress) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
+    assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
 
     F = fws.Frustum(3)
     M = Matrix(
@@ -30,24 +27,17 @@ def test_stress_matrix():
         ]
     )
     stress = [2, 2, 6, 2, 6, 6, -1, -1, -1]
-    assert F.stress_matrix(stress) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
+    assert stress_rigidity.stress_matrix(_to_FrameworkBase(F), stress) == M
 
     G = Graph([(0, "a"), ("b", "a"), ("b", 1.9), (1.9, 0), ("b", 0), ("a", 1.9)])
     F = Framework(G, {0: (0, 0), "a": (1, 0), "b": (1, 1), 1.9: (0, 1)})
+    F = _to_FrameworkBase(F)
     edge_order = [("a", 0), (1.9, "b"), (1.9, 0), ("a", "b"), ("a", 1.9), (0, "b")]
     M = Matrix([[-1, 1, -1, 1], [1, -1, 1, -1], [-1, 1, -1, 1], [1, -1, 1, -1]])
-    stress = F.stresses(edge_order=edge_order)[0].transpose().tolist()[0]
-    assert F.stress_matrix(stress, edge_order=edge_order) == M
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(F)
-        stress = (
-            stress_rigidity.stresses(F, edge_order=edge_order)[0]
-            .transpose()
-            .tolist()[0]
-        )
-        assert stress_rigidity.stress_matrix(F, stress, edge_order=edge_order) == M
+    stress = (
+        stress_rigidity.stresses(F, edge_order=edge_order)[0].transpose().tolist()[0]
+    )
+    assert stress_rigidity.stress_matrix(F, stress, edge_order=edge_order) == M
 
 
 @pytest.mark.parametrize(
@@ -66,32 +56,17 @@ def test_stress_matrix():
     ],
 )
 def test_stresses(framework, num_stresses):
-    Q1 = Matrix.hstack(*(framework.rigidity_matrix().transpose().nullspace()))
-    Q2 = Matrix.hstack(*(framework.stresses()))
+    F = _to_FrameworkBase(framework)
+    Q1 = Matrix.hstack(
+        *(infinitesimal_rigidity.rigidity_matrix(F).transpose().nullspace())
+    )
+    Q2 = Matrix.hstack(*(stress_rigidity.stresses(F)))
     assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
 
-    stresses = framework.stresses()
+    stresses = stress_rigidity.stresses(F)
     assert len(stresses) == num_stresses and all(
-        [framework.is_stress(s) for s in stresses]
+        [stress_rigidity.is_stress(F, s) for s in stresses]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        Q1 = Matrix.hstack(
-            *(
-                infinitesimal_rigidity.rigidity_matrix(_to_FrameworkBase(framework))
-                .transpose()
-                .nullspace()
-            )
-        )
-        Q2 = Matrix.hstack(*(stress_rigidity.stresses(_to_FrameworkBase(framework))))
-        assert Q1.rank() == Q2.rank() and Q1.rank() == Matrix.hstack(Q1, Q2).rank()
-
-        stresses = stress_rigidity.stresses(_to_FrameworkBase(framework))
-        assert len(stresses) == num_stresses and all(
-            [
-                stress_rigidity.is_stress(_to_FrameworkBase(framework), s)
-                for s in stresses
-            ]
-        )
 
 
 @pytest.mark.parametrize(
@@ -109,16 +84,11 @@ def test_stresses(framework, num_stresses):
     + [[fws.Frustum(i), 1] for i in range(3, 8)],
 )
 def test_stresses_numerical(framework, num_stresses):
-    stresses = framework.stresses(numerical=True)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=True)
     assert len(stresses) == num_stresses and all(
-        [framework.is_stress(s, numerical=True) for s in stresses]
+        [stress_rigidity.is_stress(F, s, numerical=True) for s in stresses]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=True)
-        assert len(stresses) == num_stresses and all(
-            [stress_rigidity.is_stress(F, s, numerical=True) for s in stresses]
-        )
 
 
 @pytest.mark.parametrize(
@@ -136,17 +106,13 @@ def test_stresses_numerical(framework, num_stresses):
 )
 @pytest.mark.parametrize("numerical", [True, False])
 def test_stress_matrix_rank(framework, stress_rank, numerical):
-    stresses = framework.stresses(numerical=numerical)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=numerical)
     assert len(stresses) == 1
-    assert framework.stress_matrix_rank(stresses[0], numerical=numerical) == stress_rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=numerical)
-        assert len(stresses) == 1
-        assert (
-            stress_rigidity.stress_matrix_rank(F, stresses[0], numerical=numerical)
-            == stress_rank
-        )
+    assert (
+        stress_rigidity.stress_matrix_rank(F, stresses[0], numerical=numerical)
+        == stress_rank
+    )
 
 
 @pytest.mark.parametrize(
@@ -159,27 +125,17 @@ def test_stress_matrix_rank(framework, stress_rank, numerical):
 )
 @pytest.mark.parametrize("numerical", [True, False])
 def test_stress_matrix_rank_symbolic_stresses(framework, stress_dim, numerical):
-    stresses = framework.stresses(numerical=False)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=False)
     assert len(stresses) == len(stress_dim)
     for stress, rank in zip(stresses, stress_dim):
         assert (
-            framework.stress_matrix_rank(stress, numerical=numerical)
-            <= framework.graph.number_of_nodes() - framework.dim - 1
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
+            <= F.graph.number_of_nodes() - F.dim - 1
         )
-        assert framework.stress_matrix_rank(stress, numerical=numerical) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=False)
-        assert len(stresses) == len(stress_dim)
-        for stress, rank in zip(stresses, stress_dim):
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
-                <= F.graph.number_of_nodes() - F.dim - 1
-            )
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical)
-                == rank
-            )
+        assert (
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=numerical) == rank
+        )
 
 
 @pytest.mark.parametrize(
@@ -191,21 +147,12 @@ def test_stress_matrix_rank_symbolic_stresses(framework, stress_dim, numerical):
     ],
 )
 def test_stress_matrix_rank_numerical_stresses(framework, stress_dim):
-    stresses = framework.stresses(numerical=True)
+    F = _to_FrameworkBase(framework)
+    stresses = stress_rigidity.stresses(F, numerical=True)
     assert len(stresses) == len(stress_dim)
     for stress, rank in zip(stresses, stress_dim):
         assert (
-            framework.stress_matrix_rank(stress, numerical=True)
-            <= framework.graph.number_of_nodes() - framework.dim - 1
+            stress_rigidity.stress_matrix_rank(F, stress, numerical=True)
+            <= F.graph.number_of_nodes() - F.dim - 1
         )
-        assert framework.stress_matrix_rank(stress, numerical=True) == rank
-    if TEST_WRAPPED_FUNCTIONS:
-        F = _to_FrameworkBase(framework)
-        stresses = stress_rigidity.stresses(F, numerical=True)
-        assert len(stresses) == len(stress_dim)
-        for stress, rank in zip(stresses, stress_dim):
-            assert (
-                stress_rigidity.stress_matrix_rank(F, stress, numerical=True)
-                <= F.graph.number_of_nodes() - F.dim - 1
-            )
-            assert stress_rigidity.stress_matrix_rank(F, stress, numerical=True) == rank
+        assert stress_rigidity.stress_matrix_rank(F, stress, numerical=True) == rank

--- a/test/framework/test__general.py
+++ b/test/framework/test__general.py
@@ -10,188 +10,126 @@ from pyrigi.framework import (
     Framework,
 )
 from pyrigi.framework import _general as framework_general
+from pyrigi.framework._transformations import (
+    transformations as framework_transformations,
+)
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
 def test_is_injective():
     F1 = fws.Complete(4, 2)
-    assert F1.is_injective()
-    assert F1.is_injective(numerical=True)
+    F1 = _to_FrameworkBase(F1)
 
     F2 = deepcopy(F1)
     F2.set_vertex_pos(0, F2[1])
-    assert not F2.is_injective()
-    assert not F2.is_injective(numerical=True)
+
+    assert framework_general.is_injective(F1)
+    assert framework_general.is_injective(F1, numerical=True)
+
+    assert not framework_general.is_injective(F2)
+    assert not framework_general.is_injective(F2, numerical=True)
 
     # test symbolical injectivity with irrational numbers
-    F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
-    F3.rotate2D(pi / 3, inplace=True)
-    assert F3.is_injective()
-    assert F3.is_injective(numerical=True)
+    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
+    framework_transformations.rotate2D(F3, pi / 3, inplace=True)
+
+    assert framework_general.is_injective(F3)
+    assert framework_general.is_injective(F3, numerical=True)
 
     # test numerical injectivity
     F4 = deepcopy(F3)
     F4.set_realization(F4.realization(numerical=True))
-    assert F4.is_injective(numerical=True)
+
+    assert framework_general.is_injective(F4, numerical=True)
 
     # test numerically not injective, but symbolically injective framework
     F5 = deepcopy(F3)
     F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
-    assert not F5.is_injective(numerical=True, tolerance=1e-8)
-    assert not F5.is_injective(numerical=True, tolerance=1e-9)
-    assert F5.is_injective()
+
+    assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
+    assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
+    assert framework_general.is_injective(F5)
 
     # test tolerance in numerical injectivity check
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
-    assert F6.is_injective(numerical=True, tolerance=1e-9)
-    assert F6.is_injective()
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_injective(F1)
-        assert framework_general.is_injective(F1, numerical=True)
-
-        F2 = _to_FrameworkBase(F2)
-        assert not framework_general.is_injective(F2)
-        assert not framework_general.is_injective(F2, numerical=True)
-
-        # test symbolical injectivity with irrational numbers
-        F3 = _to_FrameworkBase(F3)
-        assert framework_general.is_injective(F3)
-        assert framework_general.is_injective(F3, numerical=True)
-
-        # test numerical injectivity
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_injective(F4, numerical=True)
-
-        # test numerically not injective, but symbolically injective framework
-        F5 = _to_FrameworkBase(F5)
-        assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-8)
-        assert not framework_general.is_injective(F5, numerical=True, tolerance=1e-9)
-        assert framework_general.is_injective(F5)
-
-        # test tolerance in numerical injectivity check
-        F6 = _to_FrameworkBase(F6)
-        assert framework_general.is_injective(F6, numerical=True, tolerance=1e-9)
-        assert framework_general.is_injective(F6)
+    assert framework_general.is_injective(F6, numerical=True, tolerance=1e-9)
+    assert framework_general.is_injective(F6)
 
 
 def test_is_quasi_injective():
     F1 = fws.Complete(4, 2)
-    assert F1.is_quasi_injective()
-    assert F1.is_quasi_injective(numerical=True)
+    F1 = _to_FrameworkBase(F1)
+
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
 
     # test framework that is quasi-injective, but not injective
     F1.set_vertex_pos(1, F1[2])
     F1.delete_edge((1, 2))
-    assert F1.is_quasi_injective()
-    assert F1.is_quasi_injective(numerical=True)
+
+    assert framework_general.is_quasi_injective(F1)
+    assert framework_general.is_quasi_injective(F1, numerical=True)
 
     # test not quasi-injective framework
     F2 = deepcopy(F1)
     F2.set_vertex_pos(0, F2[1])
-    assert not F2.is_quasi_injective()
-    assert not F2.is_quasi_injective(numerical=True)
+
+    assert not framework_general.is_quasi_injective(F2)
+    assert not framework_general.is_quasi_injective(F2, numerical=True)
 
     # test symbolical and numerical quasi-injectivity with irrational numbers
-    F3 = F1.translate(["sqrt(2)", "pi"], inplace=False)
-    F3 = F3.rotate2D(pi / 2, inplace=False)
-    assert F3.is_quasi_injective()
-    assert F3.is_quasi_injective(numerical=True)
+    F3 = framework_transformations.translate(F1, ["sqrt(2)", "pi"], inplace=False)
+    F3 = framework_transformations.rotate2D(F3, pi / 2, inplace=False)
+
+    assert framework_general.is_quasi_injective(F3)
+    assert framework_general.is_quasi_injective(F3, numerical=True)
 
     # test numerical quasi-injectivity
     F4 = deepcopy(F3)
     F4.set_realization(F4.realization(numerical=True))
-    assert F4.is_quasi_injective(numerical=True)
+
+    assert framework_general.is_quasi_injective(F4, numerical=True)
 
     # test numerically not quasi-injective, but symbolically quasi-injective framework
     F5 = deepcopy(F3)
     F5.set_vertex_pos(0, F5[1] + point_to_vector([1e-10, 1e-10]))
-    assert not F5.is_quasi_injective(numerical=True, tolerance=1e-8)
-    assert not F5.is_quasi_injective(numerical=True, tolerance=1e-9)
-    assert F5.is_quasi_injective()
+
+    assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-8)
+    assert not framework_general.is_quasi_injective(F5, numerical=True, tolerance=1e-9)
+    assert framework_general.is_quasi_injective(F5)
 
     # test tolerance in numerical quasi-injectivity check
     F6 = deepcopy(F3)
     F6.set_vertex_pos(0, F6[1] + point_to_vector([1e-8, 1e-8]))
-    assert F6.is_quasi_injective(numerical=True, tolerance=1e-9)
-    assert F6.is_quasi_injective()
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_quasi_injective(F1)
-        assert framework_general.is_quasi_injective(F1, numerical=True)
-
-        # test framework that is quasi-injective, but not injective
-        F1 = fws.Complete(4, 2)
-        F1.set_vertex_pos(1, F1[2])
-        F1.delete_edge((1, 2))
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_quasi_injective(F1)
-        assert framework_general.is_quasi_injective(F1, numerical=True)
-
-        # test not quasi-injective framework
-        F2 = _to_FrameworkBase(F2)
-        assert not framework_general.is_quasi_injective(F2)
-        assert not framework_general.is_quasi_injective(F2, numerical=True)
-
-        # test symbolical and numerical quasi-injectivity with irrational numbers
-        F3 = _to_FrameworkBase(F3)
-        assert framework_general.is_quasi_injective(F3)
-        assert framework_general.is_quasi_injective(F3, numerical=True)
-
-        # test numerical quasi-injectivity
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_quasi_injective(F4, numerical=True)
-
-        # test numerically not quasi-injective, but symbolically quasi-injective framework
-        F5 = _to_FrameworkBase(F5)
-        assert not framework_general.is_quasi_injective(
-            F5, numerical=True, tolerance=1e-8
-        )
-        assert not framework_general.is_quasi_injective(
-            F5, numerical=True, tolerance=1e-9
-        )
-        assert framework_general.is_quasi_injective(F5)
-
-        # test tolerance in numerical quasi-injectivity check
-        F6 = _to_FrameworkBase(F6)
-        assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
-        assert framework_general.is_quasi_injective(F6)
+    assert framework_general.is_quasi_injective(F6, numerical=True, tolerance=1e-9)
+    assert framework_general.is_quasi_injective(F6)
 
 
 def test_is_equivalent():
     F1 = fws.Complete(4, 2)
-    assert F1.is_equivalent_realization(F1.realization(), numerical=False)
-    assert F1.is_equivalent_realization(F1.realization(), numerical=True)
-    assert F1.is_equivalent(F1)
+    F1 = _to_FrameworkBase(F1)
 
     F2 = fws.Complete(3, 2)
-    with pytest.raises(ValueError):
-        F1.is_equivalent_realization(F2.realization())
-
-    with pytest.raises(ValueError):
-        F1.is_equivalent(F2)
+    F2 = _to_FrameworkBase(F2)
 
     G1 = graphs.ThreePrism()
     G1.delete_vertex(5)
 
     F3 = Framework(G1, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "9/7"]})
+    F3 = _to_FrameworkBase(F3)
 
-    F4 = F3.translate((1, 1), inplace=False)
-    assert F3.is_equivalent(F4, numerical=True)
-    assert F3.is_equivalent(F4)
+    F4 = framework_transformations.translate(F3, (1, 1), inplace=False)
 
-    F5 = F3.rotate2D(pi / 2, inplace=False)
-    assert F5.is_equivalent(F3)
-    assert F5.is_equivalent(F4)
-    assert F5.is_equivalent_realization(F4.realization())
+    F5 = framework_transformations.rotate2D(F3, pi / 2, inplace=False)
 
     G2 = Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [3, 4]])
     F6 = Framework(G2, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "17/7"]})
+    F6 = _to_FrameworkBase(F6)
+
     F7 = Framework(
         G2,
         {
@@ -206,6 +144,8 @@ def test_is_equivalent():
             ],
         },
     )
+    F7 = _to_FrameworkBase(F7)
+
     F8 = Framework(
         G2,
         {
@@ -220,73 +160,51 @@ def test_is_equivalent():
             ],
         },
     )
+    F8 = _to_FrameworkBase(F8)
 
-    assert F6.is_equivalent(F7)
-    assert F6.is_equivalent(F8)
-    assert F7.is_equivalent(F8)
-
-    F9 = F5.translate((pi, "2/3"), False)
-    assert F5.is_equivalent(F9)
-
-    with pytest.raises(ValueError):
-        assert F8.is_equivalent(F2)
-
-    # testing numerical equivalence
-
+    F9 = framework_transformations.translate(F5, (pi, "2/3"), False)
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F9.realization().items()}
 
-    assert not F9.is_equivalent_realization(R1, numerical=False)
-    assert F9.is_equivalent_realization(R1, numerical=True)
+    assert framework_general.is_equivalent_realization(
+        F1, F1.realization(), numerical=False
+    )
+    assert framework_general.is_equivalent_realization(
+        F1, F1.realization(), numerical=True
+    )
+    assert framework_general.is_equivalent(F1, F1)
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        assert framework_general.is_equivalent_realization(
-            F1, F1.realization(), numerical=False
-        )
-        assert framework_general.is_equivalent_realization(
-            F1, F1.realization(), numerical=True
-        )
-        assert framework_general.is_equivalent(F1, F1)
+    with pytest.raises(ValueError):
+        framework_general.is_equivalent_realization(F1, F2.realization())
 
-        F2 = _to_FrameworkBase(F2)
-        with pytest.raises(ValueError):
-            framework_general.is_equivalent_realization(F1, F2.realization())
+    with pytest.raises(ValueError):
+        framework_general.is_equivalent(F1, F2)
 
-        with pytest.raises(ValueError):
-            framework_general.is_equivalent(F1, F2)
+    assert framework_general.is_equivalent(F3, F4, numerical=True)
+    assert framework_general.is_equivalent(F3, F4)
 
-        F3 = _to_FrameworkBase(F3)
-        F4 = _to_FrameworkBase(F4)
-        assert framework_general.is_equivalent(F3, F4, numerical=True)
-        assert framework_general.is_equivalent(F3, F4)
+    assert framework_general.is_equivalent(F5, F3)
+    assert framework_general.is_equivalent(F5, F4)
+    assert framework_general.is_equivalent_realization(F5, F4.realization())
 
-        F5 = _to_FrameworkBase(F5)
-        assert framework_general.is_equivalent(F5, F3)
-        assert framework_general.is_equivalent(F5, F4)
-        assert framework_general.is_equivalent_realization(F5, F4.realization())
+    assert framework_general.is_equivalent(F6, F7)
+    assert framework_general.is_equivalent(F6, F8)
+    assert framework_general.is_equivalent(F7, F8)
 
-        F6 = _to_FrameworkBase(F6)
-        F7 = _to_FrameworkBase(F7)
-        F8 = _to_FrameworkBase(F8)
+    assert framework_general.is_equivalent(F5, F9)
 
-        assert framework_general.is_equivalent(F6, F7)
-        assert framework_general.is_equivalent(F6, F8)
-        assert framework_general.is_equivalent(F7, F8)
+    with pytest.raises(ValueError):
+        assert framework_general.is_equivalent(F8, F2)
 
-        F9 = _to_FrameworkBase(F9)
-        assert framework_general.is_equivalent(F5, F9)
-
-        with pytest.raises(ValueError):
-            assert framework_general.is_equivalent(F8, F2)
-
-        # testing numerical equivalence
-        assert not framework_general.is_equivalent_realization(F9, R1, numerical=False)
-        assert framework_general.is_equivalent_realization(F9, R1, numerical=True)
+    # testing numerical equivalence
+    assert not framework_general.is_equivalent_realization(F9, R1, numerical=False)
+    assert framework_general.is_equivalent_realization(F9, R1, numerical=True)
 
 
 def test_is_congruent():
     G1 = Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [3, 4]])
     F1 = Framework(G1, {0: [0, 0], 1: [3, 0], 2: [2, 1], 3: [0, 4], 4: ["5/2", "17/7"]})
+    F1 = _to_FrameworkBase(F1)
+
     F2 = Framework(
         G1,
         {
@@ -301,6 +219,8 @@ def test_is_congruent():
             ],
         },
     )
+    F2 = _to_FrameworkBase(F2)
+
     F3 = Framework(
         G1,
         {
@@ -315,75 +235,44 @@ def test_is_congruent():
             ],
         },
     )
+    F3 = _to_FrameworkBase(F3)
 
-    assert F1.is_congruent_realization(F1.realization(), numerical=False)
-    assert F1.is_congruent(F1, numerical=False)
-    assert F1.is_congruent(F1, numerical=True)
-
-    assert not F1.is_congruent(F2)  # equivalent, but not congruent
-    assert not F1.is_congruent(F3)  # equivalent, but not congruent
-    assert not F2.is_congruent(F3)  # equivalent, but not congruent
-    assert not F1.is_congruent(F2, numerical=True)  # equivalent, but not congruent
-    assert not F1.is_congruent(F3, numerical=True)  # equivalent, but not congruent
-    assert not F2.is_congruent(F3, numerical=True)  # equivalent, but not congruent
-
-    F4 = F1.translate((pi, "2/3"), False)
-    F5 = F1.rotate2D(pi / 2, inplace=False)
-    assert F1.is_congruent(F4)
-    assert F1.is_congruent(F5)
-    assert F5.is_congruent(F4)
+    F4 = framework_transformations.translate(F1, (pi, "2/3"), False)
+    F5 = framework_transformations.rotate2D(F1, pi / 2, inplace=False)
 
     F6 = fws.Complete(4, 2)
+    F6 = _to_FrameworkBase(F6)
     F7 = fws.Complete(3, 2)
-    with pytest.raises(ValueError):
-        assert F6.is_congruent(F7)
+    F7 = _to_FrameworkBase(F7)
 
-    # testing numerical congruence
     R1 = {v: sympy_expr_to_float(pos) for v, pos in F4.realization().items()}
 
-    assert not F4.is_congruent_realization(R1)
-    assert F4.is_congruent_realization(R1, numerical=True)
+    assert framework_general.is_congruent_realization(
+        F1, F1.realization(), numerical=False
+    )
+    assert framework_general.is_congruent(F1, F1, numerical=False)
+    assert framework_general.is_congruent(F1, F1, numerical=True)
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F1 = _to_FrameworkBase(F1)
-        F2 = _to_FrameworkBase(F2)
-        F3 = _to_FrameworkBase(F3)
-        F4 = _to_FrameworkBase(F4)
-        F5 = _to_FrameworkBase(F5)
-        F6 = _to_FrameworkBase(F6)
-        F7 = _to_FrameworkBase(F7)
-        assert framework_general.is_congruent_realization(
-            F1, F1.realization(), numerical=False
-        )
-        assert framework_general.is_congruent(F1, F1, numerical=False)
-        assert framework_general.is_congruent(F1, F1, numerical=True)
+    assert not framework_general.is_congruent(F1, F2)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(F1, F3)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(F2, F3)  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F1, F2, numerical=True
+    )  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F1, F3, numerical=True
+    )  # equivalent, but not congruent
+    assert not framework_general.is_congruent(
+        F2, F3, numerical=True
+    )  # equivalent, but not congruent
 
-        assert not framework_general.is_congruent(
-            F1, F2
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F3
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F2, F3
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F2, numerical=True
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F1, F3, numerical=True
-        )  # equivalent, but not congruent
-        assert not framework_general.is_congruent(
-            F2, F3, numerical=True
-        )  # equivalent, but not congruent
+    assert framework_general.is_congruent(F1, F4)
+    assert framework_general.is_congruent(F1, F5)
+    assert framework_general.is_congruent(F5, F4)
 
-        assert framework_general.is_congruent(F1, F4)
-        assert framework_general.is_congruent(F1, F5)
-        assert framework_general.is_congruent(F5, F4)
+    with pytest.raises(ValueError):
+        assert framework_general.is_congruent(F6, F7)
 
-        with pytest.raises(ValueError):
-            assert framework_general.is_congruent(F6, F7)
-
-        # testing numerical congruence
-        assert not framework_general.is_congruent_realization(F4, R1)
-        assert framework_general.is_congruent_realization(F4, R1, numerical=True)
+    # testing numerical congruence
+    assert not framework_general.is_congruent_realization(F4, R1)
+    assert framework_general.is_congruent_realization(F4, R1, numerical=True)

--- a/test/framework/transformations/test_transformations.py
+++ b/test/framework/transformations/test_transformations.py
@@ -8,68 +8,45 @@ from pyrigi.framework._general import is_congruent_realization
 from pyrigi.framework._transformations import (
     transformations as framework_transformations,
 )
-from test import TEST_WRAPPED_FUNCTIONS
 from test.framework import _to_FrameworkBase
 
 
 def test_translate():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.translate((0, 0), False)
+    newF = framework_transformations.translate(F, (0, 0), False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
     translation = Matrix([[1], [1]])
-    newF = F.translate(translation, False)
+    newF = framework_transformations.translate(F, translation, False)
     assert newF[0].equals(F[0] + translation)
     assert newF[1].equals(F[1] + translation)
     assert newF[2].equals(F[2] + translation)
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.translate(F, (0, 0), False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        translation = Matrix([[1], [1]])
-        newF = framework_transformations.translate(F, translation, False)
-        assert newF[0].equals(F[0] + translation)
-        assert newF[1].equals(F[1] + translation)
-        assert newF[2].equals(F[2] + translation)
 
 
 def test_rescale():
     G = graphs.Complete(4)
     F = Framework(G, {0: (-1, 0), 1: (2, 0), 2: (1, 1), 3: (3, -2)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.rescale(1, False)
+    newF = framework_transformations.rescale(F, 1, False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rescale(2, False)
+    newF = framework_transformations.rescale(F, 2, False)
     assert newF[0].equals(Matrix([p * 2 for p in F[0]]))
     assert newF[1].equals(Matrix([p * 2 for p in F[1]]))
     assert newF[2].equals(Matrix([p * 2 for p in F[2]]))
 
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (-1, 0), 1: (2, 0), 2: (1, 1), 3: (3, -2)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rescale(F, 1, False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rescale(F, 2, False)
-        assert newF[0].equals(Matrix([p * 2 for p in F[0]]))
-        assert newF[1].equals(Matrix([p * 2 for p in F[1]]))
-        assert newF[2].equals(Matrix([p * 2 for p in F[2]]))
-
 
 def test_projected_realization():
     F = fws.Complete(4, dim=3)
-    _r = F.projected_realization(
-        proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
+    F = _to_FrameworkBase(F)
+    _r = framework_transformations.projected_realization(
+        F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
     )
     assert (
         len(_r) == 2
@@ -80,206 +57,110 @@ def test_projected_realization():
         and _r[0][3] == (1, 1)
     )
 
-    _r = F.projected_realization(
-        proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    _r = framework_transformations.projected_realization(
+        F, proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     )
     assert (
         len(_r) == 2
         and all([len(val) == 3 for val in _r[0].values()])
-        and F.is_congruent_realization(_r[0])
+        and is_congruent_realization(F, _r[0])
     )
 
     with pytest.raises(ValueError):
-        F.projected_realization(proj_dim=2, projection_matrix=Matrix([[0, 1, 1]]))
-        F.projected_realization(proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]]))
+        framework_transformations.projected_realization(
+            F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1]])
+        )
+        framework_transformations.projected_realization(
+            F, proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]])
+        )
 
     F = fws.Complete(6, dim=5)
+    F = _to_FrameworkBase(F)
     with pytest.raises(ValueError):
-        F.projected_realization(proj_dim=4)
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = fws.Complete(4, dim=3)
-        F = _to_FrameworkBase(F)
-        _r = framework_transformations.projected_realization(
-            F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1], [1, 0, 1]])
-        )
-        assert (
-            len(_r) == 2
-            and all([len(val) == 2 for val in _r[0].values()])
-            and _r[0][0] == (0, 0)
-            and _r[0][1] == (0, 1)
-            and _r[0][2] == (1, 0)
-            and _r[0][3] == (1, 1)
-        )
-
-        _r = framework_transformations.projected_realization(
-            F, proj_dim=3, projection_matrix=Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        )
-        assert (
-            len(_r) == 2
-            and all([len(val) == 3 for val in _r[0].values()])
-            and is_congruent_realization(F, _r[0])
-        )
-
-        with pytest.raises(ValueError):
-            framework_transformations.projected_realization(
-                F, proj_dim=2, projection_matrix=Matrix([[0, 1, 1]])
-            )
-            framework_transformations.projected_realization(
-                F, proj_dim=2, projection_matrix=Matrix([[0, 1], [1, 0]])
-            )
-
-        F = fws.Complete(6, dim=5)
-        F = _to_FrameworkBase(F)
-        with pytest.raises(ValueError):
-            framework_transformations.projected_realization(F, proj_dim=4)
+        framework_transformations.projected_realization(F, proj_dim=4)
 
 
 def test_rotate2D():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-
-    newF = F.rotate2D(0, inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate2D(F, 0, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate2D(pi * 4, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi * 4, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate2D(pi / 2, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi / 2, inplace=False)
     assert newF[0].equals(Matrix([[0], [0]]))
     assert newF[1].equals(Matrix([[0], [2]]))
     assert newF[2].equals(Matrix([[-1], [1]]))
 
-    newF = F.rotate2D(pi / 4, inplace=False)
+    newF = framework_transformations.rotate2D(F, pi / 4, inplace=False)
     assert newF[0].equals(Matrix([[0], [0]]))
     assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)]]))
     assert newF[2].equals(Matrix([[0], [sqrt(2)]]))
 
     F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (0, 2)})
-    newF = F.rotate2D(pi, rotation_center=[1, 1], inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate2D(
+        F, pi, rotation_center=[1, 1], inplace=False
+    )
     assert newF[0].equals(Matrix([[2], [2]]))
     assert newF[1].equals(Matrix([[0], [2]]))
     assert newF[2].equals(Matrix([[2], [0]]))
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (1, 1)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rotate2D(F, 0, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate2D(F, pi * 4, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate2D(F, pi / 2, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0]]))
-        assert newF[1].equals(Matrix([[0], [2]]))
-        assert newF[2].equals(Matrix([[-1], [1]]))
-
-        newF = framework_transformations.rotate2D(F, pi / 4, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0]]))
-        assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)]]))
-        assert newF[2].equals(Matrix([[0], [sqrt(2)]]))
-
-        F = Framework(G, {0: (0, 0), 1: (2, 0), 2: (0, 2)})
-        F = _to_FrameworkBase(F)
-        newF = framework_transformations.rotate2D(
-            F, pi, rotation_center=[1, 1], inplace=False
-        )
-        assert newF[0].equals(Matrix([[2], [2]]))
-        assert newF[1].equals(Matrix([[0], [2]]))
-        assert newF[2].equals(Matrix([[2], [0]]))
 
 
 def test_rotate3D():
     G = graphs.Complete(3)
     F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (1, 1, 0)})
+    F = _to_FrameworkBase(F)
 
-    newF = F.rotate3D(0, inplace=False)
+    newF = framework_transformations.rotate3D(F, 0, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate3D(pi * 4, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi * 4, inplace=False)
     for v, pos in newF.realization().items():
         assert pos.equals(F[v])
 
-    newF = F.rotate3D(pi / 2, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi / 2, inplace=False)
     assert newF[0].equals(Matrix([[0], [0], [0]]))
     assert newF[1].equals(Matrix([[0], [2], [0]]))
     assert newF[2].equals(Matrix([[-1], [1], [0]]))
 
-    newF = F.rotate3D(pi / 4, inplace=False)
+    newF = framework_transformations.rotate3D(F, pi / 4, inplace=False)
     assert newF[0].equals(Matrix([[0], [0], [0]]))
     assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)], [0]]))
     assert newF[2].equals(Matrix([[0], [sqrt(2)], [0]]))
 
-    F.rotate3D(pi / 2, axis_direction=[0, 1, 0], inplace=True)
+    framework_transformations.rotate3D(
+        F, pi / 2, axis_direction=[0, 1, 0], inplace=True
+    )
     assert F[0].equals(Matrix([[0], [0], [0]]))
     assert F[1].equals(Matrix([[0], [0], [-2]]))
     assert F[2].equals(Matrix([[0], [1], [-1]]))
 
     F = Framework(G, {0: (1, 0, 0), 1: (0, 1, 0), 2: (0, 0, 1)})
-    newF = F.rotate3D(2 * pi / 3, axis_direction=[1, 1, 1], inplace=False)
+    F = _to_FrameworkBase(F)
+    newF = framework_transformations.rotate3D(
+        F, 2 * pi / 3, axis_direction=[1, 1, 1], inplace=False
+    )
     assert newF[0].equals(Matrix([[0], [1], [0]]))
     assert newF[1].equals(Matrix([[0], [0], [1]]))
     assert newF[2].equals(Matrix([[1], [0], [0]]))
 
-    F.rotate3D(4 * pi / 3, axis_direction=[1, 1, 1], inplace=True)
+    framework_transformations.rotate3D(
+        F, 4 * pi / 3, axis_direction=[1, 1, 1], inplace=True
+    )
     assert F[0].equals(Matrix([[0], [0], [1]]))
     assert F[1].equals(Matrix([[1], [0], [0]]))
     assert F[2].equals(Matrix([[0], [1], [0]]))
 
     F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (0, 2, 0)})
-    F.rotate3D(pi, axis_shift=[1, 1, 0], inplace=True)
+    F = _to_FrameworkBase(F)
+    framework_transformations.rotate3D(F, pi, axis_shift=[1, 1, 0], inplace=True)
     assert F[0].equals(Matrix([[2], [2], [0]]))
     assert F[1].equals(Matrix([[0], [2], [0]]))
     assert F[2].equals(Matrix([[2], [0], [0]]))
-
-    if TEST_WRAPPED_FUNCTIONS:
-        F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (1, 1, 0)})
-        F = _to_FrameworkBase(F)
-
-        newF = framework_transformations.rotate3D(F, 0, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate3D(F, pi * 4, inplace=False)
-        for v, pos in newF.realization().items():
-            assert pos.equals(F[v])
-
-        newF = framework_transformations.rotate3D(F, pi / 2, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0], [0]]))
-        assert newF[1].equals(Matrix([[0], [2], [0]]))
-        assert newF[2].equals(Matrix([[-1], [1], [0]]))
-
-        newF = framework_transformations.rotate3D(F, pi / 4, inplace=False)
-        assert newF[0].equals(Matrix([[0], [0], [0]]))
-        assert newF[1].equals(Matrix([[sqrt(2)], [sqrt(2)], [0]]))
-        assert newF[2].equals(Matrix([[0], [sqrt(2)], [0]]))
-
-        framework_transformations.rotate3D(
-            F, pi / 2, axis_direction=[0, 1, 0], inplace=True
-        )
-        assert F[0].equals(Matrix([[0], [0], [0]]))
-        assert F[1].equals(Matrix([[0], [0], [-2]]))
-        assert F[2].equals(Matrix([[0], [1], [-1]]))
-
-        F = Framework(G, {0: (1, 0, 0), 1: (0, 1, 0), 2: (0, 0, 1)})
-        newF = F.rotate3D(2 * pi / 3, axis_direction=[1, 1, 1], inplace=False)
-        assert newF[0].equals(Matrix([[0], [1], [0]]))
-        assert newF[1].equals(Matrix([[0], [0], [1]]))
-        assert newF[2].equals(Matrix([[1], [0], [0]]))
-
-        F.rotate3D(4 * pi / 3, axis_direction=[1, 1, 1], inplace=True)
-        assert F[0].equals(Matrix([[0], [0], [1]]))
-        assert F[1].equals(Matrix([[1], [0], [0]]))
-        assert F[2].equals(Matrix([[0], [1], [0]]))
-
-        F = Framework(G, {0: (0, 0, 0), 1: (2, 0, 0), 2: (0, 2, 0)})
-        F.rotate3D(pi, axis_shift=[1, 1, 0], inplace=True)
-        assert F[0].equals(Matrix([[2], [2], [0]]))
-        assert F[1].equals(Matrix([[0], [2], [0]]))
-        assert F[2].equals(Matrix([[2], [0], [0]]))

--- a/test/graph/constructions/test_constructions.py
+++ b/test/graph/constructions/test_constructions.py
@@ -3,20 +3,12 @@ import networkx as nx
 import pyrigi.graphDB as graphs
 from pyrigi.graph._constructions import constructions as graph_constructions
 from pyrigi.graph._general import max_degree
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 def test_cone():
-    G = graphs.Complete(5).cone()
+    G = graph_constructions.cone(nx.Graph(graphs.Complete(5)))
     assert set(G.nodes) == set([0, 1, 2, 3, 4, 5]) and len(G.nodes) == 6
-    G = graphs.Complete(4).cone(vertex="a")
+    G = graph_constructions.cone(nx.Graph(graphs.Complete(4)), vertex="a")
     assert "a" in G.nodes
-    G = graphs.Cycle(4).cone()
-    assert G.number_of_nodes() == G.max_degree() + 1
-    if TEST_WRAPPED_FUNCTIONS:
-        G = graph_constructions.cone(nx.Graph(graphs.Complete(5)))
-        assert set(G.nodes) == set([0, 1, 2, 3, 4, 5]) and len(G.nodes) == 6
-        G = graph_constructions.cone(nx.Graph(graphs.Complete(4)), vertex="a")
-        assert "a" in G.nodes
-        G = graph_constructions.cone(nx.Graph(graphs.Cycle(4)))
-        assert G.number_of_nodes() == max_degree(G) + 1
+    G = graph_constructions.cone(nx.Graph(graphs.Cycle(4)))
+    assert G.number_of_nodes() == max_degree(G) + 1

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -7,7 +7,6 @@ import pyrigi.graphDB as graphs
 from pyrigi.exception import NotSupportedValueError
 from pyrigi.graph import Graph
 from pyrigi.graph._utils.utils import is_isomorphic_graph_list
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 ###############################################################
@@ -36,39 +35,54 @@ def test_k_extension():
         ]
     )
 
-    assert graphs.CompleteBipartite(3, 2).k_extension(
-        2, [0, 1, 3], [(0, 3), (1, 3)], dim=1
-    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)])
-    assert graphs.CompleteBipartite(3, 2).k_extension(
-        2, [0, 1, 3, 4], [(0, 3), (1, 3)]
-    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)])
-    assert graphs.Cycle(6).k_extension(
-        4, [0, 1, 2, 3, 4], [(0, 1), (1, 2), (2, 3), (3, 4)], dim=1
-    ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
-    if TEST_WRAPPED_FUNCTIONS:
-        assert Graph(
-            [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]
-        ) == extension.k_extension(
+    assert Graph(
+        extension.k_extension(
             nx.Graph(graphs.CompleteBipartite(3, 2)),
             2,
             [0, 1, 3],
             [(0, 3), (1, 3)],
             dim=1,
         )
-        assert Graph(
-            [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
-        ) == extension.k_extension(
+    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)])
+    assert Graph(
+        extension.k_extension(
             nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
         )
-        assert Graph(
-            [(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]
-        ) == extension.k_extension(
+    ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)])
+    assert Graph(
+        extension.k_extension(
             nx.Graph(graphs.Cycle(6)),
             4,
             [0, 1, 2, 3, 4],
             [(0, 1), (1, 2), (2, 3), (3, 4)],
             dim=1,
         )
+    ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
+    assert Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)),
+            2,
+            [0, 1, 3],
+            [(0, 3), (1, 3)],
+            dim=1,
+        )
+    )
+    assert Graph(
+        [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
+    ) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+        )
+    )
+    assert Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]) == Graph(
+        extension.k_extension(
+            nx.Graph(graphs.Cycle(6)),
+            4,
+            [0, 1, 2, 3, 4],
+            [(0, 1), (1, 2), (2, 3), (3, 4)],
+            dim=1,
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -83,10 +97,7 @@ def test_k_extension():
 )
 def test_k_extension_dim_error(graph, k, vertices, edges, dim):
     with pytest.raises(ValueError):
-        graph.k_extension(k, vertices, edges, dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            extension.k_extension(nx.Graph(graph), k, vertices, edges, dim=dim)
+        extension.k_extension(nx.Graph(graph), k, vertices, edges, dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -109,18 +120,15 @@ def test_k_extension_dim_error(graph, k, vertices, edges, dim):
 )
 def test_k_extension_error(graph, k, vertices, edges):
     with pytest.raises(ValueError):
-        graph.k_extension(k, vertices, edges)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            extension.k_extension(nx.Graph(graph), k, vertices, edges)
+        extension.k_extension(nx.Graph(graph), k, vertices, edges)
 
 
 ###############################################################
 # all_k_extensions
 ###############################################################
 def test_all_k_extensions():
-    for ext in graphs.Complete(4).all_k_extensions(1, 1):
-        assert ext in [
+    for ext in extension.all_k_extensions(nx.Graph(graphs.Complete(4)), 1, 1):
+        assert Graph(ext) in [
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3]]),
             Graph([[0, 1], [0, 3], [0, 4], [1, 2], [1, 3], [2, 3], [2, 4]]),
             Graph([[0, 1], [0, 2], [0, 4], [1, 2], [1, 3], [2, 3], [3, 4]]),
@@ -128,68 +136,40 @@ def test_all_k_extensions():
             Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]]),
             Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 4], [3, 4]]),
         ]
-    for ext in graphs.Complete(4).all_k_extensions(2, 2, only_non_isomorphic=True):
-        assert ext in [
+    for ext in extension.all_k_extensions(
+        nx.Graph(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
+    ):
+        assert Graph(ext) in [
             Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 4], [3, 4]]),
         ]
-    all_diamond_0_2 = list(
-        graphs.Diamond().all_k_extensions(0, 2, only_non_isomorphic=True)
-    )
+    all_diamond_0_2 = [
+        Graph(G)
+        for G in extension.all_k_extensions(
+            nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
+        )
+    ]
     assert (
         len(all_diamond_0_2) == 3
-        and all_diamond_0_2[0]
-        == Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
-        and all_diamond_0_2[1]
-        == Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
-        and all_diamond_0_2[2]
-        == Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
+        and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
+        == all_diamond_0_2[0]
+        and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
+        == all_diamond_0_2[1]
+        and Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
+        == all_diamond_0_2[2]
     )
-    all_diamond_1_2 = graphs.Diamond().all_k_extensions(1, 2, only_non_isomorphic=True)
-    assert next(all_diamond_1_2) == Graph(
-        [[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]
-    ) and next(all_diamond_1_2) == Graph(
-        [[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]
+    all_diamond_1_2 = [
+        Graph(G)
+        for G in extension.all_k_extensions(
+            nx.Graph(graphs.Diamond()), 1, 2, only_non_isomorphic=True
+        )
+    ]
+    assert (
+        Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]])
+        == all_diamond_1_2[0]
+        and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]])
+        == all_diamond_1_2[1]
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        for ext in extension.all_k_extensions(nx.Graph(graphs.Complete(4)), 1, 1):
-            assert Graph(ext) in [
-                Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3]]),
-                Graph([[0, 1], [0, 3], [0, 4], [1, 2], [1, 3], [2, 3], [2, 4]]),
-                Graph([[0, 1], [0, 2], [0, 4], [1, 2], [1, 3], [2, 3], [3, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 3], [1, 4], [2, 3], [2, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]]),
-                Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 4], [3, 4]]),
-            ]
-        for ext in extension.all_k_extensions(
-            nx.Graph(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
-        ):
-            assert Graph(ext) in [
-                Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
-                Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 4], [3, 4]]),
-            ]
-        all_diamond_0_2 = list(
-            extension.all_k_extensions(
-                nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
-            )
-        )
-        assert (
-            len(all_diamond_0_2) == 3
-            and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3]])
-            == all_diamond_0_2[0]
-            and Graph([[0, 1], [0, 2], [0, 3], [0, 4], [1, 2], [2, 3], [2, 4]])
-            == all_diamond_0_2[1]
-            and Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 3], [3, 4]])
-            == all_diamond_0_2[2]
-        )
-        all_diamond_1_2 = extension.all_k_extensions(
-            graphs.Diamond(), 1, 2, only_non_isomorphic=True
-        )
-        assert Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [2, 4]]) == next(
-            all_diamond_1_2
-        ) and Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 4], [2, 3], [3, 4]]) == next(
-            all_diamond_1_2
-        )
 
 
 @pytest.mark.parametrize(
@@ -210,30 +190,19 @@ def test_all_k_extensions():
 )
 def test_all_k_extensions2(graph, k, dim, sol):
     assert is_isomorphic_graph_list(
-        list(graph.all_k_extensions(k, dim, only_non_isomorphic=True)),
+        [
+            Graph(G)
+            for G in extension.all_k_extensions(
+                nx.Graph(graph), k, dim, only_non_isomorphic=True
+            )
+        ],
         [Graph.from_int(igraph) for igraph in sol],
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        assert is_isomorphic_graph_list(
-            list(
-                extension.all_k_extensions(
-                    nx.Graph(graph), k, dim, only_non_isomorphic=True
-                )
-            ),
-            [Graph.from_int(igraph) for igraph in sol],
-        )
 
 
 def test_all_k_extension_error():
     with pytest.raises(ValueError):
-        list(Graph.from_vertices([0, 1, 2]).all_k_extensions(1, 1))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            list(
-                extension.all_k_extensions(
-                    nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1
-                )
-            )
+        list(extension.all_k_extensions(nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1))
 
 
 ###############################################################
@@ -257,16 +226,14 @@ def test_all_k_extension_error():
 )
 def test_all_extensions(graph, dim, sol):
     assert is_isomorphic_graph_list(
-        list(graph.all_extensions(dim, only_non_isomorphic=True)),
+        [
+            Graph(G)
+            for G in extension.all_extensions(
+                nx.Graph(graph), dim, only_non_isomorphic=True
+            )
+        ],
         [Graph.from_int(igraph) for igraph in sol],
     )
-    if TEST_WRAPPED_FUNCTIONS:
-        assert is_isomorphic_graph_list(
-            list(
-                extension.all_extensions(nx.Graph(graph), dim, only_non_isomorphic=True)
-            ),
-            [Graph.from_int(igraph) for igraph in sol],
-        )
 
 
 @pytest.mark.parametrize(
@@ -285,31 +252,21 @@ def test_all_extensions(graph, dim, sol):
 def test_all_extensions_single(graph, dim):
     for k in range(0, dim):
         assert is_isomorphic_graph_list(
-            list(graph.all_extensions(dim, only_non_isomorphic=True, k_min=k, k_max=k)),
-            list(graph.all_k_extensions(k, dim, only_non_isomorphic=True)),
+            list(
+                extension.all_extensions(
+                    nx.Graph(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
+                )
+            ),
+            list(
+                extension.all_k_extensions(
+                    nx.Graph(graph), k, dim, only_non_isomorphic=True
+                )
+            ),
         )
         assert is_isomorphic_graph_list(
-            list(graph.all_extensions(dim, k_min=k, k_max=k)),
-            list(graph.all_k_extensions(k, dim)),
+            list(extension.all_extensions(nx.Graph(graph), dim, k_min=k, k_max=k)),
+            list(extension.all_k_extensions(nx.Graph(graph), k, dim)),
         )
-    if TEST_WRAPPED_FUNCTIONS:
-        for k in range(0, dim):
-            assert is_isomorphic_graph_list(
-                list(
-                    extension.all_extensions(
-                        nx.Graph(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
-                    )
-                ),
-                list(
-                    extension.all_k_extensions(
-                        nx.Graph(graph), k, dim, only_non_isomorphic=True
-                    )
-                ),
-            )
-            assert is_isomorphic_graph_list(
-                list(extension.all_extensions(nx.Graph(graph), dim, k_min=k, k_max=k)),
-                list(extension.all_k_extensions(nx.Graph(graph), k, dim)),
-            )
 
 
 @pytest.mark.parametrize(
@@ -326,14 +283,9 @@ def test_all_extensions_single(graph, dim):
 )
 def test_all_extensions_value_error(graph, dim, k_min, k_max):
     with pytest.raises(ValueError):
-        list(graph.all_extensions(dim=dim, k_min=k_min, k_max=k_max))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            list(
-                extension.all_extensions(
-                    nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-                )
-            )
+        list(
+            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
+        )
 
 
 @pytest.mark.parametrize(
@@ -352,14 +304,9 @@ def test_all_extensions_value_error(graph, dim, k_min, k_max):
 )
 def test_all_extensions_type_error(graph, dim, k_min, k_max):
     with pytest.raises(TypeError):
-        list(graph.all_extensions(dim=dim, k_min=k_min, k_max=k_max))
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            list(
-                extension.all_extensions(
-                    nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max
-                )
-            )
+        list(
+            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
+        )
 
 
 ###############################################################
@@ -382,9 +329,7 @@ def test_all_extensions_type_error(graph, dim, k_min, k_max):
     ],
 )
 def test_has_extension_sequence(graph):
-    assert graph.has_extension_sequence()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.has_extension_sequence(nx.Graph(graph))
+    assert extension.has_extension_sequence(nx.Graph(graph))
 
 
 @pytest.mark.parametrize(
@@ -403,20 +348,28 @@ def test_has_extension_sequence(graph):
     ],
 )
 def test_has_not_extension_sequence(graph):
-    assert not graph.has_extension_sequence()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not extension.has_extension_sequence(nx.Graph(graph))
+    assert not extension.has_extension_sequence(nx.Graph(graph))
 
 
 ###############################################################
 # extension_sequence
 ###############################################################
 def test_extension_sequence_solution():
-    assert graphs.Complete(2).extension_sequence(return_type="graphs") == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Complete(2)), return_type="graphs"
+        )
+    ] == [
         Graph([[0, 1]]),
     ]
 
-    assert graphs.Complete(3).extension_sequence(return_type="graphs") == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Complete(3)), return_type="graphs"
+        )
+    ] == [
         Graph([[1, 2]]),
         Graph([[0, 1], [0, 2], [1, 2]]),
     ]
@@ -427,13 +380,25 @@ def test_extension_sequence_solution():
         Graph([[1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
         Graph([[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4]]),
         Graph(
-            [[0, 3], [0, 4], [0, 5], [1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5]],
+            [
+                [0, 3],
+                [0, 4],
+                [0, 5],
+                [1, 3],
+                [1, 4],
+                [1, 5],
+                [2, 3],
+                [2, 4],
+                [2, 5],
+            ],
         ),
     ]
-    assert (
-        graphs.CompleteBipartite(3, 3).extension_sequence(return_type="graphs")
-        == solution
-    )
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.CompleteBipartite(3, 3)), return_type="graphs"
+        )
+    ] == solution
 
     solution_ext = [
         [0, [3, 4], [], 2],  # k, vertices, edges, new_vertex
@@ -441,26 +406,43 @@ def test_extension_sequence_solution():
         [0, [1, 2], [], 5],
         [1, [3, 4, 5], [(3, 4)], 0],
     ]
-    G = Graph([[3, 4]])
+    G = nx.Graph([[3, 4]])
     for i in range(len(solution)):
         assert solution[i] == G
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
+            extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
-    assert graphs.Diamond().extension_sequence(return_type="graphs") == [
+    assert [
+        Graph(G)
+        for G in extension.extension_sequence(
+            nx.Graph(graphs.Diamond()), return_type="graphs"
+        )
+    ] == [
         Graph([[2, 3]]),
         Graph([[0, 2], [0, 3], [2, 3]]),
         Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
     ]
 
-    result = graphs.ThreePrism().extension_sequence(return_type="graphs")
+    result = extension.extension_sequence(
+        nx.Graph(graphs.ThreePrism()), return_type="graphs"
+    )
     solution = [
         Graph([[4, 5]]),
         Graph([[3, 4], [3, 5], [4, 5]]),
         Graph([[1, 3], [1, 4], [3, 4], [3, 5], [4, 5]]),
         Graph([[1, 2], [1, 3], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]),
         Graph(
-            [[0, 1], [0, 2], [0, 3], [1, 2], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]],
+            [
+                [0, 1],
+                [0, 2],
+                [0, 3],
+                [1, 2],
+                [1, 4],
+                [2, 5],
+                [3, 4],
+                [3, 5],
+                [4, 5],
+            ],
         ),
     ]
     assert solution == result
@@ -470,101 +452,11 @@ def test_extension_sequence_solution():
         [0, [1, 5], [], 2],
         [1, [1, 2, 3], [(1, 3)], 0],
     ]
-    G = Graph([[4, 5]])
+    G = nx.Graph([[4, 5]])
     for i in range(len(result)):
-        assert result[i] == G
+        assert result[i] == Graph(G)
         if i < len(solution_ext):
-            G.k_extension(*solution_ext[i], dim=2, inplace=True)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(
-            graphs.Complete(2), return_type="graphs"
-        ) == [
-            Graph([[0, 1]]),
-        ]
-
-        assert extension.extension_sequence(
-            graphs.Complete(3), return_type="graphs"
-        ) == [
-            Graph([[1, 2]]),
-            Graph([[0, 1], [0, 2], [1, 2]]),
-        ]
-
-        solution = [
-            Graph([[3, 4]]),
-            Graph([[2, 3], [2, 4], [3, 4]]),
-            Graph([[1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
-            Graph([[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 4]]),
-            Graph(
-                [
-                    [0, 3],
-                    [0, 4],
-                    [0, 5],
-                    [1, 3],
-                    [1, 4],
-                    [1, 5],
-                    [2, 3],
-                    [2, 4],
-                    [2, 5],
-                ],
-            ),
-        ]
-        assert (
-            extension.extension_sequence(
-                graphs.CompleteBipartite(3, 3), return_type="graphs"
-            )
-            == solution
-        )
-
-        solution_ext = [
-            [0, [3, 4], [], 2],  # k, vertices, edges, new_vertex
-            [0, [3, 4], [], 1],
-            [0, [1, 2], [], 5],
-            [1, [3, 4, 5], [(3, 4)], 0],
-        ]
-        G = Graph([[3, 4]])
-        for i in range(len(solution)):
-            assert solution[i] == G
-            if i < len(solution_ext):
-                extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
-
-        assert extension.extension_sequence(graphs.Diamond(), return_type="graphs") == [
-            Graph([[2, 3]]),
-            Graph([[0, 2], [0, 3], [2, 3]]),
-            Graph([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]]),
-        ]
-
-        result = extension.extension_sequence(graphs.ThreePrism(), return_type="graphs")
-        solution = [
-            Graph([[4, 5]]),
-            Graph([[3, 4], [3, 5], [4, 5]]),
-            Graph([[1, 3], [1, 4], [3, 4], [3, 5], [4, 5]]),
-            Graph([[1, 2], [1, 3], [1, 4], [2, 5], [3, 4], [3, 5], [4, 5]]),
-            Graph(
-                [
-                    [0, 1],
-                    [0, 2],
-                    [0, 3],
-                    [1, 2],
-                    [1, 4],
-                    [2, 5],
-                    [3, 4],
-                    [3, 5],
-                    [4, 5],
-                ],
-            ),
-        ]
-        assert solution == result
-        solution_ext = [
-            [0, [4, 5], [], 3],  # k, vertices, edges, new_vertex
-            [0, [3, 4], [], 1],
-            [0, [1, 5], [], 2],
-            [1, [1, 2, 3], [(1, 3)], 0],
-        ]
-        G = Graph([[4, 5]])
-        for i in range(len(result)):
-            assert result[i] == G
-            if i < len(solution_ext):
-                extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
+            extension.k_extension(G, *solution_ext[i], dim=2, inplace=True)
 
 
 @pytest.mark.parametrize(
@@ -584,19 +476,12 @@ def test_extension_sequence_solution():
     ],
 )
 def test_extension_sequence(graph):
-    ext = graph.extension_sequence(return_type="both")
+    ext = extension.extension_sequence(nx.Graph(graph), return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = current.k_extension(*ext[i][1])
-        assert current == ext[i][0]
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(nx.Graph(graph), return_type="both")
-        assert ext is not None
-        current = ext[0]
-        for i in range(1, len(ext)):
-            current = extension.k_extension(nx.Graph(current), *ext[i][1])
-            assert Graph(current) == ext[i][0]
+        current = extension.k_extension(nx.Graph(current), *ext[i][1])
+        assert Graph(current) == Graph(ext[i][0])
 
 
 @pytest.mark.parametrize(
@@ -626,19 +511,12 @@ def test_extension_sequence(graph):
     ],
 )
 def test_extension_sequence_dim(graph, dim):
-    ext = graph.extension_sequence(dim=dim, return_type="both")
+    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = current.k_extension(*ext[i][1], dim=dim)
-        assert current == ext[i][0]
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="both")
-        assert ext is not None
-        current = ext[0]
-        for i in range(1, len(ext)):
-            current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
-            assert Graph(current) == ext[i][0]
+        current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
+        assert Graph(current) == Graph(ext[i][0])
 
 
 @pytest.mark.parametrize(
@@ -663,17 +541,10 @@ def test_extension_sequence_dim(graph, dim):
     ],
 )
 def test_extension_sequence_min_rigid(graph, dim):
-    ext = graph.extension_sequence(dim=dim, return_type="graphs")
+    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="graphs")
     assert ext is not None
     for current in ext:
-        assert current.is_min_rigid(dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        ext = extension.extension_sequence(
-            nx.Graph(graph), dim=dim, return_type="graphs"
-        )
-        assert ext is not None
-        for current in ext:
-            assert generic_rigidity.is_min_rigid(current, dim)
+        assert generic_rigidity.is_min_rigid(nx.Graph(current), dim)
 
 
 @pytest.mark.parametrize(
@@ -692,9 +563,7 @@ def test_extension_sequence_min_rigid(graph, dim):
     ],
 )
 def test_extension_sequence_none(graph):
-    assert graph.extension_sequence() is None
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(nx.Graph(graph)) is None
+    assert extension.extension_sequence(nx.Graph(graph)) is None
 
 
 @pytest.mark.parametrize(
@@ -716,16 +585,9 @@ def test_extension_sequence_none(graph):
     ],
 )
 def test_extension_sequence_dim_none(graph, dim):
-    assert graph.extension_sequence(dim) is None
-    if TEST_WRAPPED_FUNCTIONS:
-        assert extension.extension_sequence(nx.Graph(graph), dim) is None
+    assert extension.extension_sequence(nx.Graph(graph), dim) is None
 
 
 def test_extension_sequence_error():
     with pytest.raises(NotSupportedValueError):
-        graphs.Complete(3).extension_sequence(return_type="Test")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(NotSupportedValueError):
-            extension.extension_sequence(
-                nx.Graph(graphs.Complete(3)), return_type="Test"
-            )
+        extension.extension_sequence(nx.Graph(graphs.Complete(3)), return_type="Test")

--- a/test/graph/export/test_export.py
+++ b/test/graph/export/test_export.py
@@ -5,7 +5,6 @@ from sympy import Matrix
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph._export import export
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 @pytest.mark.parametrize(
@@ -20,21 +19,19 @@ from test import TEST_WRAPPED_FUNCTIONS
     ],
 )
 def test_integer_representation(graph, gint):
-    assert graph.to_int() == gint
+    assert export.to_int(nx.Graph(graph)) == gint
     assert Graph.from_int(gint).is_isomorphic(graph)
-    assert Graph.from_int(gint).to_int() == gint
-    assert Graph.from_int(graph.to_int()).is_isomorphic(graph)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert export.to_int(nx.Graph(graph)) == gint
+    assert export.to_int(nx.Graph(Graph.from_int(gint))) == gint
+    assert Graph.from_int(export.to_int(nx.Graph(graph))).is_isomorphic(graph)
 
 
 def test_integer_representation_error():
     with pytest.raises(ValueError):
-        Graph([]).to_int()
+        export.to_int(nx.Graph([]))
     with pytest.raises(ValueError):
         M = Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
         G = Graph.from_adjacency_matrix(M)
-        G.to_int()
+        export.to_int(nx.Graph(G))
     with pytest.raises(ValueError):
         Graph.from_int(0)
     with pytest.raises(TypeError):
@@ -43,10 +40,3 @@ def test_integer_representation_error():
         Graph.from_int(1.2)
     with pytest.raises(ValueError):
         Graph.from_int(-1)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            export.to_int(nx.Graph([]))
-        with pytest.raises(ValueError):
-            M = Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
-            G = Graph.from_adjacency_matrix(M)
-            export.to_int(nx.Graph(G))

--- a/test/graph/other/test_apex.py
+++ b/test/graph/other/test_apex.py
@@ -7,7 +7,6 @@ import pytest
 import pyrigi.graph._other.apex as apex
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 ###############################################################
@@ -31,9 +30,7 @@ from test import TEST_WRAPPED_FUNCTIONS
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_vertex_apex(graph, k):
-    assert graph.is_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_k_vertex_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -46,9 +43,7 @@ def test_is_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_vertex_apex(graph, k):
-    assert not graph.is_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_k_vertex_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -72,9 +67,7 @@ def test_is_not_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_edge_apex(graph, k):
-    assert graph.is_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_k_edge_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -88,9 +81,7 @@ def test_is_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_edge_apex(graph, k):
-    assert not graph.is_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_k_edge_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -114,9 +105,7 @@ def test_is_not_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_critically_k_vertex_apex(graph, k):
-    assert graph.is_critically_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -131,9 +120,7 @@ def test_is_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_critically_k_vertex_apex(graph, k):
-    assert not graph.is_critically_k_vertex_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
 
 
 ###############################################################
@@ -159,9 +146,7 @@ def test_is_not_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1 if n == 3 else 2 * n - 3] for n in range(3, 5)],
 )
 def test_is_critically_k_edge_apex(graph, k):
-    assert graph.is_critically_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_edge_apex(nx.Graph(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -176,9 +161,7 @@ def test_is_critically_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0 if n == 3 else 2 * n - 4] for n in range(3, 6)],
 )
 def test_is_not_critically_k_edge_apex(graph, k):
-    assert not graph.is_critically_k_edge_apex(k)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_edge_apex(nx.Graph(graph), k)
 
 
 ###############################################################

--- a/test/graph/rigidity/test_generic_rigidity.py
+++ b/test/graph/rigidity/test_generic_rigidity.py
@@ -9,7 +9,6 @@ import pyrigi.graph._sparsity.sparsity as sparsity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.warning import RandomizedAlgorithmWarning
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import (
     is_rigid_algorithms_all_d,
     is_rigid_algorithms_d1,
@@ -38,9 +37,7 @@ is_min_rigid_algorithms_d1 = is_min_rigid_algorithms_all_d + ["graphic"]
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_rigid(graph, dim, algorithm):
-    assert graph.is_rigid(dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -60,9 +57,7 @@ def test_is_rigid(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_rigid_d1(graph, algorithm):
-    assert graph.is_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -75,11 +70,7 @@ def test_is_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_rigid_d1(graph, algorithm):
-    assert not graph.is_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -100,9 +91,7 @@ def test_is_not_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_rigid_d2(graph, algorithm):
-    assert graph.is_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -118,11 +107,7 @@ def test_is_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_not_is_rigid_d2(graph, algorithm):
-    assert not graph.is_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -135,12 +120,8 @@ def test_not_is_rigid_d2(graph, algorithm):
 def test_is_rigid_dimension_sparsity_error(method, params):
     G = graphs.DoubleBanana()
     with pytest.raises(ValueError):
-        func = getattr(G, method)
-        func(*params, algorithm="sparsity")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            func = getattr(generic_rigidity, method)
-            func(nx.Graph(G), *params, algorithm="sparsity")
+        func = getattr(generic_rigidity, method)
+        func(nx.Graph(G), *params, algorithm="sparsity")
 
 
 ###############################################################
@@ -157,11 +138,7 @@ def test_is_rigid_dimension_sparsity_error(method, params):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_min_rigid_d1(graph, algorithm):
-    assert graph.is_min_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -180,11 +157,9 @@ def test_is_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_not_min_rigid_d1(graph, algorithm):
-    assert not graph.is_min_rigid(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -199,11 +174,7 @@ def test_is_not_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_min_rigid_d2(graph, algorithm):
-    assert graph.is_min_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -225,11 +196,9 @@ def test_is_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_not_min_rigid_d2(graph, algorithm):
-    assert not graph.is_min_rigid(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -245,11 +214,7 @@ def test_is_not_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_min_rigid_d3(graph, algorithm):
-    assert graph.is_min_rigid(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=3, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -265,11 +230,9 @@ def test_is_min_rigid_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_not_min_rigid_d3(graph, algorithm):
-    assert not graph.is_min_rigid(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not generic_rigidity.is_min_rigid(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert not generic_rigidity.is_min_rigid(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -317,70 +280,51 @@ def test_rigid_components(graph, components, dim):
 
     if dim == 1:
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="graphic")) == comps_set
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="graphic"
+                )
+            )
+            == comps_set
         )
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="graphic"
-                    )
-                )
-                == comps_set
-            )
     elif dim == 2:
-        assert to_sets(graph.rigid_components(dim=dim, algorithm="pebble")) == comps_set
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="pebble"
-                    )
+        assert (
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="pebble"
                 )
-                == comps_set
             )
+            == comps_set
+        )
         if graph.number_of_nodes() <= 8:  # since it runs through all subgraphs
             assert (
-                to_sets(graph.rigid_components(dim=dim, algorithm="subgraphs-pebble"))
+                to_sets(
+                    generic_rigidity.rigid_components(
+                        nx.Graph(graph), dim=dim, algorithm="subgraphs-pebble"
+                    )
+                )
                 == comps_set
             )
-            if TEST_WRAPPED_FUNCTIONS:
-                assert (
-                    to_sets(
-                        generic_rigidity.rigid_components(
-                            nx.Graph(graph), dim=dim, algorithm="subgraphs-pebble"
-                        )
-                    )
-                    == comps_set
-                )
 
     # randomized algorithm is tested for all dimensions for graphs
     # with at most 8 vertices (since it runs through all subgraphs)
     if graph.number_of_nodes() <= 8:
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="randomized"))
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="randomized"
+                )
+            )
             == comps_set
         )
         assert (
-            to_sets(graph.rigid_components(dim=dim, algorithm="numerical")) == comps_set
+            to_sets(
+                generic_rigidity.rigid_components(
+                    nx.Graph(graph), dim=dim, algorithm="numerical"
+                )
+            )
+            == comps_set
         )
-        if TEST_WRAPPED_FUNCTIONS:
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="randomized"
-                    )
-                )
-                == comps_set
-            )
-            assert (
-                to_sets(
-                    generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="numerical"
-                    )
-                )
-                == comps_set
-            )
 
 
 @pytest.mark.parametrize(
@@ -436,22 +380,15 @@ def test_rigid_components_pebble_random_graphs(graph):
     ],
 )
 def test_max_rigid_dimension(graph, k):
-    assert graph.max_rigid_dimension() == k
-    assert graph.max_rigid_dimension(algorithm="numerical") == k
-    if TEST_WRAPPED_FUNCTIONS:
-        assert generic_rigidity.max_rigid_dimension(nx.Graph(graph)) == k
-        assert (
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
-            == k
-        )
+    assert generic_rigidity.max_rigid_dimension(nx.Graph(graph)) == k
+    assert (
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        == k
+    )
 
 
 def test_max_rigid_dimension_warning():
     graph = graphs.K66MinusPerfectMatching()
     with pytest.warns(RandomizedAlgorithmWarning):
-        graph.max_rigid_dimension()
-        graph.max_rigid_dimension(algorithm="numerical")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.warns(RandomizedAlgorithmWarning):
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph))
-            generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph))
+        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")

--- a/test/graph/rigidity/test_global_rigidity.py
+++ b/test/graph/rigidity/test_global_rigidity.py
@@ -6,7 +6,6 @@ import pytest
 import pyrigi.graph._rigidity.global_ as global_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_globally, read_redundantly
 
 ###############################################################
@@ -47,9 +46,7 @@ from test.graph.test_graph import read_globally, read_redundantly
     ],
 )
 def test_is_globally_rigid(graph, dim):
-    assert graph.is_globally_rigid(dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -98,9 +95,7 @@ def test_is_globally_rigid(graph, dim):
     ],
 )
 def test_is_not_globally_rigid(graph, dim):
-    assert not graph.is_globally_rigid(dim=dim)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -116,9 +111,7 @@ def test_is_not_globally_rigid(graph, dim):
     ],
 )
 def test_is_globally_rigid_d2(graph):
-    assert graph.is_globally_rigid(dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
 
 
 @pytest.mark.parametrize(
@@ -136,9 +129,7 @@ def test_is_globally_rigid_d2(graph):
     ],
 )
 def test_is_not_globally_d2(graph):
-    assert not graph.is_globally_rigid(dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
 
 
 ###############################################################
@@ -261,6 +252,4 @@ def test_is_weakly_globally_linked_for_redundantly_rigid_graphs(graph):
     ],
 )
 def test_is_weakly_globally_linked_articles_graphs(graph, u, v):
-    assert graph.is_weakly_globally_linked(u, v, dim=2)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v, dim=2)
+    assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v, dim=2)

--- a/test/graph/rigidity/test_matroidal_rigidity.py
+++ b/test/graph/rigidity/test_matroidal_rigidity.py
@@ -5,7 +5,6 @@ import pyrigi.graph._rigidity.matroidal as matroidal_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.warning import RandomizedAlgorithmWarning
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_sparsity
 
 Rd_algorithms_all_d = ["default", "randomized"]
@@ -27,11 +26,7 @@ is_Rd_closed_algorithms_d2 = is_Rd_closed_algorithms_all_d + ["pebble"]
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_circuit_d1(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -52,11 +47,9 @@ def test_is_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_not_Rd_circuit_d1(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -76,11 +69,7 @@ def test_is_not_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_circuit_d2(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -118,11 +107,9 @@ def test_is_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_not_Rd_circuit_d2(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -135,11 +122,7 @@ def test_is_not_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_circuit_d3(graph, algorithm):
-    assert graph.is_Rd_circuit(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=3, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -154,11 +137,9 @@ def test_is_Rd_circuit_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_not_Rd_circuit_d3(graph, algorithm):
-    assert not graph.is_Rd_circuit(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_circuit(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_circuit(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -175,11 +156,9 @@ def test_is_not_Rd_circuit_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_Rd_closed(graph, dim, algorithm):
-    assert graph.is_Rd_closed(dim=dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=dim, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=dim, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -191,11 +170,9 @@ def test_is_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_not_Rd_closed(graph, dim, algorithm):
-    assert not graph.is_Rd_closed(dim=dim, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=dim, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=dim, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -207,11 +184,7 @@ def test_is_not_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_Rd_closed_d1(graph, algorithm):
-    assert graph.is_Rd_closed(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -222,11 +195,9 @@ def test_is_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_not_Rd_closed_d1(graph, algorithm):
-    assert not graph.is_Rd_closed(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -239,11 +210,7 @@ def test_is_not_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_Rd_closed_d2(graph, algorithm):
-    assert graph.is_Rd_closed(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -256,11 +223,9 @@ def test_is_Rd_closed_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_not_Rd_closed_d2(graph, algorithm):
-    assert not graph.is_Rd_closed(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_closed(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert not matroidal_rigidity.is_Rd_closed(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -280,11 +245,9 @@ def test_is_not_Rd_closed_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_dependent_d1(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_dependent(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -297,11 +260,9 @@ def test_is_Rd_dependent_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_independent_d1(graph, algorithm):
-    assert graph.is_Rd_independent(dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=1, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -318,11 +279,9 @@ def test_is_Rd_independent_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_dependent_d2(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_dependent(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -340,11 +299,9 @@ def test_is_Rd_dependent_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_independent_d2(graph, algorithm):
-    assert graph.is_Rd_independent(dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=2, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -353,11 +310,9 @@ def test_is_Rd_independent_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_dependent_d3(graph, algorithm):
-    assert graph.is_Rd_dependent(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_dependent(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -373,17 +328,12 @@ def test_is_Rd_dependent_d3(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_independent_d3(graph, algorithm):
-    assert graph.is_Rd_independent(dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert matroidal_rigidity.is_Rd_independent(
-            nx.Graph(graph), dim=3, algorithm=algorithm
-        )
+    assert matroidal_rigidity.is_Rd_independent(
+        nx.Graph(graph), dim=3, algorithm=algorithm
+    )
 
 
 def test_is_Rd_independent_d3_warning():
     G = graphs.K33plusEdge()
     with pytest.warns(RandomizedAlgorithmWarning):
-        G.is_Rd_independent(dim=3)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.warns(RandomizedAlgorithmWarning):
-            matroidal_rigidity.is_Rd_independent(nx.Graph(G), dim=3)
+        matroidal_rigidity.is_Rd_independent(nx.Graph(G), dim=3)

--- a/test/graph/rigidity/test_redundant_rigidity.py
+++ b/test/graph/rigidity/test_redundant_rigidity.py
@@ -4,7 +4,6 @@ import pytest
 import pyrigi.graph._rigidity.redundant as redundant_rigidity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import (
     is_rigid_algorithms_all_d,
     is_rigid_algorithms_d1,
@@ -63,11 +62,9 @@ def test_is_not_vertex_redundantly_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -81,11 +78,9 @@ def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -106,11 +101,9 @@ def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -127,11 +120,9 @@ def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -159,11 +150,9 @@ def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -190,11 +179,9 @@ def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -217,11 +204,9 @@ def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -235,11 +220,9 @@ def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -259,11 +242,9 @@ def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -277,11 +258,9 @@ def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -293,11 +272,9 @@ def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_min_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -326,11 +303,9 @@ def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_min_k_vertex_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -397,11 +372,9 @@ def test_is_not_redundantly_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -414,11 +387,9 @@ def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -441,11 +412,9 @@ def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -470,11 +439,9 @@ def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -503,11 +470,9 @@ def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -530,11 +495,9 @@ def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 ###############################################################
@@ -557,11 +520,9 @@ def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -577,11 +538,9 @@ def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=1, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=1, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -601,11 +560,9 @@ def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -620,11 +577,9 @@ def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=2, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=2, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -637,11 +592,9 @@ def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert graph.is_min_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -657,8 +610,6 @@ def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_redundantly_rigid_d3(graph, k, algorithm):
-    assert not graph.is_min_k_redundantly_rigid(k, dim=3, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not redundant_rigidity.is_min_k_redundantly_rigid(
-            nx.Graph(graph), k, dim=3, algorithm=algorithm
-        )
+    assert not redundant_rigidity.is_min_k_redundantly_rigid(
+        nx.Graph(graph), k, dim=3, algorithm=algorithm
+    )

--- a/test/graph/sparsity/test_sparsity.py
+++ b/test/graph/sparsity/test_sparsity.py
@@ -8,7 +8,6 @@ import pytest
 import pyrigi.graph._sparsity.sparsity as sparsity
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
-from test import TEST_WRAPPED_FUNCTIONS
 from test.graph.test_graph import read_sparsity
 
 is_kl_sparse_algorithms_sparsity_all_kl = ["default", "subgraph"]
@@ -38,12 +37,9 @@ is_kl_sparse_algorithms_sparsity_pebble = is_kl_sparse_algorithms_sparsity_all_k
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -59,12 +55,9 @@ def test_is_kl_sparse(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_not_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -84,12 +77,9 @@ def test_is_not_kl_sparse(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_sparse(graph):
-    assert graph.is_kl_sparse(2, 3, algorithm="subgraph")
-    assert graph.is_kl_sparse(2, 3, algorithm="pebble")
+    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
     assert graph.is_sparse()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-        assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -103,12 +93,9 @@ def test_is_2_3_sparse(graph):
     ],
 )
 def test_is_not_2_3_sparse(graph):
-    assert not graph.is_kl_sparse(2, 3, algorithm="subgraph")
-    assert not graph.is_kl_sparse(2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
     assert not graph.is_sparse()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -130,12 +117,9 @@ def test_is_not_2_3_sparse(graph):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -151,12 +135,9 @@ def test_is_kl_sparse_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -180,12 +161,9 @@ def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -203,12 +181,9 @@ def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert not graph.is_kl_sparse(K, L, algorithm=algorithm)
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not graph2.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-        assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -233,9 +208,7 @@ def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_not_sparse_graphs_big_random(graph, K, L):
-    assert not graph.is_kl_sparse(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -253,10 +226,7 @@ def test_is_not_sparse_graphs_big_random(graph, K, L):
 def test_is_kl_sparse_pebble_value_error(graph, K, L):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -273,10 +243,7 @@ def test_is_kl_sparse_pebble_value_error(graph, K, L):
 def test_is_kl_sparse_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -292,10 +259,7 @@ def test_is_kl_sparse_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(TypeError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -313,10 +277,7 @@ def test_is_kl_sparse_type_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(ValueError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(ValueError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -332,10 +293,7 @@ def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(TypeError):
-        graph.is_kl_sparse(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        with pytest.raises(TypeError):
-            sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 ###############################################################
@@ -355,9 +313,7 @@ def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -377,9 +333,7 @@ def test_is_kl_tight(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_not_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -393,12 +347,9 @@ def test_is_not_kl_tight(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_tight(graph):
-    assert graph.is_kl_tight(2, 3, algorithm="pebble")
-    assert graph.is_kl_tight(2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
     assert graph.is_tight()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-        assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
 
 
 @pytest.mark.parametrize(
@@ -418,12 +369,9 @@ def test_is_2_3_tight(graph):
     ],
 )
 def test_is_not_2_3_tight(graph):
-    assert not graph.is_kl_tight(2, 3, algorithm="subgraph")
-    assert not graph.is_kl_tight(2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
     assert not graph.is_tight()
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-        assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
 
 
 @pytest.mark.parametrize(
@@ -440,9 +388,7 @@ def test_is_not_2_3_tight(graph):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -465,9 +411,7 @@ def test_is_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -488,9 +432,7 @@ def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -517,9 +459,7 @@ def test_is_kl_tight_with_loops(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert not graph.is_kl_tight(K, L, algorithm=algorithm)
-    if TEST_WRAPPED_FUNCTIONS:
-        assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -540,9 +480,7 @@ def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_tight_big_random(graph, K, L):
-    assert graph.is_kl_tight(K, L, algorithm="pebble")
-    if TEST_WRAPPED_FUNCTIONS:
-        assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm="pebble")
+    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm="pebble")
 
 
 ###############################################################
@@ -563,17 +501,11 @@ def test_is_tight_big_random(graph, K, L):
 def test_spanning_kl_sparse_subgraph(graph):
     for K in range(1, 3):
         for L in range(0, 2 * K):
-            spanning_subgraph = graph.spanning_kl_sparse_subgraph(K, L)
-            assert spanning_subgraph.is_kl_sparse(K, L, algorithm="subgraph")
-            assert set(graph.vertex_list()) == set(spanning_subgraph.vertex_list())
-            if TEST_WRAPPED_FUNCTIONS:
-                spanning_subgraph = sparsity.spanning_kl_sparse_subgraph(
-                    nx.Graph(graph), K, L
-                )
-                assert sparsity.is_kl_sparse(
-                    spanning_subgraph, K, L, algorithm="subgraph"
-                )
-                assert set(graph.nodes) == set(spanning_subgraph.nodes)
+            spanning_subgraph = sparsity.spanning_kl_sparse_subgraph(
+                nx.Graph(graph), K, L
+            )
+            assert sparsity.is_kl_sparse(spanning_subgraph, K, L, algorithm="subgraph")
+            assert set(graph.nodes) == set(spanning_subgraph.nodes)
 
 
 ###############################################################

--- a/test/graph/test_general.py
+++ b/test/graph/test_general.py
@@ -4,63 +4,47 @@ from sympy import Matrix
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph import _general as general
-from test import TEST_WRAPPED_FUNCTIONS
 
 
 def test_adjacency_matrix():
-    G = Graph()
-    assert G.adjacency_matrix() == Matrix([])
-    G = Graph([[2, 1], [2, 3]])
-    assert G.adjacency_matrix() == Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.adjacency_matrix(vertex_order=[2, 3, 1]) == Matrix(
+    G = nx.Graph()
+    assert general.adjacency_matrix(G) == Matrix([])
+    G = nx.Graph([[2, 1], [2, 3]])
+    assert general.adjacency_matrix(G) == Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+    assert general.adjacency_matrix(G, vertex_order=[2, 3, 1]) == Matrix(
         [[0, 1, 1], [1, 0, 0], [1, 0, 0]]
     )
-    assert graphs.Complete(4).adjacency_matrix() == Matrix.ones(4) - Matrix.diag(
-        [1, 1, 1, 1]
-    )
-    G = Graph.from_vertices(["C", 1, "D"])
-    assert G.adjacency_matrix() == Matrix.zeros(3)
+    assert general.adjacency_matrix(nx.Graph(graphs.Complete(4))) == Matrix.ones(
+        4
+    ) - Matrix.diag([1, 1, 1, 1])
+    G = nx.Graph(Graph.from_vertices(["C", 1, "D"]))
+    assert general.adjacency_matrix(G) == Matrix.zeros(3)
     G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-    assert G.adjacency_matrix(vertex_order=["C", 1, "D"]) == Matrix(
+    assert general.adjacency_matrix(nx.Graph(G), vertex_order=["C", 1, "D"]) == Matrix(
         [[0, 0, 1], [0, 0, 1], [1, 1, 0]]
     )
     M = Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.from_adjacency_matrix(M).adjacency_matrix() == M
+    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
     M = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert G.from_adjacency_matrix(M).adjacency_matrix() == M
-    if TEST_WRAPPED_FUNCTIONS:
-        G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-        assert general.adjacency_matrix(
-            nx.Graph(G), vertex_order=["C", 1, "D"]
-        ) == Matrix([[0, 0, 1], [0, 0, 1], [1, 1, 0]])
+    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
 
 
 def test_vertex_and_edge_lists():
-    G = Graph([[2, 1], [2, 3]])
-    assert G.vertex_list() == [1, 2, 3]
-    assert G.edge_list() == [[1, 2], [2, 3]]
-    G = Graph([(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)])
-    assert set(G.vertex_list()) == {"C", 1, "D", 2, "E", 3, 0}
-    assert set(G.edge_list()) == {("C", 1), (1, 0), (1, 2), ("D", 2), (2, 3), ("E", 3)}
-    G = Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0])
-    assert set(G.vertex_list()) == {"C", 2, "E", 1, "D", 3, 0}
-    assert G.edge_list() == []
-    if TEST_WRAPPED_FUNCTIONS:
-        G = nx.Graph([[2, 1], [2, 3]])
-        assert general.vertex_list(G) == [1, 2, 3]
-        assert general.edge_list(G) == [[1, 2], [2, 3]]
-        G = nx.Graph(
-            [(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)]
-        )
-        assert set(general.vertex_list(G)) == {"C", 1, "D", 2, "E", 3, 0}
-        assert set(general.edge_list(G)) == {
-            ("C", 1),
-            (1, 0),
-            (1, 2),
-            ("D", 2),
-            (2, 3),
-            ("E", 3),
-        }
-        G = nx.Graph(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
-        assert set(general.vertex_list(G)) == {"C", 2, "E", 1, "D", 3, 0}
-        assert general.edge_list(G) == []
+    G = nx.Graph([[2, 1], [2, 3]])
+    assert general.vertex_list(G) == [1, 2, 3]
+    assert general.edge_list(G) == [[1, 2], [2, 3]]
+    G = nx.Graph(
+        [(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)]
+    )
+    assert set(general.vertex_list(G)) == {"C", 1, "D", 2, "E", 3, 0}
+    assert set(general.edge_list(G)) == {
+        ("C", 1),
+        (1, 0),
+        (1, 2),
+        ("D", 2),
+        (2, 3),
+        ("E", 3),
+    }
+    G = nx.Graph(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
+    assert set(general.vertex_list(G)) == {"C", 2, "E", 1, "D", 3, 0}
+    assert general.edge_list(G) == []

--- a/test/test_signature.py
+++ b/test/test_signature.py
@@ -10,11 +10,12 @@ import sys
 from inspect import Parameter, Signature, _empty
 from types import GetSetDescriptorType, ModuleType
 from typing import Any, Callable, ParamSpec, Type, TypeVar, cast, get_args, get_origin
-
 import pytest
 
 from pyrigi import Framework
 from pyrigi.graph import Graph
+
+from test.wrapper._bad_wrapper import _BadWrapper
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -242,7 +243,8 @@ def _assert_same_sign(  # noqa: C901
                 )
 
 
-@pytest.mark.parametrize(("cls"), [Graph, Framework])
+# _BadWrapper has correct signatures but bad forwarding
+@pytest.mark.parametrize(("cls"), [Graph, Framework, _BadWrapper])
 def test_signature_graph(cls: Type):
     """
     Test that all methods have the same signature as the proxy functions

--- a/test/wrapper/_bad_wrapper.py
+++ b/test/wrapper/_bad_wrapper.py
@@ -1,0 +1,80 @@
+"""
+Deliberately broken ``@copy_doc`` wrappers used by test_wrapper.py to verify
+that every class of forwarding mistake is detected by the assertion helpers.
+"""
+
+from __future__ import annotations
+
+from pyrigi._utils._doc import copy_doc
+
+from test.wrapper._bad_wrapper_base import (
+    different_function,
+    different_function2,
+    different_instance_first,
+    extra_kwarg,
+    extra_positional,
+    instance_not_first,
+    missing_kwarg_param,
+    missing_kwargs,
+    missing_positional_param,
+    proxy_not_called,
+    wrong_value,
+)
+from test.wrapper._bad_wrapper_base import _BadWrapperBase
+
+
+class _BadWrapper(_BadWrapperBase):
+    # a keyword parameter is not forwarded to the proxy
+    @copy_doc(missing_kwarg_param)
+    def missing_kwarg_param(self, x: int, label: str = "a") -> str:  # noqa: U100
+        return missing_kwarg_param(self, x)
+
+    # a positional parameter is not forwarded to the proxy
+    @copy_doc(missing_positional_param)
+    def missing_positional_param(self, x: int, label: str = "a") -> str:  # noqa: U100
+        return missing_positional_param(self, label="b")
+
+    # a parameter is modified before forwarding
+    @copy_doc(wrong_value)
+    def wrong_value(self, x: int, label: str = "a") -> str:
+        return wrong_value(self, x + 1, label)
+
+    # the instance is not passed as first positional arg
+    @copy_doc(instance_not_first)
+    def instance_not_first(self, x: int, label: str = "a") -> str:
+        return instance_not_first(x, label, self)
+
+    # a different instance is passed as first positional arg
+    @copy_doc(different_instance_first)
+    def different_instance_first(self, x: _BadWrapperBase, label: str = "a") -> str:
+        return different_instance_first(x, self, label)
+
+    # the proxy function is never invoked
+    @copy_doc(proxy_not_called)
+    def proxy_not_called(self, x: int, label: str = "a") -> str:
+        return f"{x}:{label}"
+
+    # an unexpected keyword argument is passed to the proxy
+    @copy_doc(extra_kwarg)
+    def extra_kwarg(self, x: int, label: str = "a") -> str:
+        return extra_kwarg(self, x, label, extra=True)
+
+    # an unexpected positional argument is passed to the proxy
+    @copy_doc(extra_positional)
+    def extra_positional(self, x: int, label: str = "a") -> str:
+        return extra_positional(self, x, label, 42)
+
+    # a different proxy function is called than the one from @copy_doc
+    @copy_doc(different_function)
+    def different_function(self, x: int, label: str = "a") -> str:
+        return different_function2(self, x, label)
+
+    # the wrapper method name differs from the proxy function name
+    @copy_doc(different_function)
+    def function_named_differently(self, x: int, label: str = "a") -> str:
+        return different_function(self, x, label)
+
+    # missing kwargs
+    @copy_doc(missing_kwargs)
+    def missing_kwargs(self, x: int, label: str = "a", **kwargs) -> str:  # noqa: U100
+        return missing_kwargs(self, x, label)

--- a/test/wrapper/_bad_wrapper.py
+++ b/test/wrapper/_bad_wrapper.py
@@ -17,6 +17,7 @@ from test.wrapper._bad_wrapper_base import (
     missing_kwarg_param,
     missing_kwargs,
     missing_positional_param,
+    switched_positional,
     proxy_not_called,
     wrong_value,
 )
@@ -78,3 +79,8 @@ class _BadWrapper(_BadWrapperBase):
     @copy_doc(missing_kwargs)
     def missing_kwargs(self, x: int, label: str = "a", **kwargs) -> str:  # noqa: U100
         return missing_kwargs(self, x, label)
+
+    # switched positional arguments
+    @copy_doc(switched_positional)
+    def switched_positional(self, x: int, y: int) -> str:
+        return switched_positional(self, y, x)

--- a/test/wrapper/_bad_wrapper_base.py
+++ b/test/wrapper/_bad_wrapper_base.py
@@ -1,0 +1,61 @@
+"""
+A proxy class is defined for meta-testing of wrapping together with proxy functions.
+
+Each function is a separate callable so that _find_patch_target can
+patch them independently.
+"""
+
+
+class _BadWrapperBase(object):
+    def __init__(self):
+        self.order = 1
+
+
+def missing_kwarg_param(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def missing_positional_param(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def wrong_value(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def instance_not_first(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def different_instance_first(
+    graph: _BadWrapperBase, x: _BadWrapperBase, label: str = "a"
+) -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def proxy_not_called(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def extra_kwarg(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def extra_positional(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def correct_wrapping(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def different_function(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def different_function2(graph: _BadWrapperBase, x: int, label: str = "a") -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes)"
+
+
+def missing_kwargs(graph: _BadWrapperBase, x: int, label: str = "a", **kwargs) -> str:
+    return f"{label}:{x} (graph has {graph.order} nodes: {kwargs.keys()})"

--- a/test/wrapper/_bad_wrapper_base.py
+++ b/test/wrapper/_bad_wrapper_base.py
@@ -59,3 +59,7 @@ def different_function2(graph: _BadWrapperBase, x: int, label: str = "a") -> str
 
 def missing_kwargs(graph: _BadWrapperBase, x: int, label: str = "a", **kwargs) -> str:
     return f"{label}:{x} (graph has {graph.order} nodes: {kwargs.keys()})"
+
+
+def switched_positional(graph: _BadWrapperBase, x: int, y: int) -> str:
+    return f"{y}:{x} (graph has {graph.order} nodes)"

--- a/test/wrapper/_check.py
+++ b/test/wrapper/_check.py
@@ -1,0 +1,192 @@
+import inspect
+import sys
+from typing import Any, Callable, Type
+from unittest.mock import patch
+
+import networkx as nx
+
+from pyrigi import Framework
+from pyrigi.framework.base import FrameworkBase
+from pyrigi.graph import Graph
+
+from test.wrapper._bad_wrapper_base import _BadWrapperBase
+from test.wrapper._bad_wrapper import _BadWrapper
+
+_MISSING = object()
+
+
+def _find_patch_target(method: Callable, wrapped_func: Callable) -> tuple:
+    """
+    Determine the module and attribute name to patch so that
+    ``patch.object(module, name)`` replaces ``wrapped_func`` at the
+    call-site used by ``method``.
+
+    Return a ``(module, name)`` pair suitable for ``patch.object``.
+    """
+    method_module = sys.modules[method.__module__]
+
+    for attr_name, val in vars(method_module).items():
+        if val is wrapped_func:
+            return method_module, attr_name
+        if (
+            inspect.ismodule(val)
+            and getattr(val, wrapped_func.__name__, None) is wrapped_func
+        ):
+            return val, wrapped_func.__name__
+
+    # Fall back to the module where the proxy function is defined
+    return sys.modules[wrapped_func.__module__], wrapped_func.__name__
+
+
+def _invoke_wrapper(
+    test_instance: Any,
+    attr_name: str,
+    method: Callable,
+    mock_args: dict,
+) -> tuple:
+    """
+    Patch the proxy for ``method``, call ``attr_name(**mock_args)`` on
+    ``test_instance``, and return ``(proxy_was_called, call_args, exception)``.
+
+    ``call_args`` persists after the patch context exits.
+    ``exception`` is the first exception raised during the call or generator
+    consumption, or ``None`` if everything ran cleanly.
+    """
+    patch_module, patch_name = _find_patch_target(method, method._wrapped_func)
+    with patch.object(patch_module, patch_name) as mock_func:
+        exc = None
+        result = None
+        try:
+            result = getattr(test_instance, attr_name)(**mock_args)
+        except Exception as e:
+            exc = e
+
+        if exc is None and inspect.isgeneratorfunction(method):
+            try:
+                list(result)
+            except Exception as e:
+                exc = e
+
+        return mock_func.called, mock_func.call_args, exc
+
+
+def _check_name_matches(
+    cls: Type, attr_name: str, proxy_func_name: str
+) -> tuple[bool, str]:
+    """Return ``(True, "")`` if the method name matches the proxy function name."""
+    if attr_name != proxy_func_name:
+        return False, (
+            f"{cls.__name__}.{attr_name} is decorated with @copy_doc({proxy_func_name}) "
+            f"but the method name differs from the proxy function name"
+        )
+    return True, ""
+
+
+def _check_first_arg(cls: Type, attr_name: str, call_args: Any) -> tuple[bool, str]:
+    """Check that the first positional argument to the proxy is the correct instance."""
+    first_arg = call_args[0][0]
+    if cls == _BadWrapper:
+        expected_type, label = _BadWrapperBase, "_BadWrapper"
+    elif cls == Graph:
+        expected_type, label = nx.Graph, "Graph"
+    elif cls == Framework:
+        expected_type, label = FrameworkBase, "Framework"
+    else:
+        raise NotImplementedError(f"_check_first_arg: unsupported class {cls.__name__}")
+    if not isinstance(first_arg, expected_type):
+        return False, (
+            f"{cls.__name__}.{attr_name} didn't pass the {label} instance as first arg."
+        )
+    return True, ""
+
+
+def _check_param_values(
+    cls: Type,
+    attr_name: str,
+    proxy_param_names: list,
+    mock_args: dict,
+    call_args: Any,
+) -> tuple[bool, str]:
+    """Check that every entry in mock_args was forwarded with the same value.
+
+    Falls back to positional lookup for wrappers that forward some args
+    positionally (e.g. ``rescale``, ``is_critically_k_edge_apex``).
+    """
+    for param_name, expected_value in mock_args.items():
+        actual_value = call_args.kwargs.get(param_name, _MISSING)
+        if actual_value is _MISSING and len(call_args[0]) > 1:
+            try:
+                idx = proxy_param_names.index(param_name)
+                if idx < len(call_args[0]):
+                    actual_value = call_args[0][idx]
+            except ValueError:
+                pass
+
+        if actual_value != expected_value:
+            return False, (
+                f"{cls.__name__}.{attr_name} didn't forward '{param_name}' "
+                f"correctly. Expected {expected_value}, got {actual_value}"
+            )
+    return True, ""
+
+
+def _check_no_extra_args(
+    cls: Type,
+    attr_name: str,
+    proxy_param_names: list,
+    mock_args: dict,
+    call_args: Any,
+) -> tuple[bool, str]:
+    """Check that no unexpected arguments arrived at the proxy (reverse check)."""
+    forwarded_names: set[str] = set(call_args.kwargs.keys())
+    for _, param_name in zip(call_args[0][1:], proxy_param_names[1:]):
+        forwarded_names.add(param_name)
+
+    extra_positional_count = len(call_args[0]) - len(proxy_param_names)
+    if extra_positional_count > 0:
+        return False, (
+            f"{cls.__name__}.{attr_name} forwarded {extra_positional_count} "
+            f"unexpected positional argument(s) to the proxy."
+        )
+
+    unexpected = forwarded_names - set(mock_args.keys())
+    if unexpected:
+        return False, (
+            f"{cls.__name__}.{attr_name} forwarded unexpected argument(s) "
+            f"to the proxy: {unexpected}."
+        )
+    return True, ""
+
+
+def _check_params_forwarded(
+    cls: Type,
+    attr_name: str,
+    proxy_param_names: list,
+    mock_args: dict,
+    call_args: Any,
+) -> tuple[bool, str]:
+    """
+    Check correct parameter forwarding in both directions.
+
+    1. The instance is passed as the first positional argument.
+    2. Every entry in ``mock_args`` arrives at the proxy with the same value
+       (checks both keyword and positional forwarding).
+    3. No unexpected arguments arrive at the proxy beyond what ``mock_args``
+       sent (reverse check).
+
+    ``proxy_param_names`` is the ordered list of the proxy's parameter names
+    (including the first graph/framework parameter) and is used to resolve
+    arguments that were forwarded positionally rather than by keyword.
+
+    Return ``(True, "")`` on success or ``(False, message)`` on the first
+    failed check.
+    """
+    ok, msg = _check_first_arg(cls, attr_name, call_args)
+    if not ok:
+        return False, msg
+    ok, msg = _check_param_values(
+        cls, attr_name, proxy_param_names, mock_args, call_args
+    )
+    if not ok:
+        return False, msg
+    return _check_no_extra_args(cls, attr_name, proxy_param_names, mock_args, call_args)

--- a/test/wrapper/test_wrapper.py
+++ b/test/wrapper/test_wrapper.py
@@ -99,6 +99,8 @@ def test_wrapper_parameter_forwarding(cls, test_instance):
         ("extra_kwarg", True),  # proxy called - unexpected kwarg detected
         ("extra_positional", True),  # proxy called - extra positional detected
         ("function_named_differently", True),  # proxy called - name mismatch detected
+        ("missing_kwargs", True),  # proxy called - kwargs not forwarded
+        ("switched_positional", True),  # proxy called - positional arguments switched
     ],
 )
 def test_bad_wrapper_detected(attr_name, proxy_reaches_mock):

--- a/test/wrapper/test_wrapper.py
+++ b/test/wrapper/test_wrapper.py
@@ -1,0 +1,137 @@
+import inspect
+
+import pytest
+from unittest.mock import Mock
+
+from pyrigi import Framework
+from pyrigi.graph import Graph
+
+from test.wrapper._check import (
+    _check_name_matches,
+    _check_params_forwarded,
+    _invoke_wrapper,
+)
+from test.wrapper._bad_wrapper import _BadWrapper
+
+
+def _build_mock_args(sig: inspect.Signature) -> dict:
+    """Build mock sentinels for every named param except the first (graph/framework).
+
+    VAR_KEYWORD/VAR_POSITIONAL are excluded; a ``_test_kwarg`` probe is added
+    when **kwargs is present to verify the catch-all is forwarded.
+    """
+    mock_args = {
+        name: Mock(name=name)
+        for name, param in list(sig.parameters.items())[1:]
+        if param.kind
+        not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        mock_args["_test_kwarg"] = Mock(name="_test_kwarg")
+    return mock_args
+
+
+@pytest.mark.parametrize(
+    "cls,test_instance",
+    [
+        (Graph, Graph([(0, 1), (1, 2)])),
+        (
+            Framework,
+            Framework(
+                Graph([(0, 1), (1, 2)]),
+                {0: (0, 0), 1: (1, 0), 2: (0, 1)},
+            ),
+        ),
+    ],
+)
+def test_wrapper_parameter_forwarding(cls, test_instance):
+    """
+    Test that all ``@copy_doc`` wrapper methods on ``Graph`` and ``Framework`` correctly
+    forward parameters to their underlying proxy functions.
+    """
+    any_checked = False
+
+    for attr_name, method in inspect.getmembers(cls):
+        wrapped_func = getattr(method, "_wrapped_func", None)
+        if wrapped_func is None:
+            continue
+
+        sig = inspect.signature(wrapped_func)
+        proxy_param_names = list(sig.parameters.keys())
+        mock_args = _build_mock_args(sig)
+
+        called, call_args, exc = _invoke_wrapper(
+            test_instance, attr_name, method, mock_args
+        )
+
+        if exc is not None:
+            pytest.fail(
+                f"{cls.__name__}.{attr_name} raised an unexpected exception "
+                f"while forwarding parameters — the wrapper may be modifying "
+                f"an argument before passing it: {type(exc).__name__}: {exc}"
+            )
+
+        assert called, f"{cls.__name__}.{attr_name} didn't call {wrapped_func.__name__}"
+
+        name_ok, name_msg = _check_name_matches(cls, attr_name, wrapped_func.__name__)
+        assert name_ok, name_msg
+
+        params_ok, params_msg = _check_params_forwarded(
+            cls, attr_name, proxy_param_names, mock_args, call_args
+        )
+        assert params_ok, params_msg
+
+        any_checked = True
+
+    assert any_checked
+
+
+@pytest.mark.parametrize(
+    "attr_name, proxy_reaches_mock",
+    [
+        ("missing_kwarg_param", True),  # proxy called - missing param detected
+        ("missing_positional_param", True),  # proxy called - missing param detected
+        ("wrong_value", False),  # Mock()+1 raises TypeError before proxy
+        ("instance_not_first", True),  # proxy called - wrong first arg detected
+        ("different_instance_first", True),  # proxy called - wrong first arg detected
+        ("proxy_not_called", False),  # wrapper never calls the proxy
+        ("different_function", False),  # wrapper calls different_function2 instead
+        ("extra_kwarg", True),  # proxy called - unexpected kwarg detected
+        ("extra_positional", True),  # proxy called - extra positional detected
+        ("function_named_differently", True),  # proxy called - name mismatch detected
+    ],
+)
+def test_bad_wrapper_detected(attr_name, proxy_reaches_mock):
+    """
+    Test that each known forwarding mistake in _BadWrapper is caught
+    by the check helpers.
+
+    ``proxy_reaches_mock`` documents whether the proxy mock is expected to be
+    called at all. When False, the bad behaviour manifests before the proxy is
+    reached (exception or wrong function called); when True, the proxy is called
+    but the check helpers catch the forwarding mistake.
+    """
+    test_instance = _BadWrapper()
+    method = getattr(_BadWrapper, attr_name)
+    wrapped_func = method._wrapped_func
+
+    sig = inspect.signature(wrapped_func)
+    proxy_param_names = list(sig.parameters.keys())
+    mock_args = _build_mock_args(sig)
+
+    called, call_args, _ = _invoke_wrapper(test_instance, attr_name, method, mock_args)
+
+    assert called == proxy_reaches_mock, (
+        f"_BadWrapper.{attr_name}: expected proxy "
+        f"{'to be' if proxy_reaches_mock else 'not to be'} called"
+    )
+
+    if proxy_reaches_mock:
+        name_ok, _ = _check_name_matches(_BadWrapper, attr_name, wrapped_func.__name__)
+        params_ok, _ = _check_params_forwarded(
+            _BadWrapper, attr_name, proxy_param_names, mock_args, call_args
+        )
+        assert not (name_ok and params_ok), (
+            f"_BadWrapper.{attr_name}: bad wrapper was not detected "
+            f"by the check helpers"
+        )


### PR DESCRIPTION
It is now tested that the parameters of a wrapped function are forwarded correctly in the corresponding method (PR #393, #405). Hence, only the functions are now tested, not the methods, to simplify and speed up the tests (PRs #402, #403, #404, #409) . The guide has been updated accordingly (PR #406).