### PR TITLE
Test: Added possibility to run tests on both pyrigi.Graph and networkx.Graph

### DIFF
--- a/.github/workflows/python-test-main.yml
+++ b/.github/workflows/python-test-main.yml
@@ -34,7 +34,7 @@ jobs:
         poetry run flake8 . --count --show-source --statistics
     - name: Test with pytest
       run: |
-        poetry run pytest --doctest-modules -m 'not long_local'
+        poetry run pytest --doctest-modules -m 'not long_local' --graph-class=both
         # --doctest-modules overrides the default --doctest-plus
     - name: Remove skip-execution cell magic and convert notebooks from md to ipynb
       run: |

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -67,6 +67,20 @@ The suite also includes negative tests using intentionally broken wrappers (see
 (such as missing, extra, or reordered arguments, or wrong function calls) are detected
 by the test helpers.
 
+Since functions operating on graphs take `nx.Graph` as their first argument,
+the tests are by default executed on `nx.Graph` instances.
+In order to test also on `pyrigi.Graph` on demand or when merging to `main`,
+we introduce a variable `graph_class` (set to n`x.Graph` at the beginning of each test file)
+and use it to convert objects as in `G = graph_class(Graph.from_int(k))`.
+This allows one to patch `graph_class` to `pyrigi.Graph`, which is implemented as `pytest` argument:
+```
+pytest                      # default, testing only on nx.Graphs
+pytest --graph-class=nx     # same as above
+pytest --graph-class=pyrigi # testing only on pyrigi.Graphs
+pytest --graph-class=both   # testing on both
+```
+See `test/conftest.py` for the implementation.
+
 ## Markers
 
 Functionalities requiring optional packages are tested by default;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,6 +67,9 @@ def _graph_class(request, monkeypatch):
     of the test's own module through ``monkeypatch``, ensuring that
     ``graph_class(...)`` in the test body constructs the correct graph type.
     """
+    param = getattr(request, "param", None)
+    if param is None:
+        return
     mod = getattr(request, "module", None)
     if mod is not None and hasattr(mod, "graph_class"):
         monkeypatch.setattr(mod, "graph_class", request.param)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,77 @@
+"""Graph-class parametrization for ``--graph-class`` CLI option.
+
+Test modules that define a module-level ``graph_class`` variable are
+automatically parametrized so that each test in the module runs once per
+selected graph class.  Modules without ``graph_class`` are unaffected.
+
+Example usage::
+
+    pytest test/graph/                        # default: graph_class = nx.Graph only
+    pytest test/graph/ --graph-class=pyrigi   # pyrigi.Graph only
+    pytest test/graph/ --graph-class=both     # both, i.e., run twice
+"""
+
+import sys
+
+import networkx as nx
+import pytest
+
+from pyrigi.graph import Graph as PyRigiGraph
+
+_GRAPH_IDS = {
+    nx.Graph: "nx.Graph",
+    PyRigiGraph: "pyrigi.Graph",
+}
+
+
+def pytest_addoption(parser):
+    """Register the ``--graph-class`` command-line option."""
+    parser.addoption(
+        "--graph-class",
+        action="store",
+        default="nx",
+        choices=["nx", "pyrigi", "both"],
+        help="Graph class to test: nx (default), pyrigi, or both.",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize tests whose module defines ``graph_class``.
+
+    For each test function whose module has a ``graph_class`` attribute,
+    this hook injects the ``_graph_class`` fixture parametrized with the
+    graph classes selected by ``--graph-class``.  Modules without
+    ``graph_class`` are left untouched so they are never duplicated.
+    """
+    option = metafunc.config.getoption("--graph-class")
+    if not hasattr(metafunc.module, "graph_class"):
+        return
+    if option == "both":
+        classes = [nx.Graph, PyRigiGraph]
+    elif option == "pyrigi":
+        classes = [PyRigiGraph]
+    else:
+        classes = [nx.Graph]
+    metafunc.parametrize(
+        "_graph_class",
+        classes,
+        indirect=True,
+        ids=[_GRAPH_IDS[c] for c in classes],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _graph_class(request, monkeypatch):
+    """Patch the calling module's ``graph_class`` variable.
+
+    Uses ``request.param`` (supplied by :func:`pytest_generate_tests` via
+    ``indirect=True``) to set the module-level ``graph_class`` attribute
+    of the test function's own module through ``monkeypatch``, ensuring
+    that ``graph_class(...)`` in the test body constructs the correct
+    graph type.
+    """
+    func = getattr(request.node, "obj", None)
+    if func is not None:
+        mod = sys.modules.get(func.__module__)
+        if mod is not None and hasattr(mod, "graph_class"):
+            monkeypatch.setattr(mod, "graph_class", request.param)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,8 +11,6 @@ Example usage::
     pytest test/graph/ --graph-class=both     # both, i.e., run twice
 """
 
-import sys
-
 import networkx as nx
 import pytest
 
@@ -66,12 +64,9 @@ def _graph_class(request, monkeypatch):
 
     Uses ``request.param`` (supplied by :func:`pytest_generate_tests` via
     ``indirect=True``) to set the module-level ``graph_class`` attribute
-    of the test function's own module through ``monkeypatch``, ensuring
-    that ``graph_class(...)`` in the test body constructs the correct
-    graph type.
+    of the test's own module through ``monkeypatch``, ensuring that
+    ``graph_class(...)`` in the test body constructs the correct graph type.
     """
-    func = getattr(request.node, "obj", None)
-    if func is not None:
-        mod = sys.modules.get(func.__module__)
-        if mod is not None and hasattr(mod, "graph_class"):
-            monkeypatch.setattr(mod, "graph_class", request.param)
+    mod = getattr(request, "module", None)
+    if mod is not None and hasattr(mod, "graph_class"):
+        monkeypatch.setattr(mod, "graph_class", request.param)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,7 @@
 
 Test modules that define a module-level ``graph_class`` variable are
 automatically parametrized so that each test in the module runs once per
-selected graph class.  Modules without ``graph_class`` are unaffected.
+selected graph class. Modules without ``graph_class`` are unaffected.
 
 Example usage::
 
@@ -38,8 +38,8 @@ def pytest_generate_tests(metafunc):
 
     For each test function whose module has a ``graph_class`` attribute,
     this hook injects the ``_graph_class`` fixture parametrized with the
-    graph classes selected by ``--graph-class``.  Modules without
-    ``graph_class`` are left untouched so they are never duplicated.
+    graph classes selected by ``--graph-class``. Modules without
+    ``graph_class`` are left untouched.
     """
     option = metafunc.config.getoption("--graph-class")
     if not hasattr(metafunc.module, "graph_class"):

--- a/test/graph/_flexibility/nac/test_single.py
+++ b/test/graph/_flexibility/nac/test_single.py
@@ -5,6 +5,8 @@ import pyrigi.graph._flexibility.nac as nac
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 
+graph_class = nx.Graph
+
 algorithms = ["default", "naive", "subgraphs"] + [
     "subgraphs-{}-{}-{}".format(split, merge, size)
     for split in ["none", "neighbors", "neighbors_degree"]
@@ -38,7 +40,7 @@ algorithms = ["default", "naive", "subgraphs"] + [
     algorithms,
 )
 def test_single_and_has_NAC_coloring(graph: nx.Graph, algorithm: str):
-    graph = nx.Graph(graph)
+    graph = graph_class(graph)
     NAC_col = nac.single_NAC_coloring(graph, algorithm=algorithm)
     assert NAC_col is not None
     assert nac.is_NAC_coloring(graph, NAC_col)
@@ -68,6 +70,6 @@ def test_single_and_has_NAC_coloring(graph: nx.Graph, algorithm: str):
     algorithms,
 )
 def test_single_and_has_no_NAC_coloring(graph: nx.Graph, algorithm: str):
-    graph = nx.Graph(graph)
+    graph = graph_class(graph)
     assert nac.single_NAC_coloring(graph, algorithm=algorithm) is None
     assert not nac.has_NAC_coloring(graph, algorithm=algorithm)

--- a/test/graph/constructions/test_constructions.py
+++ b/test/graph/constructions/test_constructions.py
@@ -4,11 +4,13 @@ import pyrigi.graphDB as graphs
 from pyrigi.graph._constructions import constructions as graph_constructions
 from pyrigi.graph._general import max_degree
 
+graph_class = nx.Graph
+
 
 def test_cone():
-    G = graph_constructions.cone(nx.Graph(graphs.Complete(5)))
+    G = graph_constructions.cone(graph_class(graphs.Complete(5)))
     assert set(G.nodes) == set([0, 1, 2, 3, 4, 5]) and len(G.nodes) == 6
-    G = graph_constructions.cone(nx.Graph(graphs.Complete(4)), vertex="a")
+    G = graph_constructions.cone(graph_class(graphs.Complete(4)), vertex="a")
     assert "a" in G.nodes
-    G = graph_constructions.cone(nx.Graph(graphs.Cycle(4)))
+    G = graph_constructions.cone(graph_class(graphs.Cycle(4)))
     assert G.number_of_nodes() == max_degree(G) + 1

--- a/test/graph/constructions/test_extension.py
+++ b/test/graph/constructions/test_extension.py
@@ -8,19 +8,21 @@ from pyrigi.exception import NotSupportedValueError
 from pyrigi.graph import Graph
 from pyrigi.graph._utils.utils import is_isomorphic_graph_list
 
+graph_class = nx.Graph
+
 
 ###############################################################
 # k_extension
 ###############################################################
 def test_k_extension():
-    g2 = nx.Graph(graphs.Complete(2))
+    g2 = graph_class(graphs.Complete(2))
     assert extension.zero_extension(g2, [0, 1]) == graphs.Complete(3)
     assert extension.zero_extension(g2, [1], dim=1) == graphs.Path(3)
     assert extension.one_extension(
-        nx.Graph(graphs.Complete(4)), [0, 1, 2], (0, 1)
+        graph_class(graphs.Complete(4)), [0, 1, 2], (0, 1)
     ) == Graph([(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4)])
     assert extension.one_extension(
-        nx.Graph(graphs.CompleteBipartite(3, 2)), [0, 1, 2, 3, 4], (0, 3), dim=4
+        graph_class(graphs.CompleteBipartite(3, 2)), [0, 1, 2, 3, 4], (0, 3), dim=4
     ) == Graph(
         [
             (0, 4),
@@ -38,7 +40,7 @@ def test_k_extension():
 
     assert Graph(
         extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)),
+            graph_class(graphs.CompleteBipartite(3, 2)),
             2,
             [0, 1, 3],
             [(0, 3), (1, 3)],
@@ -47,12 +49,15 @@ def test_k_extension():
     ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)])
     assert Graph(
         extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+            graph_class(graphs.CompleteBipartite(3, 2)),
+            2,
+            [0, 1, 3, 4],
+            [(0, 3), (1, 3)],
         )
     ) == Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)])
     assert Graph(
         extension.k_extension(
-            nx.Graph(graphs.Cycle(6)),
+            graph_class(graphs.Cycle(6)),
             4,
             [0, 1, 2, 3, 4],
             [(0, 1), (1, 2), (2, 3), (3, 4)],
@@ -61,7 +66,7 @@ def test_k_extension():
     ) == Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)])
     assert Graph([(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5)]) == Graph(
         extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)),
+            graph_class(graphs.CompleteBipartite(3, 2)),
             2,
             [0, 1, 3],
             [(0, 3), (1, 3)],
@@ -72,12 +77,15 @@ def test_k_extension():
         [(0, 4), (0, 5), (1, 4), (1, 5), (2, 3), (2, 4), (3, 5), (4, 5)]
     ) == Graph(
         extension.k_extension(
-            nx.Graph(graphs.CompleteBipartite(3, 2)), 2, [0, 1, 3, 4], [(0, 3), (1, 3)]
+            graph_class(graphs.CompleteBipartite(3, 2)),
+            2,
+            [0, 1, 3, 4],
+            [(0, 3), (1, 3)],
         )
     )
     assert Graph([(0, 5), (0, 6), (1, 6), (2, 6), (3, 6), (4, 5), (4, 6)]) == Graph(
         extension.k_extension(
-            nx.Graph(graphs.Cycle(6)),
+            graph_class(graphs.Cycle(6)),
             4,
             [0, 1, 2, 3, 4],
             [(0, 1), (1, 2), (2, 3), (3, 4)],
@@ -98,7 +106,7 @@ def test_k_extension():
 )
 def test_k_extension_dim_error(graph, k, vertices, edges, dim):
     with pytest.raises(ValueError):
-        extension.k_extension(nx.Graph(graph), k, vertices, edges, dim=dim)
+        extension.k_extension(graph_class(graph), k, vertices, edges, dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -121,14 +129,14 @@ def test_k_extension_dim_error(graph, k, vertices, edges, dim):
 )
 def test_k_extension_error(graph, k, vertices, edges):
     with pytest.raises(ValueError):
-        extension.k_extension(nx.Graph(graph), k, vertices, edges)
+        extension.k_extension(graph_class(graph), k, vertices, edges)
 
 
 ###############################################################
 # all_k_extensions
 ###############################################################
 def test_all_k_extensions():
-    for ext in extension.all_k_extensions(nx.Graph(graphs.Complete(4)), 1, 1):
+    for ext in extension.all_k_extensions(graph_class(graphs.Complete(4)), 1, 1):
         assert Graph(ext) in [
             Graph([[0, 2], [0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3]]),
             Graph([[0, 1], [0, 3], [0, 4], [1, 2], [1, 3], [2, 3], [2, 4]]),
@@ -138,7 +146,7 @@ def test_all_k_extensions():
             Graph([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 4], [3, 4]]),
         ]
     for ext in extension.all_k_extensions(
-        nx.Graph(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
+        graph_class(graphs.Complete(4)), 2, 2, only_non_isomorphic=True
     ):
         assert Graph(ext) in [
             Graph([[0, 3], [0, 4], [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]),
@@ -147,7 +155,7 @@ def test_all_k_extensions():
     all_diamond_0_2 = [
         Graph(G)
         for G in extension.all_k_extensions(
-            nx.Graph(graphs.Diamond()), 0, 2, only_non_isomorphic=True
+            graph_class(graphs.Diamond()), 0, 2, only_non_isomorphic=True
         )
     ]
     assert (
@@ -162,7 +170,7 @@ def test_all_k_extensions():
     all_diamond_1_2 = [
         Graph(G)
         for G in extension.all_k_extensions(
-            nx.Graph(graphs.Diamond()), 1, 2, only_non_isomorphic=True
+            graph_class(graphs.Diamond()), 1, 2, only_non_isomorphic=True
         )
     ]
     assert (
@@ -194,7 +202,7 @@ def test_all_k_extensions2(graph, k, dim, sol):
         [
             Graph(G)
             for G in extension.all_k_extensions(
-                nx.Graph(graph), k, dim, only_non_isomorphic=True
+                graph_class(graph), k, dim, only_non_isomorphic=True
             )
         ],
         [Graph.from_int(igraph) for igraph in sol],
@@ -203,7 +211,11 @@ def test_all_k_extensions2(graph, k, dim, sol):
 
 def test_all_k_extension_error():
     with pytest.raises(ValueError):
-        list(extension.all_k_extensions(nx.Graph(Graph.from_vertices([0, 1, 2])), 1, 1))
+        list(
+            extension.all_k_extensions(
+                graph_class(Graph.from_vertices([0, 1, 2])), 1, 1
+            )
+        )
 
 
 ###############################################################
@@ -230,7 +242,7 @@ def test_all_extensions(graph, dim, sol):
         [
             Graph(G)
             for G in extension.all_extensions(
-                nx.Graph(graph), dim, only_non_isomorphic=True
+                graph_class(graph), dim, only_non_isomorphic=True
             )
         ],
         [Graph.from_int(igraph) for igraph in sol],
@@ -255,18 +267,18 @@ def test_all_extensions_single(graph, dim):
         assert is_isomorphic_graph_list(
             list(
                 extension.all_extensions(
-                    nx.Graph(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
+                    graph_class(graph), dim, only_non_isomorphic=True, k_min=k, k_max=k
                 )
             ),
             list(
                 extension.all_k_extensions(
-                    nx.Graph(graph), k, dim, only_non_isomorphic=True
+                    graph_class(graph), k, dim, only_non_isomorphic=True
                 )
             ),
         )
         assert is_isomorphic_graph_list(
-            list(extension.all_extensions(nx.Graph(graph), dim, k_min=k, k_max=k)),
-            list(extension.all_k_extensions(nx.Graph(graph), k, dim)),
+            list(extension.all_extensions(graph_class(graph), dim, k_min=k, k_max=k)),
+            list(extension.all_k_extensions(graph_class(graph), k, dim)),
         )
 
 
@@ -285,7 +297,9 @@ def test_all_extensions_single(graph, dim):
 def test_all_extensions_value_error(graph, dim, k_min, k_max):
     with pytest.raises(ValueError):
         list(
-            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
+            extension.all_extensions(
+                graph_class(graph), dim=dim, k_min=k_min, k_max=k_max
+            )
         )
 
 
@@ -306,7 +320,9 @@ def test_all_extensions_value_error(graph, dim, k_min, k_max):
 def test_all_extensions_type_error(graph, dim, k_min, k_max):
     with pytest.raises(TypeError):
         list(
-            extension.all_extensions(nx.Graph(graph), dim=dim, k_min=k_min, k_max=k_max)
+            extension.all_extensions(
+                graph_class(graph), dim=dim, k_min=k_min, k_max=k_max
+            )
         )
 
 
@@ -330,7 +346,7 @@ def test_all_extensions_type_error(graph, dim, k_min, k_max):
     ],
 )
 def test_has_extension_sequence(graph):
-    assert extension.has_extension_sequence(nx.Graph(graph))
+    assert extension.has_extension_sequence(graph_class(graph))
 
 
 @pytest.mark.parametrize(
@@ -349,7 +365,7 @@ def test_has_extension_sequence(graph):
     ],
 )
 def test_has_not_extension_sequence(graph):
-    assert not extension.has_extension_sequence(nx.Graph(graph))
+    assert not extension.has_extension_sequence(graph_class(graph))
 
 
 ###############################################################
@@ -359,7 +375,7 @@ def test_extension_sequence_solution():
     assert [
         Graph(G)
         for G in extension.extension_sequence(
-            nx.Graph(graphs.Complete(2)), return_type="graphs"
+            graph_class(graphs.Complete(2)), return_type="graphs"
         )
     ] == [
         Graph([[0, 1]]),
@@ -368,7 +384,7 @@ def test_extension_sequence_solution():
     assert [
         Graph(G)
         for G in extension.extension_sequence(
-            nx.Graph(graphs.Complete(3)), return_type="graphs"
+            graph_class(graphs.Complete(3)), return_type="graphs"
         )
     ] == [
         Graph([[1, 2]]),
@@ -397,7 +413,7 @@ def test_extension_sequence_solution():
     assert [
         Graph(G)
         for G in extension.extension_sequence(
-            nx.Graph(graphs.CompleteBipartite(3, 3)), return_type="graphs"
+            graph_class(graphs.CompleteBipartite(3, 3)), return_type="graphs"
         )
     ] == solution
 
@@ -407,7 +423,7 @@ def test_extension_sequence_solution():
         [0, [1, 2], [], 5],
         [1, [3, 4, 5], [(3, 4)], 0],
     ]
-    G = nx.Graph([[3, 4]])
+    G = graph_class([[3, 4]])
     for i in range(len(solution)):
         assert solution[i] == G
         if i < len(solution_ext):
@@ -416,7 +432,7 @@ def test_extension_sequence_solution():
     assert [
         Graph(G)
         for G in extension.extension_sequence(
-            nx.Graph(graphs.Diamond()), return_type="graphs"
+            graph_class(graphs.Diamond()), return_type="graphs"
         )
     ] == [
         Graph([[2, 3]]),
@@ -425,7 +441,7 @@ def test_extension_sequence_solution():
     ]
 
     result = extension.extension_sequence(
-        nx.Graph(graphs.ThreePrism()), return_type="graphs"
+        graph_class(graphs.ThreePrism()), return_type="graphs"
     )
     solution = [
         Graph([[4, 5]]),
@@ -453,7 +469,7 @@ def test_extension_sequence_solution():
         [0, [1, 5], [], 2],
         [1, [1, 2, 3], [(1, 3)], 0],
     ]
-    G = nx.Graph([[4, 5]])
+    G = graph_class([[4, 5]])
     for i in range(len(result)):
         assert result[i] == Graph(G)
         if i < len(solution_ext):
@@ -477,11 +493,11 @@ def test_extension_sequence_solution():
     ],
 )
 def test_extension_sequence(graph):
-    ext = extension.extension_sequence(nx.Graph(graph), return_type="both")
+    ext = extension.extension_sequence(graph_class(graph), return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = extension.k_extension(nx.Graph(current), *ext[i][1])
+        current = extension.k_extension(graph_class(current), *ext[i][1])
         assert Graph(current) == Graph(ext[i][0])
 
 
@@ -512,11 +528,11 @@ def test_extension_sequence(graph):
     ],
 )
 def test_extension_sequence_dim(graph, dim):
-    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="both")
+    ext = extension.extension_sequence(graph_class(graph), dim=dim, return_type="both")
     assert ext is not None
     current = ext[0]
     for i in range(1, len(ext)):
-        current = extension.k_extension(nx.Graph(current), *ext[i][1], dim=dim)
+        current = extension.k_extension(graph_class(current), *ext[i][1], dim=dim)
         assert Graph(current) == Graph(ext[i][0])
 
 
@@ -542,10 +558,12 @@ def test_extension_sequence_dim(graph, dim):
     ],
 )
 def test_extension_sequence_min_rigid(graph, dim):
-    ext = extension.extension_sequence(nx.Graph(graph), dim=dim, return_type="graphs")
+    ext = extension.extension_sequence(
+        graph_class(graph), dim=dim, return_type="graphs"
+    )
     assert ext is not None
     for current in ext:
-        assert generic_rigidity.is_min_rigid(nx.Graph(current), dim)
+        assert generic_rigidity.is_min_rigid(graph_class(current), dim)
 
 
 @pytest.mark.parametrize(
@@ -564,7 +582,7 @@ def test_extension_sequence_min_rigid(graph, dim):
     ],
 )
 def test_extension_sequence_none(graph):
-    assert extension.extension_sequence(nx.Graph(graph)) is None
+    assert extension.extension_sequence(graph_class(graph)) is None
 
 
 @pytest.mark.parametrize(
@@ -586,9 +604,11 @@ def test_extension_sequence_none(graph):
     ],
 )
 def test_extension_sequence_dim_none(graph, dim):
-    assert extension.extension_sequence(nx.Graph(graph), dim) is None
+    assert extension.extension_sequence(graph_class(graph), dim) is None
 
 
 def test_extension_sequence_error():
     with pytest.raises(NotSupportedValueError):
-        extension.extension_sequence(nx.Graph(graphs.Complete(3)), return_type="Test")
+        extension.extension_sequence(
+            graph_class(graphs.Complete(3)), return_type="Test"
+        )

--- a/test/graph/export/test_export.py
+++ b/test/graph/export/test_export.py
@@ -6,6 +6,8 @@ import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph._export import export
 
+graph_class = nx.Graph
+
 
 @pytest.mark.parametrize(
     "graph, gint",
@@ -19,19 +21,19 @@ from pyrigi.graph._export import export
     ],
 )
 def test_integer_representation(graph, gint):
-    assert export.to_int(nx.Graph(graph)) == gint
+    assert export.to_int(graph_class(graph)) == gint
     assert Graph.from_int(gint).is_isomorphic(graph)
-    assert export.to_int(nx.Graph(Graph.from_int(gint))) == gint
-    assert Graph.from_int(export.to_int(nx.Graph(graph))).is_isomorphic(graph)
+    assert export.to_int(graph_class(Graph.from_int(gint))) == gint
+    assert Graph.from_int(export.to_int(graph_class(graph))).is_isomorphic(graph)
 
 
 def test_integer_representation_error():
     with pytest.raises(ValueError):
-        export.to_int(nx.Graph([]))
+        export.to_int(graph_class([]))
     with pytest.raises(ValueError):
         M = Matrix([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
         G = Graph.from_adjacency_matrix(M)
-        export.to_int(nx.Graph(G))
+        export.to_int(graph_class(G))
     with pytest.raises(ValueError):
         Graph.from_int(0)
     with pytest.raises(TypeError):

--- a/test/graph/other/test_apex.py
+++ b/test/graph/other/test_apex.py
@@ -8,6 +8,8 @@ import pyrigi.graph._other.apex as apex
 import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 
+graph_class = nx.Graph
+
 
 ###############################################################
 # is_k_vertex_apex
@@ -30,7 +32,7 @@ from pyrigi.graph import Graph
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_vertex_apex(graph, k):
-    assert apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_k_vertex_apex(graph_class(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -43,7 +45,7 @@ def test_is_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_vertex_apex(graph, k):
-    assert not apex.is_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_k_vertex_apex(graph_class(graph), k)
 
 
 ###############################################################
@@ -67,7 +69,7 @@ def test_is_not_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_k_edge_apex(graph, k):
-    assert apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_k_edge_apex(graph_class(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -81,7 +83,7 @@ def test_is_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_k_edge_apex(graph, k):
-    assert not apex.is_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_k_edge_apex(graph_class(graph), k)
 
 
 ###############################################################
@@ -105,7 +107,7 @@ def test_is_not_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1] for n in range(3, 8)],
 )
 def test_is_critically_k_vertex_apex(graph, k):
-    assert apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_vertex_apex(graph_class(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -120,7 +122,7 @@ def test_is_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0] for n in range(3, 8)],
 )
 def test_is_not_critically_k_vertex_apex(graph, k):
-    assert not apex.is_critically_k_vertex_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_vertex_apex(graph_class(graph), k)
 
 
 ###############################################################
@@ -146,7 +148,7 @@ def test_is_not_critically_k_vertex_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 1 if n == 3 else 2 * n - 3] for n in range(3, 5)],
 )
 def test_is_critically_k_edge_apex(graph, k):
-    assert apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert apex.is_critically_k_edge_apex(graph_class(graph), k)
 
 
 @pytest.mark.parametrize(
@@ -161,55 +163,60 @@ def test_is_critically_k_edge_apex(graph, k):
     + [[graphs.Wheel(n).cone(), 0 if n == 3 else 2 * n - 4] for n in range(3, 6)],
 )
 def test_is_not_critically_k_edge_apex(graph, k):
-    assert not apex.is_critically_k_edge_apex(nx.Graph(graph), k)
+    assert not apex.is_critically_k_edge_apex(graph_class(graph), k)
 
 
 ###############################################################
 # randomized test
 ###############################################################
+@pytest.mark.parametrize(
+    "graph",
+    [
+        Graph(nx.gnm_random_graph(n, m))
+        for n, _ in product(range(1, 8), range(10))
+        for m in range(3, math.comb(n, 2) + 1)
+    ],
+)
 @pytest.mark.long_local
-def test_randomized_apex_properties():  # noqa: C901
-    search_space = [range(1, 8), range(10)]
-    for n, _ in product(*search_space):
-        for m in range(3, math.comb(n, 2) + 1):
-            G = Graph(nx.gnm_random_graph(n, m))
-            prop_apex = apex.is_k_edge_apex(G, 1)
-            prop_2_apex = apex.is_k_edge_apex(G, 2)
-            prop_3_apex = apex.is_k_edge_apex(G, 3)
-            prop_vapex = apex.is_k_vertex_apex(G, 1)
-            prop_2_vapex = apex.is_k_vertex_apex(G, 2)
-            prop_3_vapex = apex.is_k_vertex_apex(G, 3)
-            prop_crit_apex = apex.is_critically_k_edge_apex(G, 1)
-            prop_crit_2_apex = apex.is_critically_k_edge_apex(G, 2)
-            prop_crit_3_apex = apex.is_critically_k_edge_apex(G, 3)
-            prop_crit_vapex = apex.is_critically_k_vertex_apex(G, 1)
-            prop_crit_2_vapex = apex.is_critically_k_vertex_apex(G, 2)
-            prop_crit_3_vapex = apex.is_critically_k_vertex_apex(G, 3)
+def test_randomized_apex_properties(graph):
+    G = graph_class(graph)
+    prop_apex = apex.is_k_edge_apex(G, 1)
+    prop_2_apex = apex.is_k_edge_apex(G, 2)
+    prop_3_apex = apex.is_k_edge_apex(G, 3)
+    prop_vapex = apex.is_k_vertex_apex(G, 1)
+    prop_2_vapex = apex.is_k_vertex_apex(G, 2)
+    prop_3_vapex = apex.is_k_vertex_apex(G, 3)
+    prop_crit_apex = apex.is_critically_k_edge_apex(G, 1)
+    prop_crit_2_apex = apex.is_critically_k_edge_apex(G, 2)
+    prop_crit_3_apex = apex.is_critically_k_edge_apex(G, 3)
+    prop_crit_vapex = apex.is_critically_k_vertex_apex(G, 1)
+    prop_crit_2_vapex = apex.is_critically_k_vertex_apex(G, 2)
+    prop_crit_3_vapex = apex.is_critically_k_vertex_apex(G, 3)
 
-            if prop_apex:
-                assert prop_vapex
-                assert prop_2_apex
-                assert prop_3_apex
-            if prop_2_apex:
-                assert prop_2_vapex
-                assert prop_3_apex
-            if prop_3_apex:
-                assert prop_3_vapex
-            if prop_vapex:
-                assert prop_2_vapex
-                assert prop_3_vapex
-            if prop_2_vapex:
-                assert prop_3_vapex
+    if prop_apex:
+        assert prop_vapex
+        assert prop_2_apex
+        assert prop_3_apex
+    if prop_2_apex:
+        assert prop_2_vapex
+        assert prop_3_apex
+    if prop_3_apex:
+        assert prop_3_vapex
+    if prop_vapex:
+        assert prop_2_vapex
+        assert prop_3_vapex
+    if prop_2_vapex:
+        assert prop_3_vapex
 
-            if prop_crit_apex:
-                assert prop_apex
-            if prop_crit_2_apex:
-                assert prop_2_apex
-            if prop_crit_3_apex:
-                assert prop_3_apex
-            if prop_crit_vapex:
-                assert prop_vapex
-            if prop_crit_2_vapex:
-                assert prop_2_vapex
-            if prop_crit_3_vapex:
-                assert prop_3_vapex
+    if prop_crit_apex:
+        assert prop_apex
+    if prop_crit_2_apex:
+        assert prop_2_apex
+    if prop_crit_3_apex:
+        assert prop_3_apex
+    if prop_crit_vapex:
+        assert prop_vapex
+    if prop_crit_2_vapex:
+        assert prop_2_vapex
+    if prop_crit_3_vapex:
+        assert prop_3_vapex

--- a/test/graph/other/test_separating_set.py
+++ b/test/graph/other/test_separating_set.py
@@ -13,6 +13,8 @@ from pyrigi import Graph
 from pyrigi.data_type import Vertex
 from test.graph.test_graph import relabeled_inc
 
+graph_class = nx.Graph
+
 
 def _eq(g1: Graph, g2: nx.Graph):
     if g1 != g2:
@@ -47,7 +49,7 @@ def _add_metadata(graph: nx.Graph):
     ],
 )
 def test_is_stable_set(graph, stable_set):
-    assert separating_set.is_stable_set(nx.Graph(graph), stable_set)
+    assert separating_set.is_stable_set(graph_class(graph), stable_set)
 
 
 @pytest.mark.parametrize(
@@ -64,11 +66,11 @@ def test_is_stable_set(graph, stable_set):
     ],
 )
 def test_is_not_stable_set(graph, stable_set):
-    assert not separating_set.is_stable_set(nx.Graph(graph), stable_set)
+    assert not separating_set.is_stable_set(graph_class(graph), stable_set)
 
 
 def test_is_stable_set_certificate():
-    graph = nx.Graph(graphs.Path(4))
+    graph = graph_class(graphs.Path(4))
 
     assert separating_set.is_stable_set(graph, {0, 1, 2}, certificate=True) in [
         (False, (0, 1)),
@@ -123,7 +125,7 @@ def test__remove_apply_restore_vertices():
     ],
 )
 def test_is_separating_set(graph, sep_set):
-    assert separating_set.is_separating_set(nx.Graph(graph), sep_set)
+    assert separating_set.is_separating_set(graph_class(graph), sep_set)
 
 
 @pytest.mark.parametrize(
@@ -145,12 +147,12 @@ def test_is_separating_set(graph, sep_set):
     ],
 )
 def test_is_not_separating_set(graph, sep_set):
-    assert not separating_set.is_separating_set(nx.Graph(graph), sep_set)
+    assert not separating_set.is_separating_set(graph_class(graph), sep_set)
 
 
 def test_is_separating_set_error():
     with pytest.raises(ValueError):
-        separating_set.is_separating_set(nx.Graph(graphs.Complete(2)), [0, 1])
+        separating_set.is_separating_set(graph_class(graphs.Complete(2)), [0, 1])
 
 
 @pytest.mark.parametrize(
@@ -169,7 +171,7 @@ def test_is_separating_set_error():
     ],
 )
 def test_is_uv_separating_set(graph, sep_set, u, v):
-    assert separating_set.is_uv_separating_set(nx.Graph(graph), sep_set, u, v)
+    assert separating_set.is_uv_separating_set(graph_class(graph), sep_set, u, v)
 
 
 @pytest.mark.parametrize(
@@ -187,27 +189,27 @@ def test_is_uv_separating_set(graph, sep_set, u, v):
     ],
 )
 def test_is_not_uv_separating_set(graph, sep_set, u, v):
-    assert not separating_set.is_uv_separating_set(nx.Graph(graph), sep_set, u, v)
+    assert not separating_set.is_uv_separating_set(graph_class(graph), sep_set, u, v)
 
 
 def test_is_uv_separating_set_error():
     with pytest.raises(ValueError):
         separating_set.is_uv_separating_set(
-            nx.Graph([(0, 1), (1, 2), (0, 2), (2, 3), (0, 4), (1, 4)]),
+            graph_class([(0, 1), (1, 2), (0, 2), (2, 3), (0, 4), (1, 4)]),
             {2},
             0,
             2,
         )
     with pytest.raises(ValueError):
         separating_set.is_uv_separating_set(
-            nx.Graph(graphs.CompleteBipartite(4, 4)), [0, 4, 5, 6, 7], 0, 2
+            graph_class(graphs.CompleteBipartite(4, 4)), [0, 4, 5, 6, 7], 0, 2
         )
     with pytest.raises(ValueError):
-        separating_set.is_uv_separating_set(nx.Graph(graphs.Complete(2)), [0], 1, 2)
+        separating_set.is_uv_separating_set(graph_class(graphs.Complete(2)), [0], 1, 2)
 
 
 def test_stable_separating_set_edge_cases():
-    graph = nx.Graph(Graph.from_vertices_and_edges([0, 1, 2], []))
+    graph = graph_class(Graph.from_vertices_and_edges([0, 1, 2], []))
     _add_metadata(graph)
     orig = Graph(graph.copy())
     cut = separating_set.stable_separating_set(graph)
@@ -215,7 +217,7 @@ def test_stable_separating_set_edge_cases():
     assert _eq(orig, graph)
 
     # single vertex graph
-    graph = nx.Graph(Graph.from_vertices_and_edges([0], []))
+    graph = graph_class(Graph.from_vertices_and_edges([0], []))
     _add_metadata(graph)
     orig = Graph(graph.copy())
     with pytest.raises(ValueError):
@@ -223,7 +225,7 @@ def test_stable_separating_set_edge_cases():
     assert _eq(orig, graph)
 
     # single edge graph
-    graph = nx.Graph(Graph.from_vertices_and_edges([0, 1], [(0, 1)]))
+    graph = graph_class(Graph.from_vertices_and_edges([0, 1], [(0, 1)]))
     _add_metadata(graph)
     orig = Graph(graph.copy())
     with pytest.raises(ValueError):
@@ -231,14 +233,14 @@ def test_stable_separating_set_edge_cases():
     assert _eq(orig, graph)
 
     # triangle graph
-    graph = nx.Graph(graphs.Complete(3))
+    graph = graph_class(graphs.Complete(3))
     _add_metadata(graph)
     orig = Graph(graph.copy())
     with pytest.raises(ValueError):
         separating_set.stable_separating_set(graph)
     assert _eq(orig, graph)
 
-    graph = nx.Graph(
+    graph = graph_class(
         graphs.Complete(3) + relabeled_inc(graphs.CompleteBipartite(2, 3), 2)
     )
     _add_metadata(graph)
@@ -287,7 +289,7 @@ def test_stable_separating_set(
     check_connected,
 ):
     orig = Graph(graph.copy())
-    graph = nx.Graph(graph)
+    graph = graph_class(graph)
 
     cut = separating_set.stable_separating_set(
         graph,
@@ -338,11 +340,11 @@ def test_stable_separating_set_error_single_vertex_separating_set(
     is asked to be avoided.
     """
     with pytest.raises(ValueError):
-        separating_set.stable_separating_set(nx.Graph(graph), separating_vertex)
+        separating_set.stable_separating_set(graph_class(graph), separating_vertex)
 
 
 def test_stable_separating_set_2by4_Grid():
-    graph = nx.Graph(graphs.Grid(2, 4))
+    graph = graph_class(graphs.Grid(2, 4))
     orig = Graph(graph.copy())
 
     with pytest.raises(ValueError):
@@ -364,7 +366,7 @@ def test_stable_separating_set_2by4_Grid():
 
 
 def test_stable_separating_set_prism():
-    graph = nx.Graph(graphs.ThreePrism())
+    graph = graph_class(graphs.ThreePrism())
     with pytest.raises(ValueError):
         separating_set.stable_separating_set(graph, check_flexible=False)
 
@@ -405,7 +407,7 @@ def test_stable_separating_set_random_graphs(
         # https://doi.org/10.1112/blms.12740
         p = (math.log(n) + math.log(math.log(n))) / n
     while num_tested < graph_no:
-        graph = nx.gnp_random_graph(n, p, seed=rand.randint(0, 2**30))
+        graph = graph_class(nx.gnp_random_graph(n, p, seed=rand.randint(0, 2**30)))
 
         # Filter out unreasonable graphs
         if generic_rigidity.is_rigid(graph, dim=2):

--- a/test/graph/rigidity/test_generic_rigidity.py
+++ b/test/graph/rigidity/test_generic_rigidity.py
@@ -16,6 +16,8 @@ from test.graph.test_graph import (
     relabeled_inc,
 )
 
+graph_class = nx.Graph
+
 is_min_rigid_algorithms_all_d = ["default", "randomized"]
 is_min_rigid_algorithms_d2 = is_min_rigid_algorithms_all_d + [
     "extension_sequence",
@@ -37,7 +39,7 @@ is_min_rigid_algorithms_d1 = is_min_rigid_algorithms_all_d + ["graphic"]
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_rigid(graph, dim, algorithm):
-    assert generic_rigidity.is_rigid(nx.Graph(graph), dim, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(graph_class(graph), dim, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -57,7 +59,7 @@ def test_is_rigid(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_rigid_d1(graph, algorithm):
-    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(graph_class(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -70,7 +72,7 @@ def test_is_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_rigid_d1(graph, algorithm):
-    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert not generic_rigidity.is_rigid(graph_class(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +93,7 @@ def test_is_not_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_rigid_d2(graph, algorithm):
-    assert generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert generic_rigidity.is_rigid(graph_class(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -107,7 +109,7 @@ def test_is_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_not_is_rigid_d2(graph, algorithm):
-    assert not generic_rigidity.is_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert not generic_rigidity.is_rigid(graph_class(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -121,7 +123,7 @@ def test_is_rigid_dimension_sparsity_error(method, params):
     G = graphs.DoubleBanana()
     with pytest.raises(ValueError):
         func = getattr(generic_rigidity, method)
-        func(nx.Graph(G), *params, algorithm="sparsity")
+        func(graph_class(G), *params, algorithm="sparsity")
 
 
 ###############################################################
@@ -138,7 +140,7 @@ def test_is_rigid_dimension_sparsity_error(method, params):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_min_rigid_d1(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert generic_rigidity.is_min_rigid(graph_class(graph), dim=1, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -158,7 +160,7 @@ def test_is_min_rigid_d1(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d1)
 def test_is_not_min_rigid_d1(graph, algorithm):
     assert not generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=1, algorithm=algorithm
+        graph_class(graph), dim=1, algorithm=algorithm
     )
 
 
@@ -174,7 +176,7 @@ def test_is_not_min_rigid_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_min_rigid_d2(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert generic_rigidity.is_min_rigid(graph_class(graph), dim=2, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -197,7 +199,7 @@ def test_is_min_rigid_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_d2)
 def test_is_not_min_rigid_d2(graph, algorithm):
     assert not generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -214,7 +216,7 @@ def test_is_not_min_rigid_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_min_rigid_d3(graph, algorithm):
-    assert generic_rigidity.is_min_rigid(nx.Graph(graph), dim=3, algorithm=algorithm)
+    assert generic_rigidity.is_min_rigid(graph_class(graph), dim=3, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -231,7 +233,7 @@ def test_is_min_rigid_d3(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_min_rigid_algorithms_all_d)
 def test_is_not_min_rigid_d3(graph, algorithm):
     assert not generic_rigidity.is_min_rigid(
-        nx.Graph(graph), dim=3, algorithm=algorithm
+        graph_class(graph), dim=3, algorithm=algorithm
     )
 
 
@@ -282,7 +284,7 @@ def test_rigid_components(graph, components, dim):
         assert (
             to_sets(
                 generic_rigidity.rigid_components(
-                    nx.Graph(graph), dim=dim, algorithm="graphic"
+                    graph_class(graph), dim=dim, algorithm="graphic"
                 )
             )
             == comps_set
@@ -291,7 +293,7 @@ def test_rigid_components(graph, components, dim):
         assert (
             to_sets(
                 generic_rigidity.rigid_components(
-                    nx.Graph(graph), dim=dim, algorithm="pebble"
+                    graph_class(graph), dim=dim, algorithm="pebble"
                 )
             )
             == comps_set
@@ -300,7 +302,7 @@ def test_rigid_components(graph, components, dim):
             assert (
                 to_sets(
                     generic_rigidity.rigid_components(
-                        nx.Graph(graph), dim=dim, algorithm="subgraphs-pebble"
+                        graph_class(graph), dim=dim, algorithm="subgraphs-pebble"
                     )
                 )
                 == comps_set
@@ -312,7 +314,7 @@ def test_rigid_components(graph, components, dim):
         assert (
             to_sets(
                 generic_rigidity.rigid_components(
-                    nx.Graph(graph), dim=dim, algorithm="randomized"
+                    graph_class(graph), dim=dim, algorithm="randomized"
                 )
             )
             == comps_set
@@ -320,7 +322,7 @@ def test_rigid_components(graph, components, dim):
         assert (
             to_sets(
                 generic_rigidity.rigid_components(
-                    nx.Graph(graph), dim=dim, algorithm="numerical"
+                    graph_class(graph), dim=dim, algorithm="numerical"
                 )
             )
             == comps_set
@@ -330,15 +332,20 @@ def test_rigid_components(graph, components, dim):
 @pytest.mark.parametrize(
     "graph",
     [
-        nx.gnp_random_graph(20, 0.1),
-        nx.gnm_random_graph(30, 62),
-        pytest.param(nx.gnm_random_graph(25, 46), marks=pytest.mark.slow_main),
-        pytest.param(nx.gnm_random_graph(40, 80), marks=pytest.mark.slow_main),
-        pytest.param(nx.gnm_random_graph(100, 230), marks=pytest.mark.long_local),
-        pytest.param(nx.gnm_random_graph(100, 190), marks=pytest.mark.long_local),
+        Graph(nx.gnp_random_graph(20, 0.1)),
+        Graph(nx.gnm_random_graph(30, 62)),
+        pytest.param(Graph(nx.gnm_random_graph(25, 46)), marks=pytest.mark.slow_main),
+        pytest.param(Graph(nx.gnm_random_graph(40, 80)), marks=pytest.mark.slow_main),
+        pytest.param(
+            Graph(nx.gnm_random_graph(100, 230)), marks=pytest.mark.long_local
+        ),
+        pytest.param(
+            Graph(nx.gnm_random_graph(100, 190)), marks=pytest.mark.long_local
+        ),
     ],
 )
 def test_rigid_components_pebble_random_graphs(graph):
+    graph = graph_class(graph)
     rigid_components = generic_rigidity.rigid_components(
         graph, dim=2, algorithm="pebble"
     )
@@ -378,9 +385,9 @@ def test_rigid_components_pebble_random_graphs(graph):
     ],
 )
 def test_max_rigid_dimension(graph, k):
-    assert generic_rigidity.max_rigid_dimension(nx.Graph(graph)) == k
+    assert generic_rigidity.max_rigid_dimension(graph_class(graph)) == k
     assert (
-        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        generic_rigidity.max_rigid_dimension(graph_class(graph), algorithm="numerical")
         == k
     )
 
@@ -388,5 +395,5 @@ def test_max_rigid_dimension(graph, k):
 def test_max_rigid_dimension_warning():
     graph = graphs.K66MinusPerfectMatching()
     with pytest.warns(RandomizedAlgorithmWarning):
-        generic_rigidity.max_rigid_dimension(nx.Graph(graph))
-        generic_rigidity.max_rigid_dimension(nx.Graph(graph), algorithm="numerical")
+        generic_rigidity.max_rigid_dimension(graph_class(graph))
+        generic_rigidity.max_rigid_dimension(graph_class(graph), algorithm="numerical")

--- a/test/graph/rigidity/test_global_rigidity.py
+++ b/test/graph/rigidity/test_global_rigidity.py
@@ -8,6 +8,8 @@ import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from test.graph.test_graph import read_globally, read_redundantly
 
+graph_class = nx.Graph
+
 ###############################################################
 # is_globally_rigid
 ###############################################################
@@ -46,7 +48,7 @@ from test.graph.test_graph import read_globally, read_redundantly
     ],
 )
 def test_is_globally_rigid(graph, dim):
-    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert global_rigidity.is_globally_rigid(graph_class(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -95,7 +97,7 @@ def test_is_globally_rigid(graph, dim):
     ],
 )
 def test_is_not_globally_rigid(graph, dim):
-    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=dim)
+    assert not global_rigidity.is_globally_rigid(graph_class(graph), dim=dim)
 
 
 @pytest.mark.parametrize(
@@ -111,7 +113,7 @@ def test_is_not_globally_rigid(graph, dim):
     ],
 )
 def test_is_globally_rigid_d2(graph):
-    assert global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert global_rigidity.is_globally_rigid(graph_class(graph), dim=2)
 
 
 @pytest.mark.parametrize(
@@ -129,7 +131,7 @@ def test_is_globally_rigid_d2(graph):
     ],
 )
 def test_is_not_globally_d2(graph):
-    assert not global_rigidity.is_globally_rigid(nx.Graph(graph), dim=2)
+    assert not global_rigidity.is_globally_rigid(graph_class(graph), dim=2)
 
 
 ###############################################################
@@ -149,7 +151,7 @@ def test_is_not_globally_d2(graph):
 def test_is_weakly_globally_linked_for_globally_rigid_graphs(graph):
     # in a globally rigid graph, each pair of vertices should be weakly globally linked
     for u, v in list(combinations(graph.nodes, 2)):
-        assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v)
+        assert global_rigidity.is_weakly_globally_linked(graph_class(graph), u, v)
 
 
 @pytest.mark.parametrize(
@@ -168,7 +170,7 @@ def test_is_weakly_globally_linked_for_redundantly_rigid_graphs(graph):
     for u, v in graph.edges:
         H = graph.copy()
         H.remove_edge(u, v)
-        H = nx.Graph(H)
+        H = graph_class(H)
         # now H is surely a rigid graph
         if global_rigidity.is_globally_rigid(H):
             for w1, w2 in list(combinations(graph.nodes, 2)):
@@ -254,4 +256,4 @@ def test_is_weakly_globally_linked_for_redundantly_rigid_graphs(graph):
     ],
 )
 def test_is_weakly_globally_linked_articles_graphs(graph, u, v):
-    assert global_rigidity.is_weakly_globally_linked(nx.Graph(graph), u, v, dim=2)
+    assert global_rigidity.is_weakly_globally_linked(graph_class(graph), u, v, dim=2)

--- a/test/graph/rigidity/test_matroidal_rigidity.py
+++ b/test/graph/rigidity/test_matroidal_rigidity.py
@@ -7,6 +7,8 @@ from pyrigi.graph import Graph
 from pyrigi.warning import RandomizedAlgorithmWarning
 from test.graph.test_graph import read_sparsity
 
+graph_class = nx.Graph
+
 Rd_algorithms_all_d = ["default", "randomized"]
 Rd_algorithms_d1 = Rd_algorithms_all_d + ["graphic"]
 Rd_algorithms_d2 = Rd_algorithms_all_d + ["sparsity"]
@@ -26,7 +28,9 @@ is_Rd_closed_algorithms_d2 = is_Rd_closed_algorithms_all_d + ["pebble"]
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_circuit_d1(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert matroidal_rigidity.is_Rd_circuit(
+        graph_class(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,7 +52,7 @@ def test_is_Rd_circuit_d1(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_not_Rd_circuit_d1(graph, algorithm):
     assert not matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=1, algorithm=algorithm
+        graph_class(graph), dim=1, algorithm=algorithm
     )
 
 
@@ -69,7 +73,9 @@ def test_is_not_Rd_circuit_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_circuit_d2(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert matroidal_rigidity.is_Rd_circuit(
+        graph_class(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -108,7 +114,7 @@ def test_is_Rd_circuit_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_not_Rd_circuit_d2(graph, algorithm):
     assert not matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -122,7 +128,9 @@ def test_is_not_Rd_circuit_d2(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_circuit_d3(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_circuit(nx.Graph(graph), dim=3, algorithm=algorithm)
+    assert matroidal_rigidity.is_Rd_circuit(
+        graph_class(graph), dim=3, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -138,7 +146,7 @@ def test_is_Rd_circuit_d3(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_not_Rd_circuit_d3(graph, algorithm):
     assert not matroidal_rigidity.is_Rd_circuit(
-        nx.Graph(graph), dim=3, algorithm=algorithm
+        graph_class(graph), dim=3, algorithm=algorithm
     )
 
 
@@ -157,7 +165,7 @@ def test_is_not_Rd_circuit_d3(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_Rd_closed(graph, dim, algorithm):
     assert matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=dim, algorithm=algorithm
+        graph_class(graph), dim=dim, algorithm=algorithm
     )
 
 
@@ -171,7 +179,7 @@ def test_is_Rd_closed(graph, dim, algorithm):
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_all_d)
 def test_is_not_Rd_closed(graph, dim, algorithm):
     assert not matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=dim, algorithm=algorithm
+        graph_class(graph), dim=dim, algorithm=algorithm
     )
 
 
@@ -184,7 +192,9 @@ def test_is_not_Rd_closed(graph, dim, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_Rd_closed_d1(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=1, algorithm=algorithm)
+    assert matroidal_rigidity.is_Rd_closed(
+        graph_class(graph), dim=1, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -196,7 +206,7 @@ def test_is_Rd_closed_d1(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d1)
 def test_is_not_Rd_closed_d1(graph, algorithm):
     assert not matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=1, algorithm=algorithm
+        graph_class(graph), dim=1, algorithm=algorithm
     )
 
 
@@ -210,7 +220,9 @@ def test_is_not_Rd_closed_d1(graph, algorithm):
 )
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_Rd_closed_d2(graph, algorithm):
-    assert matroidal_rigidity.is_Rd_closed(nx.Graph(graph), dim=2, algorithm=algorithm)
+    assert matroidal_rigidity.is_Rd_closed(
+        graph_class(graph), dim=2, algorithm=algorithm
+    )
 
 
 @pytest.mark.parametrize(
@@ -224,7 +236,7 @@ def test_is_Rd_closed_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_Rd_closed_algorithms_d2)
 def test_is_not_Rd_closed_d2(graph, algorithm):
     assert not matroidal_rigidity.is_Rd_closed(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -246,7 +258,7 @@ def test_is_not_Rd_closed_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_dependent_d1(graph, algorithm):
     assert matroidal_rigidity.is_Rd_dependent(
-        nx.Graph(graph), dim=1, algorithm=algorithm
+        graph_class(graph), dim=1, algorithm=algorithm
     )
 
 
@@ -261,7 +273,7 @@ def test_is_Rd_dependent_d1(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d1)
 def test_is_Rd_independent_d1(graph, algorithm):
     assert matroidal_rigidity.is_Rd_independent(
-        nx.Graph(graph), dim=1, algorithm=algorithm
+        graph_class(graph), dim=1, algorithm=algorithm
     )
 
 
@@ -280,7 +292,7 @@ def test_is_Rd_independent_d1(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_dependent_d2(graph, algorithm):
     assert matroidal_rigidity.is_Rd_dependent(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -300,7 +312,7 @@ def test_is_Rd_dependent_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_d2)
 def test_is_Rd_independent_d2(graph, algorithm):
     assert matroidal_rigidity.is_Rd_independent(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -311,7 +323,7 @@ def test_is_Rd_independent_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_dependent_d3(graph, algorithm):
     assert matroidal_rigidity.is_Rd_dependent(
-        nx.Graph(graph), dim=3, algorithm=algorithm
+        graph_class(graph), dim=3, algorithm=algorithm
     )
 
 
@@ -329,11 +341,11 @@ def test_is_Rd_dependent_d3(graph, algorithm):
 @pytest.mark.parametrize("algorithm", Rd_algorithms_all_d)
 def test_is_Rd_independent_d3(graph, algorithm):
     assert matroidal_rigidity.is_Rd_independent(
-        nx.Graph(graph), dim=3, algorithm=algorithm
+        graph_class(graph), dim=3, algorithm=algorithm
     )
 
 
 def test_is_Rd_independent_d3_warning():
     G = graphs.K33plusEdge()
     with pytest.warns(RandomizedAlgorithmWarning):
-        matroidal_rigidity.is_Rd_independent(nx.Graph(G), dim=3)
+        matroidal_rigidity.is_Rd_independent(graph_class(G), dim=3)

--- a/test/graph/rigidity/test_realization_counting.py
+++ b/test/graph/rigidity/test_realization_counting.py
@@ -15,6 +15,8 @@ import pyrigi.graph._rigidity.realization_counting as realization_counting
 
 from test import is_marker_selected
 
+graph_class = nx.Graph
+
 realization_count_plane_algorithms = [
     "default",
     pytest.param("lnumber", marks=pytest.mark.realization_counting),
@@ -46,7 +48,7 @@ def test_number_of_realizations_count_reflection_min_rigid(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), algorithm=algorithm, count_reflection=True
+            graph_class(graph), algorithm=algorithm, count_reflection=True
         )
         == num_of_realizations
     )
@@ -68,7 +70,7 @@ def test_number_of_realizations_count_reflection_globally_rigid(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), count_reflection=True
+            graph_class(graph), count_reflection=True
         )
         == num_of_realizations
     )
@@ -87,7 +89,7 @@ def test_number_of_realizations_count_reflection_globally_rigid(
 def test_number_of_realizations_count_reflection_rigid(graph, num_of_realizations):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), count_reflection=True
+            graph_class(graph), count_reflection=True
         )
         == num_of_realizations
     )
@@ -105,7 +107,7 @@ def test_number_of_realizations_count_reflection_rigid(graph, num_of_realization
 def test_number_of_realizations_count_reflection_flex(graph, dim):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, count_reflection=True
+            graph_class(graph), dim, count_reflection=True
         )
         == sp.oo
     )
@@ -128,7 +130,7 @@ def test_number_of_realizations_count_reflection_flex(graph, dim):
 def test_number_of_realizations_min_rigid(graph, num_of_realizations, algorithm):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), algorithm=algorithm
+            graph_class(graph), algorithm=algorithm
         )
         == num_of_realizations
     )
@@ -147,7 +149,7 @@ def test_number_of_realizations_min_rigid(graph, num_of_realizations, algorithm)
 def test_number_of_realizations_rigid(graph, num_of_realizations):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph),
+            graph_class(graph),
         )
         == num_of_realizations
     )
@@ -171,7 +173,7 @@ def test_number_of_realizations_rigid(graph, num_of_realizations):
     ],
 )
 def test_number_of_realizations_globally_rigid(graph, dim):
-    assert realization_counting.number_of_realizations(nx.Graph(graph), dim) == 1
+    assert realization_counting.number_of_realizations(graph_class(graph), dim) == 1
 
 
 @pytest.mark.parametrize(
@@ -184,7 +186,7 @@ def test_number_of_realizations_globally_rigid(graph, dim):
     ],
 )
 def test_number_of_realizations_flex(graph, dim):
-    assert realization_counting.number_of_realizations(nx.Graph(graph), dim) == sp.oo
+    assert realization_counting.number_of_realizations(graph_class(graph), dim) == sp.oo
 
 
 @pytest.mark.parametrize(
@@ -204,7 +206,7 @@ def test_number_of_realizations_flex(graph, dim):
 def test_number_of_realizations_sphere_min_rigid(graph, num_of_realizations, algorithm):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), algorithm=algorithm, spherical=True
+            graph_class(graph), algorithm=algorithm, spherical=True
         )
         == num_of_realizations
     )
@@ -222,7 +224,7 @@ def test_number_of_realizations_sphere_min_rigid(graph, num_of_realizations, alg
 )
 def test_number_of_realizations_sphere_rigid(graph, num_of_realizations):
     assert (
-        realization_counting.number_of_realizations(nx.Graph(graph), spherical=True)
+        realization_counting.number_of_realizations(graph_class(graph), spherical=True)
         == num_of_realizations
     )
 
@@ -242,7 +244,7 @@ def test_number_of_realizations_sphere_rigid(graph, num_of_realizations):
 def test_number_of_realizations_sphere_globally_rigid(graph, dim):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, spherical=True
+            graph_class(graph), dim, spherical=True
         )
         == 1
     )
@@ -260,7 +262,7 @@ def test_number_of_realizations_sphere_globally_rigid(graph, dim):
 def test_number_of_realizations_sphere_flex(graph, dim):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, spherical=True
+            graph_class(graph), dim, spherical=True
         )
         == sp.oo
     )
@@ -284,7 +286,10 @@ def test_number_of_realizations_sphere_count_reflection_min_rigid(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), algorithm=algorithm, spherical=True, count_reflection=True
+            graph_class(graph),
+            algorithm=algorithm,
+            spherical=True,
+            count_reflection=True,
         )
         == num_of_realizations
     )
@@ -305,7 +310,7 @@ def test_number_of_realizations_sphere_count_reflection_rigid(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), spherical=True, count_reflection=True
+            graph_class(graph), spherical=True, count_reflection=True
         )
         == num_of_realizations
     )
