### PR TITLE
Code: Refactored equality

### DIFF
--- a/pyrigi/graph/graph.py
+++ b/pyrigi/graph/graph.py
@@ -103,8 +103,6 @@ class Graph(nx.Graph):
 
     silence_rand_alg_warns = False
 
-    __hash__ = nx.Graph.__hash__
-
     def __str__(self) -> str:
         """
         Return the string representation.

--- a/pyrigi/graph/graph.py
+++ b/pyrigi/graph/graph.py
@@ -54,18 +54,6 @@ class Graph(nx.Graph):
     >>> print(G)
     Graph with vertices [0, 2, 5, 7, 'a'] and edges [[0, 7], [2, 5]]
 
-    Notes
-    -----
-    Equality between two objects of :class:`Graph` is by value,
-    but hashing is by identity
-    (``__hash__`` is inherited from :class:`~networkx.Graph`), since a
-    :class:`Graph` is mutable. Consequently, two graphs that compare
-    equal may have different hashes.
-    This means that ``in`` behaves differently when applied to lists/tuples
-    rather than sets/dictionaries.
-    In the first case equality is used; in the second case,
-    hash is first used, and then equality.
-
     METHODS
 
     This class inherits the class :class:`networkx.Graph`.

--- a/pyrigi/graph/graph.py
+++ b/pyrigi/graph/graph.py
@@ -110,7 +110,7 @@ class Graph(nx.Graph):
         o_str += f"{self.edge_list(as_tuples=True)})"
         return o_str
 
-    def __eq__(self, other: Graph) -> bool:
+    def __eq__(self, other: object) -> bool:
         """
         Return whether the other graph has the same vertices and edges.
 
@@ -121,12 +121,16 @@ class Graph(nx.Graph):
         >>> H = Graph([[2,1]])
         >>> G == H
         True
+        >>> G == 5
+        False
 
         Notes
         -----
         :func:`~networkx.utils.misc.graphs_equal`
-        behaves strangely, hence it is not used.
+        behaves differently, hence it is not used.
         """
+        if not isinstance(other, nx.Graph):
+            return NotImplemented
         if (
             self.number_of_edges() != other.number_of_edges()
             or self.number_of_nodes() != other.number_of_nodes()

--- a/pyrigi/graph/graph.py
+++ b/pyrigi/graph/graph.py
@@ -54,6 +54,18 @@ class Graph(nx.Graph):
     >>> print(G)
     Graph with vertices [0, 2, 5, 7, 'a'] and edges [[0, 7], [2, 5]]
 
+    Notes
+    -----
+    Equality between two objects of :class:`Graph` is by value,
+    but hashing is by identity
+    (``__hash__`` is inherited from :class:`~networkx.Graph`), since a
+    :class:`Graph` is mutable. Consequently, two graphs that compare
+    equal may have different hashes.
+    This means that ``in`` behaves differently when applied to lists/tuples
+    rather than sets/dictionaries.
+    In the first case equality is used; in the second case,
+    hash is first used, and then equality.
+
     METHODS
 
     This class inherits the class :class:`networkx.Graph`.

--- a/pyrigi/graph/graph.py
+++ b/pyrigi/graph/graph.py
@@ -91,6 +91,8 @@ class Graph(nx.Graph):
 
     silence_rand_alg_warns = False
 
+    __hash__ = nx.Graph.__hash__
+
     def __str__(self) -> str:
         """
         Return the string representation.


### PR DESCRIPTION
We add a hash to class `Graph`. Moreover, we point out that, since `Graph` is mutable, equality does not imply equal hash. This is consistent with the behavior in NetworkX.