### PR TITLE
Setup: Added testing tools

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+"""
+This file provides fixtures applied to both the tests and the doctests.
+"""
+
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    """
+    Close all `matplotlib` figures after each test.
+    """
+    yield
+    plt.close("all")

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -39,13 +39,13 @@ pytest -p no:doctestplus
 ```
 
 We add [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) as a development dependency,
-which allows to run tests in parallel.
+which allows one to run tests in parallel.
 By default, the number of available CPUs is determined automatically,
 but can be set manually:
 ```
 pytest -n 2
 ```
-The random seed has to be fixed to guarantee that the tests are collected in the same order
+A random seed has to be fixed to guarantee that the tests are collected in the same order
 by all workers.
 This is achieved by [pytest-randomly](https://github.com/pytest-dev/pytest-randomly).
 It gives control over the initialization of random seeds and hence allows

--- a/doc/development/howto/testing.md
+++ b/doc/development/howto/testing.md
@@ -38,6 +38,24 @@ If you do not want to run doctests, run
 pytest -p no:doctestplus
 ```
 
+We add [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) as a development dependency,
+which allows to run tests in parallel.
+By default, the number of available CPUs is determined automatically,
+but can be set manually:
+```
+pytest -n 2
+```
+The random seed has to be fixed to guarantee that the tests are collected in the same order
+by all workers.
+This is achieved by [pytest-randomly](https://github.com/pytest-dev/pytest-randomly).
+It gives control over the initialization of random seeds and hence allows
+reproducibility of failures of random tests:
+```
+pytest --randomly-seed=last
+```
+It also shuffles the tests before running to detect unintentional intertest dependencies.
+The plugin is used automatically, but can be switched off by `pytest -p no:randomly`.
+
 ## Function vs. method testing
 
 As described in [Package Structure](#pkg_structure), most of the functionality of

--- a/poetry.lock
+++ b/poetry.lock
@@ -773,6 +773,21 @@ files = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -2788,6 +2803,42 @@ pytest = ">=7.0"
 test = ["numpy", "pytest-remotedata (>=0.3.2)", "setuptools (>=30.3.0)", "sphinx"]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+description = "Pytest plugin to randomly order tests and control random.seed."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9"},
+    {file = "pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -4240,4 +4291,4 @@ realization-counting = ["lnumber"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "820253447c59804e3d40745a903bbc1522c417eb81bfedbf96fe5ca32ab29a8b"
+content-hash = "157e885ddafdf2fed189902277f7c1af89cce1ac0123fef1771247565bcc597e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ markers = [
     "meshing: marks tests using extra meshing",
 ]
 filterwarnings = [
+    "error",
     'ignore::pyrigi.warning.RandomizedAlgorithmWarning',
     'ignore::pyrigi.warning.NumericalAlgorithmWarning',
     'ignore::pyrigi.warning.NumericalCoordinateWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ setuptools = "^83.0.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.pytest.ini_options]
+[tool.pytest]
 doctest_plus = "enabled"
 pythonpath = [
   "."
@@ -85,8 +85,14 @@ testpaths = [
     "pyrigi",
     "test",
 ]
-addopts = "-m 'not slow_main and not long_local'" # deselect large tests by default
+addopts = [
+    "-m not slow_main and not long_local", # deselect large tests by default
+    "-ra", # print summary of all fails/errors
+    "--strict-config", # force an error if a config setting is misspelled
+    "--strict-markers", # force test markers to be specified in config
+]
 # you can run all tests with -m 'not slow_main or slow_main'
+log_level = "INFO"
 markers = [
     "slow_main: marks slower tests run at merge to main",
     "long_local: marks long tests run locally",
@@ -95,6 +101,7 @@ markers = [
 ]
 filterwarnings = [
     "error",
+    'default::pytest.PytestConfigWarning',
     'ignore::pyrigi.warning.RandomizedAlgorithmWarning',
     'ignore::pyrigi.warning.NumericalAlgorithmWarning',
     'ignore::pyrigi.warning.NumericalCoordinateWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,11 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    'default::pytest.PytestConfigWarning',
-    'ignore::pyrigi.warning.RandomizedAlgorithmWarning',
-    'ignore::pyrigi.warning.NumericalAlgorithmWarning',
-    'ignore::pyrigi.warning.NumericalCoordinateWarning',
-    'ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning'
+    "default::pytest.PytestConfigWarning",
+    "ignore::pyrigi.warning.RandomizedAlgorithmWarning",
+    "ignore::pyrigi.warning.NumericalAlgorithmWarning",
+    "ignore::pyrigi.warning.NumericalCoordinateWarning",
+    "ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning"
 ]
 
 [tool.jupytext]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ pytest = "^9.1.1"
 pytest-doctestplus = "^1.2.1"
 pytest-cov = "^7.1.0"
 flake8-unused-arguments = "^0.0.14"
+pytest-randomly = "^4.1.0"
+pytest-xdist = "^3.8.0"
 
 [tool.poetry.group.doc.dependencies]
 furo = "^2024.8.6"
@@ -87,11 +89,12 @@ testpaths = [
 ]
 addopts = [
     "-m not slow_main and not long_local", # deselect large tests by default
+        # you can run all tests with -m 'not slow_main or slow_main'
+    "-n", "auto", # automatically detect the number of CPUs to run in parallel
     "-ra", # print summary of all fails/errors
     "--strict-config", # force an error if a config setting is misspelled
     "--strict-markers", # force test markers to be specified in config
 ]
-# you can run all tests with -m 'not slow_main or slow_main'
 log_level = "INFO"
 markers = [
     "slow_main: marks slower tests run at merge to main",

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -1,6 +1,5 @@
 import os
 
-import matplotlib.pyplot as plt
 import pytest
 
 import pyrigi.frameworkDB as fws

--- a/test/framework/plot/test_plot.py
+++ b/test/framework/plot/test_plot.py
@@ -26,8 +26,6 @@ def test_plot_error(realization):
     with pytest.raises(ValueError):
         framework_plot.plot(F)
 
-    plt.close()
-
 
 def test_plot():
     F = Framework(graphs.Complete(2), {0: [1, 0], 1: [0, 1]})
@@ -37,8 +35,6 @@ def test_plot():
     F = Framework(graphs.Complete(2), {0: [1, 0, 0], 1: [0, 1, 1]})
     F = _to_FrameworkBase(F)
     framework_plot.plot(F)
-
-    plt.close("all")
 
 
 def test_plot2D():
@@ -78,8 +74,6 @@ def test_plot2D():
     framework_plot.plot2D(F, stress=0)
     framework_plot.plot2D(F, stress=stress_rigidity.stresses(F)[0])
     framework_plot.plot2D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
-
-    plt.close("all")
 
 
 def test_plot3D():
@@ -125,8 +119,6 @@ def test_plot3D():
     framework_plot.plot3D(F, stress=0)
     framework_plot.plot3D(F, stress=stress_rigidity.stresses(F)[0])
     framework_plot.plot3D(F, stress=stress_rigidity.stresses(F, numerical=True)[0])
-
-    plt.close("all")
 
 
 def test_animate3D_rotation():

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -346,7 +346,6 @@ def test_parameter_value_error(method, params):
 def test_plot():
     G = graphs.DoubleBanana()
     G.plot(layout="random")
-    plt.close("all")
 
 
 @pytest.mark.long_local

--- a/test/graph/test_graph.py
+++ b/test/graph/test_graph.py
@@ -2,7 +2,6 @@ import math
 from itertools import product
 from random import randint
 
-import matplotlib.pyplot as plt
 import networkx as nx
 import pytest
 


### PR DESCRIPTION
- By turning warnings that are not explicitly listed to be ignored to errors in `pytest`, we can discover for instance `DeprecationWarnings` earlier.
- `pytest` is set up to be stricter with invalid config or markers
- `pytest-randomly` is added to detect possible intertest dependency and to gain reproducibility of random tests
- `pytest-xdist` is added to run tests in parallel