@@ -326,7 +331,7 @@ def test_number_of_realizations_sphere_count_reflection_globally_rigid(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), spherical=True, count_reflection=True
+            graph_class(graph), spherical=True, count_reflection=True
         )
         == num_of_realizations
     )
@@ -344,7 +349,7 @@ def test_number_of_realizations_sphere_count_reflection_globally_rigid(
 def test_number_of_realizations_sphere_count_reflection_flex(graph, dim):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, spherical=True, count_reflection=True
+            graph_class(graph), dim, spherical=True, count_reflection=True
         )
         == sp.oo
     )
@@ -373,11 +378,11 @@ def test_number_of_realizations_rigid_higher_dim(
 ):
     assert (
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, count_reflection=True
+            graph_class(graph), dim, count_reflection=True
         )
         == num_of_realizations
     )
-    assert realization_counting.number_of_realizations(nx.Graph(graph), dim) == (
+    assert realization_counting.number_of_realizations(graph_class(graph), dim) == (
         (num_of_realizations // 2) if num_of_realizations != 1 else 1
     )
 
@@ -390,7 +395,7 @@ def test_number_of_realizations_rigid_higher_dim(
 )
 def test_number_of_realizations_dim_error(graph, dim):
     with pytest.raises(NotImplementedError):
-        realization_counting.number_of_realizations(nx.Graph(graph), dim)
+        realization_counting.number_of_realizations(graph_class(graph), dim)
 
 
 @pytest.mark.parametrize(
@@ -402,7 +407,7 @@ def test_number_of_realizations_dim_error(graph, dim):
 )
 def test_number_of_realizations_type_error(graph, dim):
     with pytest.raises(TypeError):
-        realization_counting.number_of_realizations(nx.Graph(graph), dim)
+        realization_counting.number_of_realizations(graph_class(graph), dim)
 
 
 @pytest.mark.parametrize(
@@ -412,7 +417,7 @@ def test_number_of_realizations_type_error(graph, dim):
 def test_number_of_realizations_algorithm_error(alg):
     with pytest.raises(ValueError):
         realization_counting.number_of_realizations(
-            nx.Graph(graphs.Complete(3)), dim=2, algorithm=alg
+            graph_class(graphs.Complete(3)), dim=2, algorithm=alg
         )
 
 
@@ -427,7 +432,7 @@ def test_number_of_realizations_algorithm_error(alg):
 def test_number_of_realizations_method_error(graph, dim):
     with pytest.raises(ValueError):
         realization_counting.number_of_realizations(
-            nx.Graph(graph), dim, algorithm="lnumber"
+            graph_class(graph), dim, algorithm="lnumber"
         )
 
 
@@ -445,7 +450,7 @@ def test_number_of_realizations_lnumber_error(spherical):
     )
     with pytest.raises(ValueError):
         realization_counting.number_of_realizations(
-            nx.Graph(graph), algorithm="lnumber", spherical=spherical
+            graph_class(graph), algorithm="lnumber", spherical=spherical
         )
 
 
@@ -608,7 +613,7 @@ def _run_realization_test_on_graph(G: nx.Graph, dim: int, check_lnumber: bool) -
 def test_randomized_realization_counting(request, graph, dim, m, n):
     check_lnumber = is_marker_selected(request.config, "realization_counting")
 
-    G = nx.Graph(graph)
+    G = graph_class(graph)
     # The graph is converted to pyrigi.Graph and then back to nx.Graph
     # to see its vertices and edges in the output if a test fails.
 
@@ -638,7 +643,7 @@ def test_randomized_realization_counting(request, graph, dim, m, n):
 def test_small_realizations_counting(request, n, edges):
     check_lnumber = is_marker_selected(request.config, "realization_counting")
 
-    G = nx.Graph(Graph.from_vertices_and_edges(range(n), edges))
+    G = graph_class(Graph.from_vertices_and_edges(range(n), edges))
     assert G.number_of_nodes() == n
     assert G.number_of_edges() == len(edges)
 

--- a/test/graph/rigidity/test_redundant_rigidity.py
+++ b/test/graph/rigidity/test_redundant_rigidity.py
@@ -10,6 +10,8 @@ from test.graph.test_graph import (
     is_rigid_algorithms_d2,
 )
 
+graph_class = nx.Graph
+
 
 ###############################################################
 # is_vertex_redundantly_rigid
@@ -26,7 +28,7 @@ from test.graph.test_graph import (
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_vertex_redundantly_rigid_d2(graph, algorithm):
     assert redundant_rigidity.is_vertex_redundantly_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -42,7 +44,7 @@ def test_is_vertex_redundantly_rigid_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_vertex_redundantly_rigid_d2(graph, algorithm):
     assert not redundant_rigidity.is_vertex_redundantly_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -67,7 +69,7 @@ def test_is_not_vertex_redundantly_rigid_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
     assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -83,7 +85,7 @@ def test_is_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
     assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -106,7 +108,7 @@ def test_is_not_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
     assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -125,7 +127,7 @@ def test_is_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
     assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -155,7 +157,7 @@ def test_is_not_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
     assert redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -184,7 +186,7 @@ def test_is_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
     assert not redundant_rigidity.is_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -209,7 +211,7 @@ def test_is_not_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -225,7 +227,7 @@ def test_is_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -247,7 +249,7 @@ def test_is_not_min_k_vertex_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -263,7 +265,7 @@ def test_is_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -277,7 +279,7 @@ def test_is_not_min_k_vertex_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -308,7 +310,7 @@ def test_is_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_vertex_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -330,7 +332,7 @@ def test_is_not_min_k_vertex_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_redundantly_rigid_d2(graph, algorithm):
     assert redundant_rigidity.is_redundantly_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -354,7 +356,7 @@ def test_is_redundantly_rigid_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_redundantly_rigid_d2(graph, algorithm):
     assert not redundant_rigidity.is_redundantly_rigid(
-        nx.Graph(graph), dim=2, algorithm=algorithm
+        graph_class(graph), dim=2, algorithm=algorithm
     )
 
 
@@ -381,7 +383,7 @@ def test_is_not_redundantly_rigid_d2(graph, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
     assert redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -396,7 +398,7 @@ def test_is_k_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
     assert not redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -421,7 +423,7 @@ def test_is_not_k_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
     assert redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -448,7 +450,7 @@ def test_is_k_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
     assert not redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -479,7 +481,7 @@ def test_is_not_k_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
     assert redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -504,7 +506,7 @@ def test_is_k_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
     assert not redundant_rigidity.is_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -529,7 +531,7 @@ def test_is_not_k_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -547,7 +549,7 @@ def test_is_min_k_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d1)
 def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=1, algorithm=algorithm
+        graph_class(graph), k, dim=1, algorithm=algorithm
     )
 
 
@@ -569,7 +571,7 @@ def test_is_not_min_k_redundantly_rigid_d1(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -586,7 +588,7 @@ def test_is_min_k_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_d2)
 def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=2, algorithm=algorithm
+        graph_class(graph), k, dim=2, algorithm=algorithm
     )
 
 
@@ -601,7 +603,7 @@ def test_is_not_min_k_redundantly_rigid_d2(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
     assert redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )
 
 
@@ -619,5 +621,5 @@ def test_is_min_k_redundantly_rigid_d3(graph, k, algorithm):
 @pytest.mark.parametrize("algorithm", is_rigid_algorithms_all_d)
 def test_is_not_min_k_redundantly_rigid_d3(graph, k, algorithm):
     assert not redundant_rigidity.is_min_k_redundantly_rigid(
-        nx.Graph(graph), k, dim=3, algorithm=algorithm
+        graph_class(graph), k, dim=3, algorithm=algorithm
     )

--- a/test/graph/sparsity/test_sparsity.py
+++ b/test/graph/sparsity/test_sparsity.py
@@ -10,6 +10,8 @@ import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from test.graph.test_graph import read_sparsity
 
+graph_class = nx.Graph
+
 is_kl_sparse_algorithms_sparsity_all_kl = ["default", "subgraph"]
 is_kl_sparse_algorithms_sparsity_pebble = is_kl_sparse_algorithms_sparsity_all_kl + [
     "pebble"
@@ -38,8 +40,8 @@ is_kl_sparse_algorithms_sparsity_pebble = is_kl_sparse_algorithms_sparsity_all_k
 def test_is_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -56,8 +58,8 @@ def test_is_kl_sparse(graph, K, L, algorithm):
 def test_is_not_kl_sparse(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -77,8 +79,8 @@ def test_is_not_kl_sparse(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_sparse(graph):
-    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-    assert sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert sparsity.is_kl_sparse(graph_class(graph), 2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_sparse(graph_class(graph), 2, 3, algorithm="pebble")
     assert graph.is_sparse()
 
 
@@ -93,8 +95,8 @@ def test_is_2_3_sparse(graph):
     ],
 )
 def test_is_not_2_3_sparse(graph):
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="subgraph")
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), 2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(graph_class(graph), 2, 3, algorithm="subgraph")
+    assert not sparsity.is_kl_sparse(graph_class(graph), 2, 3, algorithm="pebble")
     assert not graph.is_sparse()
 
 
@@ -118,8 +120,8 @@ def test_is_not_2_3_sparse(graph):
 def test_is_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -136,8 +138,8 @@ def test_is_kl_sparse_pebble(graph, K, L, algorithm):
 def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -162,8 +164,8 @@ def test_is_not_kl_sparse_pebble(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -182,8 +184,8 @@ def test_is_kl_sparse_with_loops(graph, K, L, algorithm):
 def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     graph2 = graph + Graph.from_vertices_and_edges([max(graph.vertex_list()) + 1], [])
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
-    assert not sparsity.is_kl_sparse(nx.Graph(graph2), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_sparse(graph_class(graph2), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -208,7 +210,7 @@ def test_is_not_kl_sparse_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_not_sparse_graphs_big_random(graph, K, L):
-    assert not sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+    assert not sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -226,7 +228,7 @@ def test_is_not_sparse_graphs_big_random(graph, K, L):
 def test_is_kl_sparse_pebble_value_error(graph, K, L):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm="pebble")
+        sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm="pebble")
 
 
 @pytest.mark.parametrize(
@@ -243,7 +245,7 @@ def test_is_kl_sparse_pebble_value_error(graph, K, L):
 def test_is_kl_sparse_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(ValueError):
-        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -259,7 +261,7 @@ def test_is_kl_sparse_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
     with pytest.raises(TypeError):
-        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -277,7 +279,7 @@ def test_is_kl_sparse_type_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(ValueError):
-        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -293,7 +295,7 @@ def test_is_kl_sparse_with_loops_value_error(graph, K, L, algorithm):
 def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
     with pytest.raises(TypeError):
-        sparsity.is_kl_sparse(nx.Graph(graph), K, L, algorithm=algorithm)
+        sparsity.is_kl_sparse(graph_class(graph), K, L, algorithm=algorithm)
 
 
 ###############################################################
@@ -313,7 +315,7 @@ def test_is_kl_sparse_with_loops_type_error(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -333,7 +335,7 @@ def test_is_kl_tight(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_all_kl)
 def test_is_not_kl_tight(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -347,8 +349,8 @@ def test_is_not_kl_tight(graph, K, L, algorithm):
     ],
 )
 def test_is_2_3_tight(graph):
-    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-    assert sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert sparsity.is_kl_tight(graph_class(graph), 2, 3, algorithm="pebble")
+    assert sparsity.is_kl_tight(graph_class(graph), 2, 3, algorithm="subgraph")
     assert graph.is_tight()
 
 
@@ -369,8 +371,8 @@ def test_is_2_3_tight(graph):
     ],
 )
 def test_is_not_2_3_tight(graph):
-    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="pebble")
-    assert not sparsity.is_kl_tight(nx.Graph(graph), 2, 3, algorithm="subgraph")
+    assert not sparsity.is_kl_tight(graph_class(graph), 2, 3, algorithm="pebble")
+    assert not sparsity.is_kl_tight(graph_class(graph), 2, 3, algorithm="subgraph")
     assert not graph.is_tight()
 
 
