### PR TITLE
Setup: Removed unused sphinxcontrib-napoleon

### DIFF
--- a/doc/development/howto/documentation.md
+++ b/doc/development/howto/documentation.md
@@ -11,7 +11,7 @@ The documentation is generated from docstrings using [Sphinx](https://www.sphinx
 We use the theme [Furo](https://github.com/pradyunsg/furo).
 The docstrings are written in [reST](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html),
 formatted according to [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)
-and parsed using [napoleon](https://sphinxcontrib-napoleon.readthedocs.io/)
+and parsed using [napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html)
 to retrieve the information from type hinting.
 The other documentation source files are written in [MyST](https://myst-parser.readthedocs.io/)
 (see also the [cheatsheet](cheatsheet)).

--- a/poetry.lock
+++ b/poetry.lock
@@ -2459,21 +2459,6 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pockets"
-version = "0.9.1"
-description = "A collection of helpful Python tools!"
-optional = false
-python-versions = "*"
-groups = ["doc"]
-files = [
-    {file = "pockets-0.9.1-py2.py3-none-any.whl", hash = "sha256:68597934193c08a08eb2bf6a1d85593f627c22f9b065cc727a4f03f669d96d86"},
-    {file = "pockets-0.9.1.tar.gz", hash = "sha256:9320f1a3c6f7a9133fe3b571f283bcf3353cd70249025ae8d618e40e9f7e92b3"},
-]
-
-[package.dependencies]
-six = ">=1.5.2"
-
-[[package]]
 name = "pre-commit"
 version = "3.8.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -3539,22 +3524,6 @@ files = [
 test = ["flake8", "mypy", "pytest"]
 
 [[package]]
-name = "sphinxcontrib-napoleon"
-version = "0.7"
-description = "Sphinx \"napoleon\" extension."
-optional = false
-python-versions = "*"
-groups = ["doc"]
-files = [
-    {file = "sphinxcontrib-napoleon-0.7.tar.gz", hash = "sha256:407382beed396e9f2d7f3043fad6afda95719204a1e1a231ac865f40abcbfcf8"},
-    {file = "sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl", hash = "sha256:711e41a3974bdf110a484aec4c1a556799eb0b3f3b897521a018ad7e2db13fef"},
-]
-
-[package.dependencies]
-pockets = ">=0.3"
-six = ">=1.5.2"
-
-[[package]]
 name = "sphinxcontrib-qthelp"
 version = "2.0.0"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents"
@@ -4135,4 +4104,4 @@ realization-counting = ["lnumber"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "c325fc423c87c8a4ae16681acd8bd01d793d175d332f45bd9bd8cd842286fd3a"
+content-hash = "5b3500e7348ed10c5969f79993a4dda4c4b1fb2ade0c9f870206799ef9d013d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ sphinx-proof = "^0.2.0"
 sphinx-tippy = "^0.4.3"
 sphinx-autodoc-typehints = "^3.1.0"
 sphinxcontrib-bibtex = "^2.6.3"
-sphinxcontrib-napoleon = "^0.7"
 jupytext = "^1.16.7"
 setuptools = "^75.8.0"
 


### PR DESCRIPTION
The dependency is removed since https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html is actually used.