@@ -388,7 +390,7 @@ def test_is_not_2_3_tight(graph):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -411,7 +413,7 @@ def test_is_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) == 0
-    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -432,7 +434,7 @@ def test_is_not_kl_tight_pebble(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -459,7 +461,7 @@ def test_is_kl_tight_with_loops(graph, K, L, algorithm):
 @pytest.mark.parametrize("algorithm", is_kl_sparse_algorithms_sparsity_pebble)
 def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     assert nx.number_of_selfloops(graph) > 0
-    assert not sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm=algorithm)
+    assert not sparsity.is_kl_tight(graph_class(graph), K, L, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(
@@ -480,7 +482,7 @@ def test_is_not_kl_tight_with_loops(graph, K, L, algorithm):
     ],
 )
 def test_is_tight_big_random(graph, K, L):
-    assert sparsity.is_kl_tight(nx.Graph(graph), K, L, algorithm="pebble")
+    assert sparsity.is_kl_tight(graph_class(graph), K, L, algorithm="pebble")
 
 
 ###############################################################
@@ -502,7 +504,7 @@ def test_spanning_kl_sparse_subgraph(graph):
     for K in range(1, 3):
         for L in range(0, 2 * K):
             spanning_subgraph = sparsity.spanning_kl_sparse_subgraph(
-                nx.Graph(graph), K, L
+                graph_class(graph), K, L
             )
             assert sparsity.is_kl_sparse(spanning_subgraph, K, L, algorithm="subgraph")
             assert set(graph.nodes) == set(spanning_subgraph.nodes)

--- a/test/graph/test_general.py
+++ b/test/graph/test_general.py
@@ -5,35 +5,37 @@ import pyrigi.graphDB as graphs
 from pyrigi.graph import Graph
 from pyrigi.graph import _general as general
 
+graph_class = nx.Graph
+
 
 def test_adjacency_matrix():
-    G = nx.Graph()
+    G = graph_class()
     assert general.adjacency_matrix(G) == Matrix([])
-    G = nx.Graph([[2, 1], [2, 3]])
+    G = graph_class([[2, 1], [2, 3]])
     assert general.adjacency_matrix(G) == Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
     assert general.adjacency_matrix(G, vertex_order=[2, 3, 1]) == Matrix(
         [[0, 1, 1], [1, 0, 0], [1, 0, 0]]
     )
-    assert general.adjacency_matrix(nx.Graph(graphs.Complete(4))) == Matrix.ones(
+    assert general.adjacency_matrix(graph_class(graphs.Complete(4))) == Matrix.ones(
         4
     ) - Matrix.diag([1, 1, 1, 1])
-    G = nx.Graph(Graph.from_vertices(["C", 1, "D"]))
+    G = graph_class(Graph.from_vertices(["C", 1, "D"]))
     assert general.adjacency_matrix(G) == Matrix.zeros(3)
     G = Graph.from_vertices_and_edges(["C", 1, "D"], [[1, "D"], ["C", "D"]])
-    assert general.adjacency_matrix(nx.Graph(G), vertex_order=["C", 1, "D"]) == Matrix(
-        [[0, 0, 1], [0, 0, 1], [1, 1, 0]]
-    )
+    assert general.adjacency_matrix(
+        graph_class(G), vertex_order=["C", 1, "D"]
+    ) == Matrix([[0, 0, 1], [0, 0, 1], [1, 1, 0]])
     M = Matrix([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
+    assert general.adjacency_matrix(graph_class(Graph.from_adjacency_matrix(M))) == M
     M = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 0]])
-    assert general.adjacency_matrix(nx.Graph(Graph.from_adjacency_matrix(M))) == M
+    assert general.adjacency_matrix(graph_class(Graph.from_adjacency_matrix(M))) == M
 
 
 def test_vertex_and_edge_lists():
-    G = nx.Graph([[2, 1], [2, 3]])
+    G = graph_class([[2, 1], [2, 3]])
     assert general.vertex_list(G) == [1, 2, 3]
     assert general.edge_list(G) == [[1, 2], [2, 3]]
-    G = nx.Graph(
+    G = graph_class(
         [(chr(i + 67), i + 1) for i in range(3)] + [(i, i + 1) for i in range(3)]
     )
     assert set(general.vertex_list(G)) == {"C", 1, "D", 2, "E", 3, 0}
@@ -45,6 +47,6 @@ def test_vertex_and_edge_lists():
         (2, 3),
         ("E", 3),
     }
-    G = nx.Graph(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
+    G = graph_class(Graph.from_vertices(["C", 1, "D", 2, "E", 3, 0]))
     assert set(general.vertex_list(G)) == {"C", 2, "E", 1, "D", 3, 0}
     assert general.edge_list(G) == []

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -361,7 +361,7 @@ def test_plot():
 def test_randomized_rigidity_properties(graph, dim, n, m):  # noqa: C901
     G = graph_class(graph)
     # The graph is converted to pyrigi.Graph and then back according
-    # to graph_class    # to see its vertices and edges in the output
+    # to graph_class to see its vertices and edges in the output
     # if a test fails.
 
     assert G.number_of_nodes() == n

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -22,6 +22,8 @@ from pyrigi.exception import LoopError
 from pyrigi.framework import Framework
 from pyrigi.graph import Graph
 
+graph_class = nx.Graph
+
 is_rigid_algorithms_all_d = ["default", "randomized", "numerical"]
 is_rigid_algorithms_d1 = is_rigid_algorithms_all_d + ["graphic"]
 is_rigid_algorithms_d2 = is_rigid_algorithms_all_d + ["sparsity"]
@@ -357,9 +359,10 @@ def test_plot():
     ],
 )
 def test_randomized_rigidity_properties(graph, dim, n, m):  # noqa: C901
-    G = nx.Graph(graph)
-    # The graph is converted to pyrigi.Graph and then back to nx.Graph
-    # to see its vertices and edges in the output if a test fails.
+    G = graph_class(graph)
+    # The graph is converted to pyrigi.Graph and then back according
+    # to graph_class    # to see its vertices and edges in the output
+    # if a test fails.
 
     assert G.number_of_nodes() == n
     assert G.number_of_edges() == m


### PR DESCRIPTION
By default, we test functions on `nx.Graph`. This PR allows to run the tests also on `pyrigi.Graph` as follows
```
pytest       # default, testing only on nx.Graphs
pytest --graph-class=nx # same as above
pytest --graph-class=pyrigi # testing only on pyrigi.Graphs
pytest --graph-class=both # testing on both
```